### PR TITLE
Update Apollo Client link in footer.ts

### DIFF
--- a/packages/chakra-helpers/src/footer.ts
+++ b/packages/chakra-helpers/src/footer.ts
@@ -52,7 +52,7 @@ export const productCategory: Category = {
     },
     {
       text: 'Apollo Client',
-      href: 'https://www.apollographql.com/docs/apollo-client/'
+      href: 'https://www.apollographql.com/docs/react/'
     },
     {
       text: 'Apollo Server',


### PR DESCRIPTION
The current link to the Apollo Client docs in the footer is 404ing:

![CleanShot 2022-04-21 at 15 35 34@2x](https://user-images.githubusercontent.com/5139846/164539301-e8a8dfff-7f1a-417b-bf85-b6c11b9d0d6e.png)

As far as I can tell the correct link is https://www.apollographql.com/docs/react/