### PR TITLE
update docs for explorer.prompt to reflect accepting messages in markdown

### DIFF
--- a/src/content/studio/explorer/connecting-authenticating.mdx
+++ b/src/content/studio/explorer/connecting-authenticating.mdx
@@ -193,7 +193,9 @@ Function for making HTTP requests to external services from within a preflight s
 </td>
 <td>
 
-Prompt the user for input and returns the value in a promise. If the user cancels the prompt, the promise resolves to `null`. `msg` can include markdown.
+Function that [rompt the user for input and returns the value in a promise. If the user cancels the prompt, the promise resolves to `null`.  
+
+The prompt supports Markdown rendering of the msg parameter.  
 
 </td>
 </tr>

--- a/src/content/studio/explorer/connecting-authenticating.mdx
+++ b/src/content/studio/explorer/connecting-authenticating.mdx
@@ -195,7 +195,7 @@ Function for making HTTP requests to external services from within a preflight s
 
 Function that [rompt the user for input and returns the value in a promise. If the user cancels the prompt, the promise resolves to `null`.  
 
-The prompt supports Markdown rendering of the msg parameter.  
+The prompt supports Markdown rendering of the `msg` parameter.  
 
 </td>
 </tr>

--- a/src/content/studio/explorer/connecting-authenticating.mdx
+++ b/src/content/studio/explorer/connecting-authenticating.mdx
@@ -193,7 +193,7 @@ Function for making HTTP requests to external services from within a preflight s
 </td>
 <td>
 
-Function that prompts the user for input and returns the value in a promise. If the user cancels the prompt, the promise resolves to `null`.
+Prompt the user for input and returns the value in a promise. If the user cancels the prompt, the promise resolves to `null`. `msg` can include markdown.
 
 </td>
 </tr>


### PR DESCRIPTION
In response to a suggestion from https://github.com/apollographql/apollo-studio-community/discussions/152, we now render markdown passed into `explorer.prompt`. This PR updates the docs to reflect that  

![image](https://user-images.githubusercontent.com/743976/159773251-fb7f6767-54b4-4c5d-b398-571a95f03cd7.png)
