### PR TITLE
Add warning about using runtime schema registration

### DIFF
--- a/src/content/studio/schema/schema-reporting.mdx
+++ b/src/content/studio/schema/schema-reporting.mdx
@@ -8,7 +8,9 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key';
 
 > **Schema reporting does not currently support graphs that use Apollo Federation.** If you have a federated graph, instead see [Setting up managed federation](https://www.apollographql.com/docs/federation/managed-federation/setup/).
 
-> **⚠️ Caution ⚠️**
+> **⚠️ Important:** With schema reporting, your sever publishes schema updates at runtime. This can lead to non-deterministic results. We recommend instead using the [Rover CLI](/rover/) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.
+>
+> For more information on staging and releasing schema updates, see You can also read our Enterprise Guide on [Change management in Apollo Federation](/enterprise-guide/change-management/)
 >
 > Schema reporting requires your sever to publish the schema updates at runtime. This can lead to non-deterministic results.
 > We recommend using the [Rover CLI](https://www.apollographql.com/docs/rover) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.

--- a/src/content/studio/schema/schema-reporting.mdx
+++ b/src/content/studio/schema/schema-reporting.mdx
@@ -10,7 +10,7 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key';
 
 > **⚠️ Important:** With schema reporting, your sever publishes schema updates at runtime. This can lead to non-deterministic results. We recommend instead using the [Rover CLI](/rover/) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.
 >
-> For more information on staging and releasing schema updates, see You can also read our Enterprise Guide on [Change management in Apollo Federation](/enterprise-guide/change-management/)
+> For more information on staging and releasing schema updates, see [Change management in Apollo Federation](/enterprise-guide/change-management/)
 >
 > Schema reporting requires your sever to publish the schema updates at runtime. This can lead to non-deterministic results.
 > We recommend using the [Rover CLI](https://www.apollographql.com/docs/rover) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.

--- a/src/content/studio/schema/schema-reporting.mdx
+++ b/src/content/studio/schema/schema-reporting.mdx
@@ -8,6 +8,12 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key';
 
 > **Schema reporting does not currently support graphs that use Apollo Federation.** If you have a federated graph, instead see [Setting up managed federation](https://www.apollographql.com/docs/federation/managed-federation/setup/).
 
+> **⚠️ Caution ⚠️**
+>
+> Schema reporting requires your sever to publish the schema updates at runtime. This can lead to non-deterministic results.
+> We recommend using the [Rover CLI](https://www.apollographql.com/docs/rover) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.
+> You can also read our Enterprise Guide on [Change Management](https://www.apollographql.com/docs/enterprise-guide/change-management) for more info on how to stage and release schema updates.
+
 ## Apollo Server setup
 
 Schema reporting is available in Apollo Server version 2.15 and later. To enable it:

--- a/src/content/studio/schema/schema-reporting.mdx
+++ b/src/content/studio/schema/schema-reporting.mdx
@@ -11,10 +11,6 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key';
 > **⚠️ Important:** With schema reporting, your sever publishes schema updates at runtime. This can lead to non-deterministic results. We recommend instead using the [Rover CLI](/rover/) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.
 >
 > For more information on staging and releasing schema updates, see [Change management in Apollo Federation](/enterprise-guide/change-management/)
->
-> Schema reporting requires your sever to publish the schema updates at runtime. This can lead to non-deterministic results.
-> We recommend using the [Rover CLI](https://www.apollographql.com/docs/rover) in a CI/CD pipeline for isolated and reproducible schema checks and publishes.
-> You can also read our Enterprise Guide on [Change Management](https://www.apollographql.com/docs/enterprise-guide/change-management) for more info on how to stage and release schema updates.
 
 ## Apollo Server setup
 


### PR DESCRIPTION
The schema reporting plugin is something we advise against in the SA team due to the non-deterministic nature of running code in your production environment which can change frequently.

This will hopefully make it more clear that schema reporting is a tool to get up and running quickly, but using Rover is the preferred schema publishing method.


https://www.apollographql.com/docs/studio/schema/schema-reporting/