### PR TITLE
Update build-status-notification.md

### DIFF
--- a/src/content/studio/build-status-notification.md
+++ b/src/content/studio/build-status-notification.md
@@ -4,7 +4,7 @@ title: Build status notifications (preview)
 
 > Build status notifications require an [Enterprise plan](https://www.apollographql.com/pricing/). They are currently in preview.
 
-You can [configure Apollo Studio](./notification-setup) to notify your team via webhook whenever Apollo attempts to compose a new supergraph schema for your [federated graph](https://www.apollographql.com/docs/federation/). The notification indicates whether composition succeeded and provides a temporary URL to the new supergraph schema if so.
+You can [configure Apollo Studio](./notification-setup) to notify your team via webhook whenever Apollo attempts to build a new supergraph schema for your [federated graph](https://www.apollographql.com/docs/federation/). The notification indicates whether the build succeeded and provides a temporary URL to the new supergraph schema if so.
 
 You can configure separate change notifications for each [variant](./org/graphs/#managing-variants) of your graph.
 
@@ -41,8 +41,8 @@ interface ResponseShape {
 }
 ```
 
-- **If composition succeeds**, the value of `supergraphSchemaURL` is a short-lived (24-hour) URL that enables you to fetch the supergraph core schema _without_ authenticating (such as with an API key). Otherwise, this field is not present.
+- **If the build succeeds**, the value of `supergraphSchemaURL` is a short-lived (24-hour) URL that enables you to fetch the supergraph schema _without_ authenticating (such as with an API key). Otherwise, this field is not present.
 
-- **If composition fails**, `buildErrors` is an array of `BuildError` objects that describe the errors that occurred during composition. Otherwise, this field is not present.
+- **If the build fails**, `buildErrors` is an array of `BuildError` objects that describe the errors that occurred during the build. Otherwise, this field is not present.
 
 - The value of `variantID` is in the format `graphID@variantName` (e.g., `mygraph@staging`). This format is known as a [graph ref](https://www.apollographql.com/docs/rover/conventions/#graph-refs).


### PR DESCRIPTION
relax the use of `composition` in favor of `build` now that this feature is supported by contracts