### PR TITLE
Add tech notes docset

### DIFF
--- a/sources/local.yml
+++ b/sources/local.yml
@@ -3,3 +3,4 @@
 # https://github.com/gatsbyjs/gatsby/issues/5510
 /: src/content/basics
 studio: src/content/studio
+technotes: src/content/technotes

--- a/src/content/technotes/README.md
+++ b/src/content/technotes/README.md
@@ -1,0 +1,47 @@
+# Apollo Tech Notes
+
+This file is the contributing guide for this section of the docs. It is not exposed on the public site.
+
+## Running Locally
+
+Since all the files for technotes is in the `docs` repo, we can run the simplified local dev mode.
+First, follow the instructions in the main README about how to setup Netlify and installing packages, but then you can use the local command to do a fast startup:
+
+```shell
+npm run start:local
+```
+
+## Creating a new Tech Note
+
+### Create a new file
+Create a new file in the `src/content/technotes/` directory. The file should follow the format `TN0001-my-page-name.mdx`
+
+* Use kebab-case format for entire file name, this will also be the url format
+* Prefix the file name with `TNXXXX` where `X` is an incremental number from the previous tech notes.
+* Use `.mdx`
+* Add the following MDX headers to the top of the file: `title`, `description`, `tags`
+  * ```mdx
+    ---
+    title: My Title of Tech Note
+    description: Sub-description of the technote that may be used for links and metadata
+    tags: [server, client, foo, bar] // Any tags relevant to tech note
+    ---
+
+    Starting content of technote...
+    ```
+    
+### Add file to sidebar
+
+Update the `src/content/technotes/config.json` so that you add the tech note to the long list in the sidebar.
+
+In the `config.json` you should use the following format:
+
+```json
+"sidebar": {
+    "Home": "/",
+    "TN0001 - My Tech Note": "TN0001-my-tech-note"
+}
+```
+
+The key on the left is what is seen by users in the UI so it should have standard English spacing of the title, but with the tech note number as a prefix.
+The value on the right is the name of the file, but without the file extension `.mdx`

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client ID Enforcement
-description: Require clients to pass in headers and operations name which help in monitoring schema usage
+description: Require clients to pass in headers and operations name to help in monitoring schema usage
 tags: [server, observability]
 ---
 
