### PR TITLE
Update section 1 under Setup to address gateway/subgraph versions to use for Fed 1 and Fed 2 contracts

### DIFF
--- a/src/content/studio/contracts.mdx
+++ b/src/content/studio/contracts.mdx
@@ -85,8 +85,8 @@ In Studio, each contract variant has its own README, schema reference, and Explo
 
 **Before you create any contracts:**
 
-1. Update your gateway's `@apollo/gateway` library to version 0.34 or later.
-2. Update your Apollo Server subgraphs to use version 0.1.1 or later of the `@apollo/subgraph` library.
+1. For Fed 1 contract variants, update your gateway's `@apollo/gateway` library to version 0.34.0 or later. For Fed 2 contract variants, ensure that you are running gateway versions higher than 2.0.2 otherwise you will encounter runtime errors.
+2. Update your Apollo Server subgraphs to use version 0.1.1 or later of the `@apollo/subgraph` library. For Fed 2 contract variants, ensure that your `@apollo/subgraph` version is higher than 2.0.0. 
    - `@apollo/subgraph` recently replaced `@apollo/federation` for Apollo Server instances acting as subgraphs. Symbol names are unchanged.
 3. If you're still using the Apollo CLI to publish subgraph schemas (via `apollo service:push`), [install the Rover CLI](https://www.apollographql.com/docs/rover/getting-started/) and begin using [`rover subgraph publish`](https://www.apollographql.com/docs/rover/subgraphs/#publishing-a-subgraph-schema-to-apollo-studio) instead.
 

--- a/src/content/studio/contracts.mdx
+++ b/src/content/studio/contracts.mdx
@@ -85,7 +85,7 @@ In Studio, each contract variant has its own README, schema reference, and Explo
 
 **Before you create any contracts:**
 
-1. For Fed 1 contract variants, update your gateway's `@apollo/gateway` library to version 0.34.0 or later. For Fed 2 contract variants, ensure that you are running gateway versions higher than 2.0.2 otherwise you will encounter runtime errors.
+1. For Federation 2 contract variants, ensure that you're running gateway versions higher than 2.0.2. For Federation 1 contract variants, update your gateway's `@apollo/gateway` library to version 0.34.0 or later. Otherwise, you'll encounter runtime errors.
 2. Update your Apollo Server subgraphs to use version 0.1.1 or later of the `@apollo/subgraph` library. For Fed 2 contract variants, ensure that your `@apollo/subgraph` version is higher than 2.0.0. 
    - `@apollo/subgraph` recently replaced `@apollo/federation` for Apollo Server instances acting as subgraphs. Symbol names are unchanged.
 3. If you're still using the Apollo CLI to publish subgraph schemas (via `apollo service:push`), [install the Rover CLI](https://www.apollographql.com/docs/rover/getting-started/) and begin using [`rover subgraph publish`](https://www.apollographql.com/docs/rover/subgraphs/#publishing-a-subgraph-schema-to-apollo-studio) instead.

--- a/src/content/studio/contracts.mdx
+++ b/src/content/studio/contracts.mdx
@@ -86,7 +86,7 @@ In Studio, each contract variant has its own README, schema reference, and Explo
 **Before you create any contracts:**
 
 1. For Federation 2 contract variants, ensure that you're running gateway versions higher than 2.0.2. For Federation 1 contract variants, update your gateway's `@apollo/gateway` library to version 0.34.0 or later. Otherwise, you'll encounter runtime errors.
-2. Update your Apollo Server subgraphs to use version 0.1.1 or later of the `@apollo/subgraph` library. For Fed 2 contract variants, ensure that your `@apollo/subgraph` version is higher than 2.0.0. 
+2. For Federation 2 contract variants, update your Apollo Server subgraphs to use version 2.0.0 or later of the `@apollo/subgraph` library. For Federation 1 contract variants, update `@apollo/subgraph` to version 0.1.1 or later.
    - `@apollo/subgraph` recently replaced `@apollo/federation` for Apollo Server instances acting as subgraphs. Symbol names are unchanged.
 3. If you're still using the Apollo CLI to publish subgraph schemas (via `apollo service:push`), [install the Rover CLI](https://www.apollographql.com/docs/rover/getting-started/) and begin using [`rover subgraph publish`](https://www.apollographql.com/docs/rover/subgraphs/#publishing-a-subgraph-schema-to-apollo-studio) instead.
 


### PR DESCRIPTION
This PR adds a little bit more information on which gateway versions and subgraph versions to use for Fed 1 and Fed 2 contract variants.

old:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/10705986/168392880-2aeb172e-bb4c-4cb9-8f5c-6c121eb30e56.png">


new:
<img width="868" alt="image" src="https://user-images.githubusercontent.com/10705986/168393056-bc68e588-7492-411a-88a8-ef9f8c580b48.png">

