### PR TITLE
Add styles for sequence diagrams

### DIFF
--- a/src/utils/mermaid.js
+++ b/src/utils/mermaid.js
@@ -81,11 +81,23 @@ export function useMermaidStyles() {
         stroke: primary,
         fill: background
       },
+      [['g line', 'svg>line']]: {
+        stroke: tertiary
+      },
+      [['.actor-man line', '.actor-man circle']]: {
+        stroke: tertiary,
+        fill: background
+      },
       [['.label text', 'span']]: {
         color: 'inherit',
         fill: 'currentColor'
       },
-      [['.edgePath .path', '.flowchart-link', '.messageLine0']]: {
+      [[
+        '.edgePath .path',
+        '.flowchart-link',
+        '.messageLine0',
+        '.messageLine1'
+      ]]: {
         stroke: 'currentColor'
       },
       [['.marker', '#arrowhead path']]: {


### PR DESCRIPTION
Before:
<img width="681" alt="Screen Shot 2022-03-21 at 4 39 44 PM" src="https://user-images.githubusercontent.com/3433000/159380418-181f3ca4-4a75-40d9-a278-1b842af1ddd4.png">

After:
<img width="678" alt="Screen Shot 2022-03-21 at 4 39 26 PM" src="https://user-images.githubusercontent.com/3433000/159380429-46b7a628-077b-4250-a6ed-715093bab530.png">

