### PR TITLE
Add remote docs source for internal CS docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npm start -- ../apollo-client
 For your convenience, this repo also comes with special `start` NPM scripts for each docset, assuming you have this repo checked out in the same directory as the other OSS repos.
 
 - `npm run start:client`
+- `npm run start:customer-success`
 - `npm run start:server`
 - `npm run start:ios`
 - `npm run start:kotlin`
@@ -114,6 +115,7 @@ The docs content is written and maintained in the following places. Many of them
 - [Apollo Federation](https://github.com/apollographql/federation)
 - [Rover CLI](https://github.com/apollographql/rover)
 - [Apollo Router](https://github.com/apollographql/router)
+- [Customer Success (internal)](https://github.com/apollographql/customer-success)
 
 ## Docset configuration
 
@@ -140,7 +142,7 @@ The `config.json` file lives at the root of its docset's content directory, and 
 ```
 
 | Name           | Required? | Description                                                                                                                                                                                                                                                                                                       |
-| -------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | title          | yes       | The title of the docset. It is used to construct page titles and shown in the header when the docset is selected.                                                                                                                                                                                                 |
 | sidebar        | yes       | A JSON object mapping sidebar nav labels to their paths. Use paths beginning with a slash, relative to the root of the content directory for internal links. Full URLs are transformed into external links that open in a new tab. These objects can be nested to define categories and subcategories in the nav. |
 | version        | no        | A string representing the version of the software that is being documented, i.e. "v3". This value is shown in the version dropdown if multiple versions of a docset are configured.                                                                                                                               |
@@ -514,7 +516,7 @@ Using the old infrastructure, we were spending a lot of time building our docs. 
 #### Netlify build stats (Feb 1 - Feb 24, 2022)
 
 | Site                          | Builds | Average time | Total time |
-| ----------------------------- | ------ | ------------ | ---------- |
+|-------------------------------|--------|--------------|------------|
 | apollo-federation-docs        | 424    | 4m 55s       | 2,084m     |
 | apollo-client-docs            | 237    | 8m 21s       | 1,979m     |
 | apollo-router-docs            | 437    | 2m 21s       | 1,027m     |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "start": "./dev.sh",
     "start:local": "DOCS_MODE=local npm start",
     "start:client": "npm start -- ../apollo-client",
+    "start:customer-success": "npm start -- ../customer-success",
     "start:server": "npm start -- ../apollo-server",
     "start:ios": "npm start -- ../apollo-ios",
     "start:kotlin": "npm start -- ../apollo-kotlin",

--- a/sources/remote.js
+++ b/sources/remote.js
@@ -16,6 +16,10 @@ module.exports = {
     remote: 'https://github.com/apollographql/apollo-server',
     branch: 'version-2'
   },
+  'customer-success': {
+    remote: `https://trevorblades:${process.env.GITHUB_TOKEN}@github.com/apollographql/customer-success`,
+    branch: 'main'
+  },
   ios: {
     remote: 'https://github.com/apollographql/apollo-ios',
     branch: 'main'


### PR DESCRIPTION
This PR adds a remote source for an internal CS docs site, which is now ready to be deployed for the first time. 

The CS docs repo can be found here:

https://github.com/apollographql/customer-success