@@ -8,6 +8,7 @@ As part of the Studio metrics reporting, you can [tag the request with the clien
 
 We strongly encourage gateway maintainers to require that the client name, client version, and operation name are included in every request. Once clients start using the graph without this info, it is much more difficult to make them go back and update their existing code. You can add this requirement as an [Apollo Server plugin](https://www.apollographql.com/docs/apollo-server/builtin-plugins) in your gateway:
 
+## Plugin Code
 ```js
 const clientEnforcementPlugin = {
   requestDidStart: ({ request, logger }) => {

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -64,4 +64,16 @@ const server = new ApolloServer({
 });
 ```
 
-The headers specified here are the default ones sent by Apollo Client, but you can change them to any other headers you might be using today.
+## Adding enforcement for existing clients
+
+If clients are already consuming your graph and _are not_ providing client metadata, adding universal enforcement will _break_ those clients. To resolve this you should take the following steps:
+
+### Use other headers
+
+If you have other existing headers in your HTTP requests that can be parsed to extract some client info, you can extract the info from there.
+
+If you do change the identifying headers, also update the [Usage Reporting Plugin](https://www.apollographql.com/docs/studio/metrics/client-awareness/#advanced-apollo-server-configuration) to use the new headers so that the proper client info is also sent to Studio.
+
+### Ask clients to update their requests
+
+The long-term fix will require that clients start sending the required headers needed to extract client info. While clients are working on updating their requests you can add the plugin code to your gateway, but instead of throwing an error you can log a warning so that the gateway team can track when all requests have been updated.

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -1,5 +1,6 @@
 ---
 title: Client ID Enforcement
+description: Require clients to pass in headers and operations name which help in monitoring schema usage
 tags: [server, observability]
 ---
 
@@ -62,3 +63,5 @@ const server = new ApolloServer({
   plugins: [clientEnforcementPlugin]
 });
 ```
+
+The headers specified here are the default ones sent by Apollo Client, but you can change them to any other headers you might be using today.

--- a/src/content/technotes/config.json
+++ b/src/content/technotes/config.json
@@ -5,8 +5,6 @@
   ],
   "sidebar": {
     "Home": "/",
-    "Server": {
-      "Client ID Enforcement": "/server-side/client-id-enforcement"
-    }
+    "TN0001 - Client ID Enforcement": "TN0001-client-id-enforcement"
   }
 }

--- a/src/content/technotes/config.json
+++ b/src/content/technotes/config.json
@@ -1,0 +1,12 @@
+{
+  "title": "Tech Notes",
+  "algoliaFilters": [
+    "docset:technotes"
+  ],
+  "sidebar": {
+    "Example": "/",
+    "Server": {
+      "Client ID Enforcement": "/server-side/client-id-enforcement"
+    }
+  }
+}

--- a/src/content/technotes/config.json
+++ b/src/content/technotes/config.json
@@ -4,7 +4,7 @@
     "docset:technotes"
   ],
   "sidebar": {
-    "Example": "/",
+    "Home": "/",
     "Server": {
       "Client ID Enforcement": "/server-side/client-id-enforcement"
     }

--- a/src/content/technotes/index.mdx
+++ b/src/content/technotes/index.mdx
@@ -2,4 +2,4 @@
 title: Apollo Tech Notes
 ---
 
-Apollo Tech Notes serve as a place to host technical content of many various topics. They can include example code snippets, short explinations on architecture ideas, or more info on how to use the Apollo plaform that doesn't quite have a home in the  main docs.
+Apollo Tech Notes serve as a place to host technical content of many various topics. They can include example code snippets, short explanations on architecture ideas, or more info on how to use the Apollo platform that doesn't quite have a home in the  main docs.

--- a/src/content/technotes/index.mdx
+++ b/src/content/technotes/index.mdx
@@ -1,0 +1,5 @@
+---
+title: Introduction to Apollo Tech Notes
+---
+
+Hello from new page!

--- a/src/content/technotes/index.mdx
+++ b/src/content/technotes/index.mdx
@@ -2,4 +2,11 @@
 title: Apollo Tech Notes
 ---
 
-Apollo Tech Notes serve as a place to host technical content of many various topics. They can include example code snippets, short explanations on architecture ideas, or more info on how to use the Apollo platform that doesn't quite have a home in the  main docs.
+Apollo Tech Notes serve as a place to host technical content of many various topics. They can include example code snippets, short explanations on architecture ideas, or more info on how to use the Apollo platform that doesn't quite have a home in the main docs.
+
+## Reporting issues
+
+If you find any issue with a particular tech note, feel free to use the "Edit on GitHub" button to create a new PR with the suggested changes. Otherwise, you can view the source and create a GitHub issue on the [apollographql/docs](https://github.com/apollographql/docs) repo.
+
+## Adding new tech notes
+If you have an idea for a new tech note, please [create a new GitHub issue](https://github.com/apollographql/docs/issues) with the suggested changes or topic that you would like covered.

--- a/src/content/technotes/index.mdx
+++ b/src/content/technotes/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Apollo Tech Notes
+title: Apollo Tech Notes
 ---
 
-Hello from new page!
+Apollo Tech Notes serve as a place to host technical content of many various topics. They can include example code snippets, short explinations on architecture ideas, or more info on how to use the Apollo plaform that doesn't quite have a home in the  main docs.

--- a/src/content/technotes/server-side/client-id-enforcement.mdx
+++ b/src/content/technotes/server-side/client-id-enforcement.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client ID Enforcement
-tags: server, observability
+tags: [server, observability]
 ---
 
 As part of the Studio metrics reporting, you can [tag the request with the client name and version](https://www.apollographql.com/docs/studio/metrics/client-awareness). This info can be extremely useful to schema authors to understand who is using certain fields in the graph and who to contact when changes or deprecations need to be made. Clients also have the ability to [name their operations](https://www.apollographql.com/docs/react/data/operation-best-practices/#name-all-operations), which can provide more context around how and where the data is being used within the client. Together these pieces of info make a graph much easier to monitor and allows teams to communicate with each other successfully.

--- a/src/content/technotes/server-side/client-id-enforcement.mdx
+++ b/src/content/technotes/server-side/client-id-enforcement.mdx
@@ -1,0 +1,64 @@
+---
+title: Client ID Enforcement
+tags: server, observability
+---
+
+As part of the Studio metrics reporting, you can [tag the request with the client name and version](https://www.apollographql.com/docs/studio/metrics/client-awareness). This info can be extremely useful to schema authors to understand who is using certain fields in the graph and who to contact when changes or deprecations need to be made. Clients also have the ability to [name their operations](https://www.apollographql.com/docs/react/data/operation-best-practices/#name-all-operations), which can provide more context around how and where the data is being used within the client. Together these pieces of info make a graph much easier to monitor and allows teams to communicate with each other successfully.
+
+We strongly encourage gateway maintainers to require that the client name, client version, and operation name are included in every request. Once clients start using the graph without this info, it is much more difficult to make them go back and update their existing code. You can add this requirement as an [Apollo Server plugin](https://www.apollographql.com/docs/apollo-server/builtin-plugins) in your gateway:
+
+```js
+const clientEnforcementPlugin = {
+  requestDidStart: ({ request, logger }) => {
+    let clientName = request.http.headers.get(
+      'apollographql-client-name'
+    );
+    let clientVersion = request.http.headers.get(
+      'apollographql-client-version'
+    );
+
+    if (!clientName) {
+      let logString = `Execution Denied: Operation has no identified client`;
+      logger.debug(logString);
+
+      throw new ApolloError(logString);
+    }
+
+    if (!clientVersion) {
+      let logString = `Execution Denied: Client ${clientName} has no identified version`;
+      logger.debug(logString);
+
+      throw new ApolloError(logString);
+    }
+
+    return {
+      parsingDidStart({ queryHash, request }) {
+        if (!request.operationName) {
+          logger.debug(`Unnamed Operation: ${queryHash}`);
+
+          let error = new ApolloError(
+            'Execution denied: Unnamed operation'
+          );
+
+          Object.assign(error.extensions, {
+            queryHash: queryHash,
+            clientName: clientName,
+            clientVersion: clientVersion,
+            exception: {
+              message: `All operations must be named`
+            }
+          });
+
+          throw error;
+        }
+      }
+    };
+  }
+};
+
+const server = new ApolloServer({
+  gateway,
+  subscriptions: false,
+  plugins: [clientEnforcementPlugin]
+});
+```


### PR DESCRIPTION
Start work on the tech notes idea and where the content could live. The new section is not added to the nav bar options so you have to navigate directly to `http://localhost:3000/technotes` to see the home page.