### PR TITLE
update @apollo/explorer package to get all new embed features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,15 +306,19 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@apollo/explorer": {
-      "version": "0.3.0",
-      "license": "MIT",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@apollo/explorer/-/explorer-0.5.2.tgz",
+      "integrity": "sha512-gccRzIHlZ+K8g5skuSHgrHgHSrURittl6dIRhLF7eJ5pQZ41PnZLnTLt0zvLir/j7C/iM0n3U3So0APMlmL4ZQ==",
+      "dependencies": {
+        "use-deep-compare-effect": "^1.8.1"
+      },
       "engines": {
         "node": ">=12.0",
         "npm": ">=7.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -49354,7 +49358,7 @@
       "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
-        "@apollo/explorer": "^0.3.0",
+        "@apollo/explorer": "^0.5.2",
         "fenceparser": "^1.1.1",
         "outdent": "^0.8.0",
         "parse-numeric-range": "^1.3.0",
@@ -49507,7 +49511,7 @@
     "@apollo/chakra-helpers": {
       "version": "file:packages/chakra-helpers",
       "requires": {
-        "@apollo/explorer": "^0.3.0",
+        "@apollo/explorer": "^0.5.2",
         "@apollo/space-kit": "8.11.0",
         "@chakra-ui/react": "^1.6.10",
         "@react-icons/all-files": "^4.1.0",
@@ -49555,8 +49559,12 @@
       }
     },
     "@apollo/explorer": {
-      "version": "0.3.0",
-      "requires": {}
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@apollo/explorer/-/explorer-0.5.2.tgz",
+      "integrity": "sha512-gccRzIHlZ+K8g5skuSHgrHgHSrURittl6dIRhLF7eJ5pQZ41PnZLnTLt0zvLir/j7C/iM0n3U3So0APMlmL4ZQ==",
+      "requires": {
+        "use-deep-compare-effect": "^1.8.1"
+      }
     },
     "@apollo/space-kit": {
       "version": "8.11.0",

--- a/packages/chakra-helpers/package.json
+++ b/packages/chakra-helpers/package.json
@@ -31,7 +31,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@apollo/explorer": "^0.3.0",
+    "@apollo/explorer": "^0.5.2",
     "fenceparser": "^1.1.1",
     "outdent": "^0.8.0",
     "parse-numeric-range": "^1.3.0",


### PR DESCRIPTION
I recently released a change to the @apollo/explorer package that switches around logic for the boolean for showing the header on the embed. Earlier versions won't show the embed (as is the case on the docs page currently), but newer versions will.  
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/14367451/170365952-1b04e969-37fa-41aa-9c96-9fee15ccdf8c.png">

Lets upgrade so we can see the header on the explorer?
