### PR TITLE
Allow for multiple highlighted areas in code blocks

### DIFF
--- a/.changeset/olive-actors-argue.md
+++ b/.changeset/olive-actors-argue.md
@@ -1,0 +1,5 @@
+---
+"@apollo/chakra-helpers": patch
+---
+
+Allow for multiple highlight areas in code blocks

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -127,15 +127,22 @@ export const CodeBlock = ({
         // create an array of lines highlighted by "highlight-start" and
         // "highlight-end" comments
         const highlightRange = [];
+        let isHighlighting = false;
+        let highlightOffset = 0;
         for (let i = 0; i < tokens.length; i++) {
           const line = tokens[i];
           if (isHighlightEnd(line)) {
-            highlightRange.pop();
-            break;
-          }
-
-          if (highlightRange.length || isHighlightStart(line)) {
-            highlightRange.push(i + 1);
+            // turn highlighting off
+            isHighlighting = false;
+            // account for the soon-to-be-missing start and end comments
+            highlightOffset += 2;
+          } else if (isHighlightStart(line)) {
+            // start highlighting
+            isHighlighting = true;
+          } else if (isHighlighting) {
+            // while highlighting, push the current index minus the offset into
+            // the array of highlighted lines
+            highlightRange.push(i - highlightOffset);
           }
         }
 


### PR DESCRIPTION
Now you can highlight multiple areas of code using `// highlight-start` and `// highlight-end` comments.

```js
module.exports = {
  client: {
    // highlight-start
    service: {
      name: "github",
      url: "https://api.github.com/graphql",
      // highlight-end
      // optional headers
      // highlight-start
      headers: {
        authorization: "Bearer lkjfalkfjadkfjeopknavadf",
      },
      // highlight-end
      // optional disable SSL validation check
      skipSSLValidation: true,
    },
  },
};
```

![Screen Shot 2022-06-03 at 12 56 47 PM](https://user-images.githubusercontent.com/1216917/171941267-41fe5ac4-e2ca-41bf-84f0-e227f33bbf2b.png)