### PR TITLE
Prism themes

### DIFF
--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -55,8 +55,6 @@ export default function CodeBlock({children}) {
   const {onCopy, hasCopied} = useClipboard(code);
   const theme = useColorModeValue(lightTheme, darkTheme);
   const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
-  const borderColor = useColorModeValue('gray.200', 'gray.700');
-  const titleBgColor = useColorModeValue('white', 'inherit');
   const lineNumberColor = useColorModeValue('gray.300', '#798fbb');
   const languageMenu = useContext(CodeBlockContext);
 
@@ -78,7 +76,6 @@ export default function CodeBlock({children}) {
             pos="relative"
             shadow="sm"
             borderWidth="1px"
-            borderColor={borderColor}
           >
             <Box fontSize="md" fontFamily="mono">
               {title && (
@@ -86,7 +83,6 @@ export default function CodeBlock({children}) {
                   px={SPACING}
                   py="2"
                   borderBottomWidth="1px"
-                  bgColor={titleBgColor}
                   borderTopRadius="md"
                 >
                   {title}

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -3,7 +3,6 @@ import Prism from 'prismjs';
 import PropTypes from 'prop-types';
 import React, {createContext, useContext} from 'react';
 import fenceparser from 'fenceparser';
-import nightOwl from 'prism-react-renderer/themes/nightOwl';
 import nightOwlLight from 'prism-react-renderer/themes/nightOwlLight';
 import rangeParser from 'parse-numeric-range';
 import {
@@ -15,6 +14,7 @@ import {
   useColorModeValue
 } from '@chakra-ui/react';
 import {FiClipboard} from 'react-icons/fi';
+import {theme as darkTheme} from '../prism-themes/dark';
 
 // these must be imported after Prism
 import 'prismjs/components/prism-bash';
@@ -51,7 +51,7 @@ export default function CodeBlock({children}) {
   const [code] = Array.isArray(innerChildren) ? innerChildren : [innerChildren];
 
   const {onCopy, hasCopied} = useClipboard(code);
-  const theme = useColorModeValue(nightOwlLight, nightOwl);
+  const theme = useColorModeValue(nightOwlLight, darkTheme);
   const highlightColor = useColorModeValue('blackAlpha.100', 'blackAlpha.400');
 
   const languageMenu = useContext(CodeBlockContext);

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Flex,
   chakra,
   useClipboard,
   useColorModeValue
@@ -99,46 +100,35 @@ export default function CodeBlock({children}) {
                 overflow="auto"
               >
                 {tokens.map((line, i) => (
-                  <Box
-                    {...getLineProps({
-                      line,
-                      key: i
-                    })}
-                    key={i}
-                    pl={(SPACING / 2) * (showLineNumbers ? 2 : 1)}
-                    bg={linesToHighlight.includes(i + 1) && highlightColor}
-                  >
-                    <Box ml={showLineNumbers && lineNumberOffset}>
-                      {line.map((token, key) => (
-                        <span key={key} {...getTokenProps({token, key})} />
-                      ))}
+                  <Flex key={i}>
+                    {showLineNumbers && (
+                      <Box
+                        aria-hidden="true"
+                        userSelect="none"
+                        textAlign="right" // line number alignment used in VS Code
+                        w={lineNumberOffset}
+                        mr={SPACING}
+                        color={lineNumberColor}
+                      >
+                        {i + 1}
+                      </Box>
+                    )}
+                    <Box
+                      {...getLineProps({
+                        line,
+                        key: i
+                      })}
+                      bg={linesToHighlight.includes(i + 1) && highlightColor}
+                    >
+                      <Box>
+                        {line.map((token, key) => (
+                          <span key={key} {...getTokenProps({token, key})} />
+                        ))}
+                      </Box>
                     </Box>
-                  </Box>
+                  </Flex>
                 ))}
               </chakra.pre>
-              {/* put below all code and then position so that if user selects text, line numbers will be excluded */}
-              {showLineNumbers && (
-                <chakra.pre
-                  aria-hidden="true" // hide from screen reader
-                  pos="absolute"
-                  top={title ? '57px' : SPACING} // 57px = SPACING (16px) + height of title box (41px)
-                  left={SPACING}
-                  textAlign="right"
-                  fontFamily="inherit"
-                  bgColor={theme.plain.backgroundColor} // for horizontal scrolling of code text
-                >
-                  {tokens.map((_, index) => (
-                    <Box
-                      key={index}
-                      w={lineNumberOffset}
-                      mr={SPACING}
-                      color={lineNumberColor}
-                    >
-                      {index + 1}
-                    </Box>
-                  ))}
-                </chakra.pre>
-              )}
             </Box>
             <ButtonGroup size="xs" pos="absolute" top="2" right="2">
               <Button leftIcon={<FiClipboard />} onClick={onCopy}>

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -61,7 +61,7 @@ export default function CodeBlock({children}) {
       Prism={Prism}
       theme={theme}
       code={code.trim()}
-      language={className.replace(/language-/, '').replace(/{.*?}/, '')} // TODO: use regex and get match for language instead of double replace
+      language={className.replace(/language-/, '')}
     >
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <Box rounded="md" style={style} pos="relative" shadow="sm">

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -95,12 +95,17 @@ export default function CodeBlock({children}) {
               <chakra.pre
                 className={className}
                 py={SPACING}
-                px={showLineNumbers && SPACING}
                 fontFamily="inherit"
                 overflow="auto"
               >
                 {tokens.map((line, i) => (
-                  <Flex key={i}>
+                  <Flex
+                    key={i}
+                    px={showLineNumbers && SPACING}
+                    minW="100%" // width styles for line highlighting to always go all the way across code block
+                    w="fit-content"
+                    bg={linesToHighlight.includes(i + 1) && highlightColor}
+                  >
                     {showLineNumbers && (
                       <Box
                         aria-hidden="true"
@@ -118,7 +123,6 @@ export default function CodeBlock({children}) {
                         line,
                         key: i
                       })}
-                      bg={linesToHighlight.includes(i + 1) && highlightColor}
                     >
                       <Box>
                         {line.map((token, key) => (

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -61,7 +61,7 @@ export default function CodeBlock({children}) {
       Prism={Prism}
       theme={theme}
       code={code.trim()}
-      language={className.replace(/language-/, '')}
+      language={className.replace(/language-/, '').replace(/{.*?}/, '')} // TODO: use regex and get match for language instead of double replace
     >
       {({className, style, tokens, getLineProps, getTokenProps}) => (
         <Box rounded="md" style={style} pos="relative" shadow="sm">

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -124,6 +124,7 @@ export default function CodeBlock({children}) {
                   top={title ? '57px' : SPACING} // 57px = SPACING (16px) + height of title box (41px)
                   left={SPACING}
                   textAlign="right"
+                  fontFamily="inherit"
                   bgColor={theme.plain.backgroundColor} // for horizontal scrolling of code text
                 >
                   {tokens.map((_, index) => (

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -32,14 +32,15 @@ import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-typescript';
 
 export const CodeBlockContext = createContext();
-
+const SPACING = 4;
 export default function CodeBlock({children}) {
   const [child] = Array.isArray(children) ? children : [children];
   const {
     className = 'language-text',
     children: innerChildren,
     metastring,
-    'data-meta': dataMeta
+    'data-meta': dataMeta,
+    showLineNumbers = true
   } = child.props;
 
   const meta = metastring || dataMeta;
@@ -55,6 +56,7 @@ export default function CodeBlock({children}) {
   const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
   const borderColor = useColorModeValue('gray.200', 'gray.700');
   const titleBgColor = useColorModeValue('white', 'inherit');
+  const lineNumberColor = useColorModeValue('gray.300', '#798fbb');
   const languageMenu = useContext(CodeBlockContext);
 
   return (
@@ -64,58 +66,88 @@ export default function CodeBlock({children}) {
       code={code.trim()}
       language={className.replace(/^language-/, '')}
     >
-      {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <Box
-          rounded="md"
-          style={style}
-          pos="relative"
-          shadow="sm"
-          borderWidth="1px"
-          borderColor={borderColor}
-        >
-          <Box fontSize="md" fontFamily="mono">
-            {title && (
-              <Box
-                px="4"
-                py="2"
-                borderBottomWidth="1px"
-                bgColor={titleBgColor}
-                borderTopRadius="md"
-              >
-                {title}
-              </Box>
-            )}
-            <chakra.pre
-              className={className}
-              py="4"
-              fontFamily="inherit"
-              overflow="auto"
-            >
-              {tokens.map((line, i) => (
+      {({className, style, tokens, getLineProps, getTokenProps}) => {
+        // length of longest line number
+        // ex. if there are 28 lines in the code block, lineNumberOffset = 2ch
+        const lineNumberOffset = tokens.length.toString().length + 'ch';
+        return (
+          <Box
+            rounded="md"
+            style={style}
+            pos="relative"
+            shadow="sm"
+            borderWidth="1px"
+            borderColor={borderColor}
+          >
+            <Box fontSize="md" fontFamily="mono">
+              {title && (
                 <Box
-                  key={i}
-                  {...getLineProps({
-                    line,
-                    key: i
-                  })}
-                  px="4"
-                  bg={linesToHighlight.includes(i + 1) && highlightColor}
+                  px={SPACING}
+                  py="2"
+                  borderBottomWidth="1px"
+                  bgColor={titleBgColor}
+                  borderTopRadius="md"
                 >
-                  {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({token, key})} />
-                  ))}
+                  {title}
                 </Box>
-              ))}
-            </chakra.pre>
+              )}
+              <chakra.pre
+                className={className}
+                py={SPACING}
+                px={showLineNumbers && SPACING}
+                fontFamily="inherit"
+                overflow="auto"
+              >
+                {tokens.map((line, i) => (
+                  <Box
+                    {...getLineProps({
+                      line,
+                      key: i
+                    })}
+                    key={i}
+                    pl={(SPACING / 2) * (showLineNumbers ? 2 : 1)}
+                    bg={linesToHighlight.includes(i + 1) && highlightColor}
+                  >
+                    <Box ml={showLineNumbers && lineNumberOffset}>
+                      {line.map((token, key) => (
+                        <span key={key} {...getTokenProps({token, key})} />
+                      ))}
+                    </Box>
+                  </Box>
+                ))}
+              </chakra.pre>
+              {/* put below all code and then position so that if user selects text, line numbers will be excluded */}
+              {showLineNumbers && (
+                <chakra.pre
+                  aria-hidden="true" // hide from screen reader
+                  pos="absolute"
+                  top={title ? '57px' : SPACING} // 57px = SPACING (16px) + height of title box (41px)
+                  left={SPACING}
+                  textAlign="right"
+                  bgColor={theme.plain.backgroundColor} // for horizontal scrolling of code text
+                >
+                  {tokens.map((_, index) => (
+                    <Box
+                      key={index}
+                      w={lineNumberOffset}
+                      mr={SPACING}
+                      color={lineNumberColor}
+                    >
+                      {index + 1}
+                    </Box>
+                  ))}
+                </chakra.pre>
+              )}
+            </Box>
+            <ButtonGroup size="xs" pos="absolute" top="2" right="2">
+              <Button leftIcon={<FiClipboard />} onClick={onCopy}>
+                {hasCopied ? 'Copied!' : 'Copy'}
+              </Button>
+              {languageMenu}
+            </ButtonGroup>
           </Box>
-          <ButtonGroup size="xs" pos="absolute" top="2" right="2">
-            <Button leftIcon={<FiClipboard />} onClick={onCopy}>
-              {hasCopied ? 'Copied!' : 'Copy'}
-            </Button>
-            {languageMenu}
-          </ButtonGroup>
-        </Box>
-      )}
+        );
+      }}
     </Highlight>
   );
 }

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -60,7 +60,7 @@ export default function CodeBlock({children}) {
   const theme = useColorModeValue(lightTheme, darkTheme);
   const highlightColor = useColorModeValue('gray.100', 'gray.700');
   const lineNumberColor = useColorModeValue(
-    'gray.300',
+    'gray.400',
     colors.midnight.lighter
   );
   const languageMenu = useContext(CodeBlockContext);

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -33,7 +33,7 @@ import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-typescript';
 
 export const CodeBlockContext = createContext();
-const SPACING = 4;
+const CODE_BLOCK_SPACING = 4;
 export default function CodeBlock({children}) {
   const [child] = Array.isArray(children) ? children : [children];
   const {
@@ -83,7 +83,7 @@ export default function CodeBlock({children}) {
             <Box fontSize="md" fontFamily="mono">
               {title && (
                 <Box
-                  px={SPACING}
+                  px={CODE_BLOCK_SPACING}
                   py="2"
                   borderBottomWidth="1px"
                   borderTopRadius="md"
@@ -93,14 +93,14 @@ export default function CodeBlock({children}) {
               )}
               <chakra.pre
                 className={className}
-                py={SPACING}
+                py={CODE_BLOCK_SPACING}
                 fontFamily="inherit"
                 overflow="auto"
               >
                 {tokens.map((line, i) => (
                   <Flex
                     key={i}
-                    px={SPACING}
+                    px={CODE_BLOCK_SPACING}
                     minW="100%" // width styles for line highlighting to always go all the way across code block
                     w="fit-content"
                     bg={linesToHighlight.includes(i + 1) && highlightColor}
@@ -111,7 +111,7 @@ export default function CodeBlock({children}) {
                         userSelect="none"
                         textAlign="right" // line number alignment used in VS Code
                         w={lineNumberOffset}
-                        mr={SPACING}
+                        mr={CODE_BLOCK_SPACING}
                         color={lineNumberColor}
                       >
                         {i + 1}

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -44,7 +44,11 @@ export default function CodeBlock({children}) {
   } = child.props;
 
   const meta = metastring || dataMeta;
-  const {title, highlight, showLineNumbers} = meta ? fenceparser(meta) : {};
+  const {
+    title,
+    highlight,
+    showLineNumbers = false
+  } = meta ? fenceparser(meta) : {};
   const linesToHighlight = highlight
     ? rangeParser(Object.keys(highlight).toString())
     : [];
@@ -96,7 +100,7 @@ export default function CodeBlock({children}) {
                 {tokens.map((line, i) => (
                   <Flex
                     key={i}
-                    px={showLineNumbers && SPACING}
+                    px={SPACING}
                     minW="100%" // width styles for line highlighting to always go all the way across code block
                     w="fit-content"
                     bg={linesToHighlight.includes(i + 1) && highlightColor}

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -58,7 +58,7 @@ export default function CodeBlock({children}) {
 
   const {onCopy, hasCopied} = useClipboard(code);
   const theme = useColorModeValue(lightTheme, darkTheme);
-  const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
+  const highlightColor = useColorModeValue('gray.100', 'gray.700');
   const lineNumberColor = useColorModeValue(
     'gray.300',
     colors.midnight.lighter

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -3,7 +3,6 @@ import Prism from 'prismjs';
 import PropTypes from 'prop-types';
 import React, {createContext, useContext} from 'react';
 import fenceparser from 'fenceparser';
-import nightOwlLight from 'prism-react-renderer/themes/nightOwlLight';
 import rangeParser from 'parse-numeric-range';
 import {
   Box,
@@ -15,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import {FiClipboard} from 'react-icons/fi';
 import {theme as darkTheme} from '../prism-themes/dark';
+import {theme as lightTheme} from '../prism-themes/light';
 
 // these must be imported after Prism
 import 'prismjs/components/prism-bash';
@@ -51,8 +51,8 @@ export default function CodeBlock({children}) {
   const [code] = Array.isArray(innerChildren) ? innerChildren : [innerChildren];
 
   const {onCopy, hasCopied} = useClipboard(code);
-  const theme = useColorModeValue(nightOwlLight, darkTheme);
-  const highlightColor = useColorModeValue('blackAlpha.100', 'blackAlpha.400');
+  const theme = useColorModeValue(lightTheme, darkTheme);
+  const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
 
   const languageMenu = useContext(CodeBlockContext);
 

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -48,7 +48,7 @@ export default function CodeBlock({children}) {
   const {
     title,
     highlight,
-    showLineNumbers = false
+    showLineNumbers = true
   } = meta ? fenceparser(meta) : {};
   const linesToHighlight = highlight
     ? rangeParser(Object.keys(highlight).toString())

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -53,7 +53,8 @@ export default function CodeBlock({children}) {
   const {onCopy, hasCopied} = useClipboard(code);
   const theme = useColorModeValue(lightTheme, darkTheme);
   const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
-
+  const borderColor = useColorModeValue('gray.200', 'gray.700');
+  const titleBgColor = useColorModeValue('white', 'inherit');
   const languageMenu = useContext(CodeBlockContext);
 
   return (
@@ -61,13 +62,26 @@ export default function CodeBlock({children}) {
       Prism={Prism}
       theme={theme}
       code={code.trim()}
-      language={className.replace(/language-/, '')}
+      language={className.replace(/^language-/, '')}
     >
       {({className, style, tokens, getLineProps, getTokenProps}) => (
-        <Box rounded="md" style={style} pos="relative" shadow="sm">
+        <Box
+          rounded="md"
+          style={style}
+          pos="relative"
+          shadow="sm"
+          borderWidth="1px"
+          borderColor={borderColor}
+        >
           <Box fontSize="md" fontFamily="mono">
             {title && (
-              <Box px="4" py="2" borderBottomWidth="1px">
+              <Box
+                px="4"
+                py="2"
+                borderBottomWidth="1px"
+                bgColor={titleBgColor}
+                borderTopRadius="md"
+              >
                 {title}
               </Box>
             )}

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -14,6 +14,7 @@ import {
   useColorModeValue
 } from '@chakra-ui/react';
 import {FiClipboard} from 'react-icons/fi';
+import {colors} from '@apollo/space-kit/colors';
 import {theme as darkTheme} from '../prism-themes/dark';
 import {theme as lightTheme} from '../prism-themes/light';
 
@@ -58,7 +59,10 @@ export default function CodeBlock({children}) {
   const {onCopy, hasCopied} = useClipboard(code);
   const theme = useColorModeValue(lightTheme, darkTheme);
   const highlightColor = useColorModeValue('gray.100', 'blackAlpha.400');
-  const lineNumberColor = useColorModeValue('gray.300', '#798fbb');
+  const lineNumberColor = useColorModeValue(
+    'gray.300',
+    colors.midnight.lighter
+  );
   const languageMenu = useContext(CodeBlockContext);
 
   return (

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -40,12 +40,11 @@ export default function CodeBlock({children}) {
     className = 'language-text',
     children: innerChildren,
     metastring,
-    'data-meta': dataMeta,
-    showLineNumbers = true
+    'data-meta': dataMeta
   } = child.props;
 
   const meta = metastring || dataMeta;
-  const {title, highlight} = meta ? fenceparser(meta) : {};
+  const {title, highlight, showLineNumbers} = meta ? fenceparser(meta) : {};
   const linesToHighlight = highlight
     ? rangeParser(Object.keys(highlight).toString())
     : [];

--- a/src/components/CodeBlock.js
+++ b/src/components/CodeBlock.js
@@ -77,13 +77,7 @@ export default function CodeBlock({children}) {
         // ex. if there are 28 lines in the code block, lineNumberOffset = 2ch
         const lineNumberOffset = tokens.length.toString().length + 'ch';
         return (
-          <Box
-            rounded="md"
-            style={style}
-            pos="relative"
-            shadow="sm"
-            borderWidth="1px"
-          >
+          <Box rounded="md" style={style} pos="relative" borderWidth="1px">
             <Box fontSize="md" fontFamily="mono">
               {title && (
                 <Box

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -1,6 +1,7 @@
 import {colors} from '@apollo/space-kit/colors';
+import {mix} from 'polished';
 
-const {midnight, blilet, orange, teal, yellow} = colors;
+const {midnight, blilet, orange, teal, yellow, purple, blue} = colors;
 const white = '#ffffff'; // TODO: import white directly from chakra theme
 
 export const theme = {
@@ -54,19 +55,19 @@ export const theme = {
     {
       types: ['changed'],
       style: {
-        color: '#FFCB6B'
+        color: mix(0.5, yellow.dark, yellow.base) // fairly close to original #FFCB6B, but using space kit colors here
       }
     },
     {
       types: ['attr-name'],
       style: {
-        color: '#C792EA'
+        color: mix(0.5, purple.base, purple.lightest) // fairly close to original #C792EA, but using space kit colors here
       }
     },
     {
       types: ['regex'],
       style: {
-        color: '#89DDFF'
+        color: mix(0.5, teal.light, blue.light) // fairly close to original #89DDFF, but using space kit colors here
       }
     },
     {

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -2,11 +2,10 @@ import {colors} from '@apollo/space-kit/colors';
 import {mix} from 'polished';
 
 const {midnight, blilet, orange, teal, yellow, purple, blue} = colors;
-const white = '#ffffff'; // TODO: import white directly from chakra theme
 
 export const theme = {
   plain: {
-    color: white,
+    color: 'white',
     backgroundColor: midnight.darkest
   },
   styles: [
@@ -25,7 +24,7 @@ export const theme = {
     {
       types: ['constant'],
       style: {
-        color: white
+        color: 'white'
       }
     },
     {

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -1,49 +1,54 @@
+import {colors} from '@apollo/space-kit/colors';
+
+const {midnight, blilet, orange, teal, yellow} = colors;
+const white = '#ffffff'; // TODO: import white directly from chakra theme
+
 export const theme = {
   plain: {
-    color: '#ffffff',
-    backgroundColor: '#060f2f'
+    color: white,
+    backgroundColor: midnight.darkest
   },
   styles: [
     {
       types: ['comment', 'punctuation'],
       style: {
-        color: '#798FBB'
+        color: midnight.lighter
       }
     },
     {
       types: ['variable', 'string'],
       style: {
-        color: '#FFC18F'
+        color: orange.light
       }
     },
     {
       types: ['constant'],
       style: {
-        color: '#FFFFFF'
+        color: white
       }
     },
     {
       types: ['keyword', 'builtin', 'number', 'char'],
       style: {
-        color: '#F59140'
+        color: orange.base
       }
     },
     {
       types: ['tag', 'deleted'],
       style: {
-        color: '#41D9D3'
+        color: teal.base
       }
     },
     {
       types: ['function'],
       style: {
-        color: '#7A92F0'
+        color: blilet.light
       }
     },
     {
       types: ['symbol', 'inserted'],
       style: {
-        color: '#8BF6F2'
+        color: teal.light
       }
     },
     {
@@ -67,7 +72,7 @@ export const theme = {
     {
       types: ['boolean'],
       style: {
-        color: '#F4D03F'
+        color: yellow.base
       }
     }
   ]

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -1,0 +1,77 @@
+// TODO: some code blocks don't seem to be getting syntax color styles
+// code block w/ `js{12-17}` language prop doesn't colorize correctly, but `js` language prop does
+
+export const theme = {
+  plain: {
+    color: '#ffffff',
+    backgroundColor: '#060f2f'
+  },
+  styles: [
+    {
+      types: ['comment', 'punctuation'],
+      style: {
+        color: '#798FBB'
+      }
+    },
+    {
+      types: ['variable', 'string'],
+      style: {
+        color: '#FFC18F'
+      }
+    },
+    {
+      types: ['constant'],
+      style: {
+        color: '#FFFFFF'
+      }
+    },
+    {
+      types: ['keyword', 'builtin', 'number', 'char'],
+      style: {
+        color: '#F59140'
+      }
+    },
+    {
+      types: ['tag', 'deleted'],
+      style: {
+        color: '#41D9D3'
+      }
+    },
+    {
+      types: ['function'],
+      style: {
+        color: '#7A92F0'
+      }
+    },
+    {
+      types: ['symbol', 'inserted'],
+      style: {
+        color: '#8BF6F2'
+      }
+    },
+    {
+      types: ['changed'],
+      style: {
+        color: '#FFCB6B'
+      }
+    },
+    {
+      types: ['attr-name'],
+      style: {
+        color: '#C792EA'
+      }
+    },
+    {
+      types: ['regex'],
+      style: {
+        color: '#89DDFF'
+      }
+    },
+    {
+      types: ['boolean'],
+      style: {
+        color: '#F4D03F'
+      }
+    }
+  ]
+};

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -1,6 +1,3 @@
-// TODO: some code blocks don't seem to be getting syntax color styles
-// code block w/ `js{12-17}` language prop doesn't colorize correctly, but `js` language prop does
-
 export const theme = {
   plain: {
     color: '#ffffff',

--- a/src/prism-themes/dark.js
+++ b/src/prism-themes/dark.js
@@ -1,5 +1,6 @@
 import {colors} from '@apollo/space-kit/colors';
 import {mix} from 'polished';
+import {sharedStyles} from './sharedStyles';
 
 const {midnight, blilet, orange, teal, yellow, purple, blue} = colors;
 
@@ -9,6 +10,7 @@ export const theme = {
     backgroundColor: midnight.darkest
   },
   styles: [
+    ...sharedStyles,
     {
       types: ['comment', 'punctuation'],
       style: {

--- a/src/prism-themes/light.js
+++ b/src/prism-themes/light.js
@@ -1,4 +1,5 @@
 import {colors} from '@apollo/space-kit/colors';
+import {sharedStyles} from './sharedStyles';
 
 const {black, silver, orange, grey, pink, teal, indigo, yellow} = colors;
 
@@ -8,6 +9,7 @@ export const theme = {
     backgroundColor: silver.lighter
   },
   styles: [
+    ...sharedStyles,
     {
       types: ['comment', 'prolog', 'doctype', 'cdata'],
       style: {
@@ -60,24 +62,6 @@ export const theme = {
       types: ['regex', 'important', 'variable'],
       style: {
         color: yellow.darker
-      }
-    },
-    {
-      types: ['important', 'bold'],
-      style: {
-        fontWeight: 'bold'
-      }
-    },
-    {
-      types: ['italic'],
-      style: {
-        fontStyle: 'italic'
-      }
-    },
-    {
-      types: ['entity'],
-      style: {
-        cursor: 'help'
       }
     }
   ]

--- a/src/prism-themes/light.js
+++ b/src/prism-themes/light.js
@@ -1,0 +1,84 @@
+export const theme = {
+  plain: {
+    color: '#2F353F', // black.lighter
+    backgroundColor: '#F4F6F8' // silver.light
+  },
+  styles: [
+    {
+      types: ['comment', 'prolog', 'doctype', 'cdata'],
+      style: {
+        color: '#B46626' // orange.dark
+      }
+    },
+
+    {
+      types: ['punctuation'],
+      style: {
+        color: '#5A6270' // grey.dark
+      }
+    },
+    {
+      types: [
+        'property',
+        'tag',
+        'boolean',
+        'number',
+        'constant',
+        'symbol',
+        'deleted'
+      ],
+      style: {
+        color: '#832363' // pink.darker
+      }
+    },
+    {
+      types: ['selector', 'attr-name', 'string', 'char', 'builtin', 'inserted'],
+      style: {
+        color: '#1D7B78' // teal.darker
+      }
+    },
+    {
+      types: ['atrule', 'attr-value', 'keyword'],
+      style: {
+        color: 'inherit',
+        background: 'transparent'
+      }
+    },
+    {
+      types: ['atrule', 'attr-value', 'keyword'],
+      style: {
+        color: '#311C87' // indigo.dark
+      }
+    },
+    {
+      types: ['class-name', 'function'],
+      style: {
+        color: '#832363' // pink.darker
+      }
+    },
+    {
+      types: ['regex', 'important', 'variable'],
+      style: {
+        color: '#84671D' // yellow.darker
+      }
+    },
+    {
+      types: ['important', 'bold'],
+      style: {
+        fontWeight: 'bold'
+      }
+    },
+    {
+      types: ['italic'],
+      style: {
+        fontStyle: 'italic'
+      }
+    },
+    {
+      types: ['entity'],
+      style: {
+        cursor: 'help'
+      }
+    }
+  ]
+};

--- a/src/prism-themes/light.js
+++ b/src/prism-themes/light.js
@@ -5,7 +5,7 @@ const {black, silver, orange, grey, pink, teal, indigo, yellow} = colors;
 export const theme = {
   plain: {
     color: black.lighter,
-    backgroundColor: silver.light
+    backgroundColor: silver.lighter
   },
   styles: [
     {

--- a/src/prism-themes/light.js
+++ b/src/prism-themes/light.js
@@ -1,20 +1,24 @@
+import {colors} from '@apollo/space-kit/colors';
+
+const {black, silver, orange, grey, pink, teal, indigo, yellow} = colors;
+
 export const theme = {
   plain: {
-    color: '#2F353F', // black.lighter
-    backgroundColor: '#F4F6F8' // silver.light
+    color: black.lighter,
+    backgroundColor: silver.light
   },
   styles: [
     {
       types: ['comment', 'prolog', 'doctype', 'cdata'],
       style: {
-        color: '#B46626' // orange.dark
+        color: orange.dark
       }
     },
 
     {
       types: ['punctuation'],
       style: {
-        color: '#5A6270' // grey.dark
+        color: grey.dark
       }
     },
     {
@@ -28,13 +32,13 @@ export const theme = {
         'deleted'
       ],
       style: {
-        color: '#832363' // pink.darker
+        color: pink.darker
       }
     },
     {
       types: ['selector', 'attr-name', 'string', 'char', 'builtin', 'inserted'],
       style: {
-        color: '#1D7B78' // teal.darker
+        color: teal.darker
       }
     },
     {
@@ -47,19 +51,19 @@ export const theme = {
     {
       types: ['atrule', 'attr-value', 'keyword'],
       style: {
-        color: '#311C87' // indigo.dark
+        color: indigo.dark
       }
     },
     {
       types: ['class-name', 'function'],
       style: {
-        color: '#832363' // pink.darker
+        color: pink.darker
       }
     },
     {
       types: ['regex', 'important', 'variable'],
       style: {
-        color: '#84671D' // yellow.darker
+        color: yellow.darker
       }
     },
     {

--- a/src/prism-themes/light.js
+++ b/src/prism-themes/light.js
@@ -29,7 +29,9 @@ export const theme = {
         'number',
         'constant',
         'symbol',
-        'deleted'
+        'deleted',
+        'class-name',
+        'function'
       ],
       style: {
         color: pink.darker
@@ -52,12 +54,6 @@ export const theme = {
       types: ['atrule', 'attr-value', 'keyword'],
       style: {
         color: indigo.dark
-      }
-    },
-    {
-      types: ['class-name', 'function'],
-      style: {
-        color: pink.darker
       }
     },
     {

--- a/src/prism-themes/sharedStyles.js
+++ b/src/prism-themes/sharedStyles.js
@@ -1,0 +1,20 @@
+export const sharedStyles = [
+  {
+    types: ['important', 'bold'],
+    style: {
+      fontWeight: 'bold'
+    }
+  },
+  {
+    types: ['italic'],
+    style: {
+      fontStyle: 'italic'
+    }
+  },
+  {
+    types: ['entity'],
+    style: {
+      cursor: 'help'
+    }
+  }
+];


### PR DESCRIPTION
This PR adds both a light and dark mode color theme for the code blocks that use the Apollo colors, as well as adding in an option to add line numbers to code blocks.

Light theme is from the existing Prism theme used in the current docs, ported over from a `prism.less` file to the syntax expected by `prism-react-renderer`. Dark theme is the [Apollo Midnight VS Code theme](https://marketplace.visualstudio.com/items?itemName=apollographql.apollo-midnight-color-theme#:~:text=From%20VS%20Code%3A,for%20apollo%20midnight%20color%20theme&text=Set%20the%20theme%20as%20your,Color%20Theme%20%2D%3E%20Apollo%20Midnight%20) that I then converted to a Prism theme using [this converter tool](https://prism.dotenv.dev/).

Code block w/ line numbers, title, and some line highlighting:
http://localhost:8888/react/get-started#3-connect-your-client-to-react 

Similar code block example as above, but highlighted line has horizontal scroll (second code block in this section):
http://localhost:8888/react/get-started#4-fetch-data-with-usequery

## TO DO 
- [x] Double check that Apollo Midnight color theme works for JS, TS, and GraphQL (and any other languages used in docs?)
- [x] Create light mode theme
- [x] Change highlighted line background color for dark mode -- current color doesn't have high enough contrast w/ "regular" bg color