### PR TITLE
Remove JSX spaces from markdown

### DIFF
--- a/src/content/studio/check-configurations.mdx
+++ b/src/content/studio/check-configurations.mdx
@@ -14,7 +14,7 @@ After you [enable schema checks](./schema-checks/) for your graph, you can custo
 In [Apollo Studio](https://studio.apollographql.com), you can configure default rules that are applied to every executed schema check. You define these rules from the Configuration tab of your graph's Checks page:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/check-configurations/check-configuration-page.png"
   alt="Check configuration page in Apollo Studio"
 />
@@ -25,7 +25,7 @@ In [Apollo Studio](https://studio.apollographql.com), you can configure default 
 - **Operation count threshold**: _Exclude_ all operations that were executed fewer than this number of times within the specified **time range**.
 - **Variants**: _Include_ all distinct operations that were executed against each selected variant of your graph. The default value is "Base variant" (i.e., whichever variant schema checks are being run against).
 - **Client exclusions**: _Exclude_ all operations that were executed by particular clients, such as clients used exclusively for development and testing.
-  {' '}
+
   <img
     class="screenshot"
     src="./img/check-configurations/excluded-clients.png"
@@ -103,7 +103,7 @@ The graph ref `docs-example-graph@staging` specifies the `staging` variant of th
 To check your schema against multiple variants, call `rover graph check` once for each variant. Doing so results in status checks similar to the following:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/multi-github-check.png"
   alt="Multiple service checks"
 />

--- a/src/content/studio/getting-started.mdx
+++ b/src/content/studio/getting-started.mdx
@@ -50,8 +50,6 @@ The **Apollo schema registry** powers nearly every feature of Apollo Studio, alo
 
 To register your server's schema, first obtain a **graph API key** for your graph:
 
-{' '}
-
 <ObtainGraphApiKey />
 
 Once you have your API key, select the registration method that corresponds to your graph's architecture:
@@ -82,8 +80,6 @@ Now whenever your server starts up, it automatically registers its schema with t
 
 <ExpansionPanel title="Another GraphQL server WITHOUT Apollo Federation">
 
-{' '}
-
 <RegisterCli />
 
 </ExpansionPanel>
@@ -91,8 +87,6 @@ Now whenever your server starts up, it automatically registers its schema with t
 <ExpansionPanel title="Any GraphQL server WITH Apollo Federation">
 
 > After you complete this step, you should also complete the remaining steps in [Setting up managed federation](https://www.apollographql.com/docs/federation/managed-federation/setup/).
-
-{' '}
 
 <RegisterFederatedCli />
 

--- a/src/content/studio/schema-checks.mdx
+++ b/src/content/studio/schema-checks.mdx
@@ -8,7 +8,7 @@ Certain changes to your GraphQL schema (such as removing a field or type) might 
 You can review the results of schema checks inside Studio, helping you make informed decisions about evolving your graph:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/checks-studio.jpg"
   alt="Schema check results in Studio"
   width="300"
@@ -53,8 +53,6 @@ rover graph check docs-example-graph@current --schema ./schema.graphql
 It requires the following:
 
 - Your registered graph's [graph ref](https://www.apollographql.com/docs/rover/conventions/#graph-refs). This is available from your graph's Schema tab in Studio:
-
-  {' '}
 
   <img
     class="screenshot"
@@ -107,7 +105,7 @@ Each change to the schema is labeled either `PASS` or `FAIL`.
 The output also includes a Studio URL that provides full details on the changes and their impact on existing clients and operations:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/service-check-page.png"
   alt="Service check page in Apollo Studio"
 />
@@ -121,7 +119,7 @@ Occasionally, schema checks might flag a change that you know is safe. For examp
 In cases like this, you can **override** a flagged change in Apollo Studio from the associated check's details page:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/mark-operation.png"
   alt="Service check page in Apollo Studio"
 />
@@ -140,7 +138,7 @@ You override flagged changes on an operation-by-operation basis. For each operat
 You can rerun checks from inside Studio:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/rerun-check.png"
   alt="Rerun check in Apollo Studio"
 />
@@ -170,7 +168,7 @@ When you run `subgraph check`, Apollo Studio performs a **composition check** be
 Results of both check types are available in Studio from your graph's Checks tab:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/checks-studio.jpg"
   alt="Schema check results in Studio"
   width="300"
@@ -232,7 +230,7 @@ jobs:
 If you're using GitHub, you can install the [Apollo Studio GitHub app](https://github.com/marketplace/apollo-studio#pricing-and-setup). This app enables Apollo Studio to send a webhook back to your GitHub project on each call to `rover graph check`, providing built-in pass/fail status checks on your pull requests:
 
 <img
-  class="screenshot"
+  className="screenshot"
   src="./img/schema-checks/github-check.png"
   alt="GitHub Status View"
 />


### PR DESCRIPTION
This PR removes errant `{' '}` instances in local MDX content