### PR TITLE
Fix last code block syntax highlight issues

### DIFF
--- a/src/content/studio/contracts.mdx
+++ b/src/content/studio/contracts.mdx
@@ -83,7 +83,7 @@ With contracts, you apply **tags** to types and fields in your subgraph schemas 
 
 For example, let's take a look at this Products subgraph schema:
 
-```graphql{1-4,16-19}:title=products.graphql
+```graphql {1-4,16-19} title="products.graphql"
 # You must include this definition in any schema with tags!
 directive @tag(name: String!) repeatable on
   | FIELD_DEFINITION

--- a/src/content/studio/explorer/additional-features.mdx
+++ b/src/content/studio/explorer/additional-features.mdx
@@ -30,7 +30,7 @@ While editing your operations, you can toggle between inline or extracted notati
 
 #### Inline variable
 
-```graphql:title=query.graphql
+```graphql title="query.graphql"
 query {
   user(id: "Beth Harmon") {
     name
@@ -40,7 +40,7 @@ query {
 
 #### Extracted variable
 
-```graphql:title=query.graphql
+```graphql title="query.graphql"
 query($id: ID!) {
   user(id: $id) {
     name
@@ -48,7 +48,7 @@ query($id: ID!) {
 }
 ```
 
-```json:title=variables.json
+```json title="variables.json"
 {
   "id": "Beth Harmon"
 }
@@ -205,7 +205,7 @@ The Explorer [extends your schema with `graphql-lodash`](https://github.com/APIs
 
 Here's an example of a query that uses `graphql-lodash`. You can try pasting this in the Explorer embedded at http://apollographql.com/studio/develop:
 
-```graphql:title=example.graphql
+```graphql title="example.graphql"
 query StarWarsGenderStats {
   genderStats: allPeople @_(get: "edges") {
     edges @_(countBy: "node.gender") {

--- a/src/content/studio/federated-graphs.mdx
+++ b/src/content/studio/federated-graphs.mdx
@@ -105,7 +105,7 @@ The contact info includes a name (of a team or individual), along with an option
 
 To add the `@contact` directive to your schema, you first need to _define_ the directive. Add the following definition to each of your subgraph schemas:
 
-```graphql:title=schema.graphql
+```graphql title="schema.graphql"
 directive @contact(
   "Contact title of the subgraph owner"
   name: String!
@@ -118,7 +118,7 @@ directive @contact(
 
 You can now apply the `@contact` directive to the special `schema` object. Many schemas don’t include this object because it’s not required, but you can add it like so:
 
-```graphql:title=schema.graphql
+```graphql title="schema.graphql"
 schema @contact(
   name: "Acephei Server Team",
   url: "https://myteam.slack.com/archives/teams-chat-room-url",
@@ -150,7 +150,7 @@ As shown, the `schema` object must include a field for each root operation type 
 - Similarly, you cannot provide your `@contact` directive to Apollo via [schema reporting](./schema/schema-reporting/). This registration method also does not include directives.
 - If your subgraph doesn’t already have a `schema` object, you need to add one to use the `@contact` directive. The `schema` object cannot be empty, so you need to include at least one field in it (most commonly `query: Query`). If you do provide the `Query` type like this, it needs to include at least one field in your subgraph’s schema. If your subgraph’s `Query` type is empty, you need to add a dummy field for the SDL to be valid:
 
-  ```graphql:title=schema.graphql
+  ```graphql title="schema.graphql"
   @contact(...)
   schema {
     query: Query

--- a/src/content/studio/getting-started.mdx
+++ b/src/content/studio/getting-started.mdx
@@ -62,7 +62,7 @@ Set your graph API key as the value of the `APOLLO_KEY` environment variable in 
 
 If you're using the [`dotenv`](https://www.npmjs.com/package/dotenv) library, you can add these definitions to the `.env` file in your project's root directory, like so:
 
-```bash{1-2}:title=.env
+```bash {1-2} title=".env"
 APOLLO_KEY=YOUR_KEY_HERE
 APOLLO_SCHEMA_REPORTING=true
 APOLLO_GRAPH_ID=your-graph-id

--- a/src/content/studio/metrics/client-awareness.mdx
+++ b/src/content/studio/metrics/client-awareness.mdx
@@ -27,7 +27,7 @@ By default, Apollo Server checks for the presence of the following HTTP headers 
 
 **If you're using Apollo Client**, you can populate these headers automatically for every operation request by providing the `name` and `version` options to the `ApolloClient` constructor, like so:
 
-```js{8-9}
+```js {8-9}
 import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 
@@ -48,7 +48,7 @@ You can configure Apollo Server to use a different method to determine the `name
 
 In the following example, the `generateClientInfo` function calls a `userSuppliedLogic` function, which can return values for the client's name and version based on the details of the `request`.
 
-```js{8-14}
+```js {8-14}
 const { ApolloServer } = require("apollo-server");
 const { ApolloServerPluginUsageReporting } = require("apollo-server-core");
 

--- a/src/content/studio/metrics/operation-signatures.mdx
+++ b/src/content/studio/metrics/operation-signatures.mdx
@@ -18,7 +18,7 @@ To help Studio identify functionally identical operations, Apollo Server generat
 
 Consider the following operations:
 
-```graphql{10-11,17}
+```graphql {10-11,17}
 query GetPostDetails($postId: String!) {
   post(id: $postId) {
     author

--- a/src/content/studio/operation-registry.mdx
+++ b/src/content/studio/operation-registry.mdx
@@ -130,7 +130,7 @@ Subscription support is enabled by default in Apollo Server 2.x and provided by 
 
 To disable subscriptions support on Apollo Server 2.x, a `subscriptions: false` setting should be included on the instantiation of Apollo Server, as follows:
 
-```js{5-6}
+```js {5-6}
 const server = new ApolloServer({
   // Existing configuration
   typeDefs,
@@ -155,7 +155,7 @@ npm install @apollo/server-plugin-operation-registry
 
 Next, the plugin must be enabled. This requires adding the appropriate module to the `plugins` parameter to the Apollo Server options:
 
-```js{8-12}
+```js {8-12}
 const server = new ApolloServer({
   // Existing configuration
   typeDefs,
@@ -175,7 +175,7 @@ const server = new ApolloServer({
 
 The full setup:
 
-```js{21-25}
+```js {21-25}
 const { ApolloServer } = require('apollo-server');
 const { ApolloGateway } = require("@apollo/gateway");
 
@@ -282,7 +282,7 @@ To selectively enable operation safelisting, the `forbidUnregisteredOperations` 
 
 For example, to enforce the operation registry safelisting while skipping enforcement for any request in which the `Let-me-pass` header was present with a value of `Pretty please?`, the following configuration could be used:
 
-```js{12-27}
+```js {12-27}
 const server = new ApolloServer({
   // Existing configuration
   typeDefs,
@@ -331,7 +331,7 @@ This **experimental** function can be used to monitor the number of operations i
 
 <ExpansionPanel title="Code sample">
 
-```js{4-10}
+```js {4-10}
 const server = new ApolloServer({
   plugins: [
     require("@apollo/server-plugin-operation-registry")({
@@ -356,7 +356,7 @@ This function is run when an operation is not found in the manifest.
 
 <ExpansionPanel title="Code sample">
 
-```js{4-6}
+```js {4-6}
 const server = new ApolloServer({
   plugins: [
     require("@apollo/server-plugin-operation-registry")({
@@ -378,7 +378,7 @@ This function is run when an operation is not in the manifest and
 
 <ExpansionPanel title="Code sample">
 
-```js{5-7}
+```js {5-7}
 const server = new ApolloServer({
   plugins: [
     require("@apollo/server-plugin-operation-registry")({

--- a/src/content/studio/schema-checks-apollo-cli.mdx
+++ b/src/content/studio/schema-checks-apollo-cli.mdx
@@ -119,7 +119,7 @@ We recommend defining a separate CI job for each [variant of your schema](./chec
 
 The following config defines a schema check job for a CircleCI pipeline. Your config's syntax varies depending on your CI tool, but the job's steps are the same.
 
-```yaml{30}:title=config.yml
+```yaml {30} title="config.yml"
 version: 2
 
 jobs:

--- a/src/content/studio/schema-checks.mdx
+++ b/src/content/studio/schema-checks.mdx
@@ -192,7 +192,7 @@ The `rover config auth` command is _interactive_, which means you shouldn't use 
 
 The following config defines a schema check job for a CircleCI pipeline. Your config's syntax varies depending on your CI tool, but the job's steps are the same.
 
-```yaml{30}:title=config.yml
+```yaml {30}:title=config.yml
 version: 2
 
 jobs:

--- a/src/content/studio/schema-checks.mdx
+++ b/src/content/studio/schema-checks.mdx
@@ -192,7 +192,7 @@ The `rover config auth` command is _interactive_, which means you shouldn't use 
 
 The following config defines a schema check job for a CircleCI pipeline. Your config's syntax varies depending on your CI tool, but the job's steps are the same.
 
-```yaml {30}:title=config.yml
+```yaml {30} title="config.yml"
 version: 2
 
 jobs:

--- a/src/content/studio/schema/schema-reporting.mdx
+++ b/src/content/studio/schema/schema-reporting.mdx
@@ -38,7 +38,7 @@ Your server can register its schema to a particular [variant of your graph](../o
 
 To do so with Apollo Server, set the `APOLLO_GRAPH_VARIANT` environment variable in each server environment:
 
-```none:title=.env
+```none title=".env"
 APOLLO_KEY=YOUR_KEY_HERE
 APOLLO_GRAPH_ID=your-graph-id
 APOLLO_GRAPH_VARIANT=staging

--- a/src/content/studio/validating-client-operations.mdx
+++ b/src/content/studio/validating-client-operations.mdx
@@ -44,7 +44,7 @@ Your application can incorporate `client:check` into its continuous delivery pip
 
 Here's a Circle CI configuration excerpt that incorporates the command:
 
-```yaml{30}:title=config.yml
+```yaml {30} title="config.yml"
 version: 2
 
 jobs:


### PR DESCRIPTION
Fixing some of the last highlighting issues with the code blocks. This is documented in the README how to solve but was not applied to all pages like the following:

* https://www.apollographql.com/docs/studio/explorer/additional-features/#dark-mode