### PR TITLE
WIP - Launch Tech Notes with tags and filtering

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,7 @@ const {
 } = require('gatsby-source-filesystem');
 const {join} = require('path');
 const {v5} = require('uuid');
+const _ = require('lodash');
 
 exports.sourceNodes = ({
   actions: {createNode},
@@ -122,6 +123,11 @@ exports.createPages = async ({actions, graphql}) => {
           sourceInstanceName
         }
       }
+      tags: allMdx {
+        group(field: frontmatter___tags) {
+          name: fieldValue
+        }
+      }
     }
   `);
 
@@ -163,6 +169,17 @@ exports.createPages = async ({actions, graphql}) => {
         id,
         versions,
         ...configs[sourceInstanceName]
+      }
+    });
+  });
+
+  data.tags.group.forEach(tag => {
+    actions.createPage({
+      path: `/technotes/tags/${_.kebabCase(tag.name)}`,
+      component: require.resolve('./src/templates/technotes/tag'),
+      context: {
+        tag: tag.name,
+        ...configs['technotes']
       }
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -48945,7 +48945,7 @@
     },
     "packages/chakra-helpers": {
       "name": "@apollo/chakra-helpers",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@apollo/explorer": "^0.5.2",

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -90,6 +90,9 @@ export function DocsetMenu({docset, versions, currentVersion, ...props}) {
               >
                 Odyssey Tutorials
               </DocsetButton>
+              <DocsetButton to="/technotes" leftIcon={DOCSET_ICONS.odyssey}>
+                Tech Notes
+              </DocsetButton>
             </DocsetGroup>
             <DocsetGroup title="Apollo Client">
               <DocsetButton leftIcon={DOCSET_ICONS.react} to="/react">

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -12,7 +12,7 @@ import MobileNav from './MobileNav';
 import Pagination from './Pagination';
 import PropTypes from 'prop-types';
 import React, {Fragment, createElement, useCallback, useMemo} from 'react';
-import RelativeLink, {ButtonLink} from './RelativeLink';
+import RelativeLink, {ButtonLink, PrimaryLink} from './RelativeLink';
 import Sidebar, {
   SIDEBAR_WIDTH_BASE,
   SIDEBAR_WIDTH_XL,
@@ -38,6 +38,7 @@ import {
   OrderedList,
   Stack,
   Table,
+  Tag,
   Tbody,
   Td,
   Text,
@@ -64,6 +65,7 @@ import {MDXRenderer} from 'gatsby-plugin-mdx';
 import {PathContext, useFieldTableStyles} from '../utils';
 import {YouTube} from './YouTube';
 import {graphql, useStaticQuery} from 'gatsby';
+import {kebabCase} from 'lodash';
 import {rehype} from 'rehype';
 import {useMermaidStyles} from '../utils/mermaid';
 
@@ -216,7 +218,7 @@ export default function Page({file, pageContext, uri}) {
   } = file;
 
   const {frontmatter, headings} = childMdx || childMarkdownRemark;
-  const {title, description, toc} = frontmatter;
+  const {title, description, toc, tags} = frontmatter;
   const {docset, versions, currentVersion, navItems, algoliaFilters} =
     pageContext;
   const titleFont = encodeURIComponent('Source Sans Pro');
@@ -378,6 +380,18 @@ export default function Page({file, pageContext, uri}) {
                 >
                   {description}
                 </chakra.h2>
+              )}
+              {tags?.length && (
+                <Flex gap={1} mt={{base: 2, md: 3}}>
+                  {tags.map(tag => (
+                    <PrimaryLink
+                      key={tag}
+                      href={`/technotes/tags/${kebabCase(tag)}`}
+                    >
+                      <Tag size="lg">{tag}</Tag>
+                    </PrimaryLink>
+                  ))}
+                </Flex>
               )}
               <Divider my="8" />
               <Box

--- a/src/components/TechNotes/RecentNotes.js
+++ b/src/components/TechNotes/RecentNotes.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import {graphql, useStaticQuery} from 'gatsby';
+import {Flex, HStack} from '@chakra-ui/react';
+import {PrimaryLink} from '../RelativeLink';
+
+export default function RecentNotes() {
+  const {
+    allFile: {nodes: files}
+  } = useStaticQuery(
+    graphql`
+      query RecentTechNotes {
+        allFile(
+          filter: { childMdx: { slug: { regex: "/^TN\\d{4}/" } } }
+          sort: { fields: changeTime, order: DESC }
+          limit: 10
+        ) {
+          nodes {
+            changeTime
+            childMdx {
+              slug
+              frontmatter {
+                title
+                id
+              }
+            }
+          }
+        }
+      }
+      `
+  );
+
+  return (
+    <Flex direction="column">
+      {files.map(file => (
+        <HStack key={file.childMdx.slug} justifyContent={'space-between'}>
+          <PrimaryLink href={`/technotes/${file.childMdx.slug}`}>
+            {file.childMdx.frontmatter.id} - {file.childMdx.frontmatter.title}
+          </PrimaryLink>
+          <span>
+            Last updated{' '}
+            {new Intl.DateTimeFormat().format(new Date(file.changeTime))}
+          </span>
+        </HStack>
+      ))}
+    </Flex>
+  );
+}

--- a/src/components/TechNotes/TagList.js
+++ b/src/components/TechNotes/TagList.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {graphql, useStaticQuery} from 'gatsby';
+import {Button, Flex} from '@chakra-ui/react';
+import {kebabCase} from 'lodash';
+
+export default function TagList() {
+  const {
+    allMdx: {group}
+  } = useStaticQuery(
+    graphql`
+      query AllTags {
+        allMdx {
+          group(field: frontmatter___tags) {
+            tag: fieldValue
+            totalCount
+          }
+        }
+      }
+    `
+  );
+
+  return (
+    <Flex gap={2}>
+      {group
+        .sort((a, b) => a.tag.localeCompare(b.tag))
+        .map(group => (
+          <Button
+            key={group.tag}
+            as="a"
+            href={`/technotes/tags/${kebabCase(group.tag)}`}
+          >
+            {group.tag} ({group.totalCount})
+          </Button>
+        ))}
+    </Flex>
+  );
+}

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -1,5 +1,6 @@
 ---
-title: TN0001 - Client ID enforcement
+title: Client ID enforcement
+id: TN0001
 description: Require client details and operation names to help monitor schema usage
 tags: [server, observability]
 ---
@@ -18,10 +19,8 @@ If you're using Apollo Server for your gateway, you can require client metadata 
 
 ```js title="index.js"
 const clientEnforcementPlugin = {
-  requestDidStart: ({ request, logger }) => {
-    let clientName = request.http.headers.get(
-      'apollographql-client-name'
-    );
+  requestDidStart: ({request, logger}) => {
+    let clientName = request.http.headers.get('apollographql-client-name');
     let clientVersion = request.http.headers.get(
       'apollographql-client-version'
     );
@@ -41,13 +40,11 @@ const clientEnforcementPlugin = {
     }
 
     return {
-      parsingDidStart({ queryHash, request }) {
+      parsingDidStart({queryHash, request}) {
         if (!request.operationName) {
           logger.debug(`Unnamed Operation: ${queryHash}`);
 
-          let error = new ApolloError(
-            'Execution denied: Unnamed operation'
-          );
+          let error = new ApolloError('Execution denied: Unnamed operation');
 
           Object.assign(error.extensions, {
             queryHash: queryHash,

--- a/src/content/technotes/TN0002-schema-naming-conventions.mdx
+++ b/src/content/technotes/TN0002-schema-naming-conventions.mdx
@@ -1,5 +1,6 @@
 ---
-title: TN0002 - Schema naming conventions
+title: Schema naming conventions
+id: TN0002
 description: Conventions for types, fields, and arguments
 tags: [schema design]
 ---

--- a/src/content/technotes/TN0003-opentelemetry-traces-to-prometheus.mdx
+++ b/src/content/technotes/TN0003-opentelemetry-traces-to-prometheus.mdx
@@ -1,20 +1,23 @@
 ---
 title: Connecting OpenTelemetry traces to Prometheus
+id: TN0003
 tags: [server, observability]
 ---
+
 Operation traces provide insight into performance issues that are occurring at various execution points in your graph. However, individual traces don't provide a view of your graph's broader performance.
 
-Helpfully, you can convert your operation traces into aggregated metrics without requiring manual instrumentation. To accomplish this, we'll use `spanmetricsprocessor` in an OpenTelemetry Collector instance to automatically generate metrics from our existing trace spans. 
+Helpfully, you can convert your operation traces into aggregated metrics without requiring manual instrumentation. To accomplish this, we'll use `spanmetricsprocessor` in an OpenTelemetry Collector instance to automatically generate metrics from our existing trace spans.
 
 ## OpenTelemetry Collector configuration
-OpenTelemetry provides two different repositories for their OpenTelemetry Collector: 
 
-* The [core library](https://github.com/open-telemetry/opentelemetry-collector) 
-* The [contributor library](https://github.com/open-telemetry/opentelemetry-collector-contrib)
+OpenTelemetry provides two different repositories for their OpenTelemetry Collector:
+
+- The [core library](https://github.com/open-telemetry/opentelemetry-collector)
+- The [contributor library](https://github.com/open-telemetry/opentelemetry-collector-contrib)
 
 These repositories are similar in scope, but the contributor library includes extended features that aren't suitable for the core library. To derive performance metrics from our existing spans, we'll use the contributor library to take advantage of the `spanmetricsprocessor` via the associated Docker image.
 
-> We also recommend checking out the [Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to build binaries that are tailored to your environment instead of relying on prebuilt images. 
+> We also recommend checking out the [Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) to build binaries that are tailored to your environment instead of relying on prebuilt images.
 
 When your OpenTelemetry Collector is ready to run, you can start configuring it with this barebones example:
 
@@ -35,7 +38,7 @@ receivers:
 
 exporters:
   prometheus:
-    endpoint: "0.0.0.0:9464"
+    endpoint: '0.0.0.0:9464'
 
 processors:
   batch:
@@ -55,7 +58,7 @@ service:
 
 ## Apollo Server setup
 
-Add the OTLP Exporter (`@opentelemetry/exporter-trace-otlp-http`  Node package) following the same instructions [as shown in the documentation for Apollo Server and OpenTelemetry.](https://www.apollographql.com/docs/federation/opentelemetry/) 
+Add the OTLP Exporter (`@opentelemetry/exporter-trace-otlp-http` Node package) following the same instructions [as shown in the documentation for Apollo Server and OpenTelemetry.](https://www.apollographql.com/docs/federation/opentelemetry/)
 
 ## Apollo Router setup
 
@@ -63,13 +66,13 @@ To send traces from the Apollo Router to OpenTelemetry Collector, see [this arti
 
 ## Prometheus setup
 
-Lastly, we need to add the OpenTelemetry Collector as a target within Prometheus. It'll use the standard port for Prometheus metrics (`9464`). 
+Lastly, we need to add the OpenTelemetry Collector as a target within Prometheus. It'll use the standard port for Prometheus metrics (`9464`).
 
 That's it- you should have access to span metrics using the same operation name!
 
 ## Example queries
 
-Here are a few sample queries to help explore the data structure being reported: 
+Here are a few sample queries to help explore the data structure being reported:
 
 - P95 by service: `histogram_quantile(.95, sum(rate(latency_bucket[5m])) by (le, service_name))`
 - Average latency by service and operation (e.g. `router` / `graphql.validate`): `sum by (operation, service_name)(rate(latency_sum{}[1m])) / sum by (operation, service_name)(rate(latency_count{}[1m]))`

--- a/src/content/technotes/_redirects
+++ b/src/content/technotes/_redirects
@@ -1,4 +1,5 @@
 # Adds redirects from the TN number to the correct tech note
 # Note that the first paramater is relative, but the second is static, meaning it is /technotes/TN0001 -> /technotes/TN0001-client-id-enforcement
 /TN0001 /technotes/TN0001-client-id-enforcement
+/TN0002 /technotes/TN0002-schema-naming-conventions
 /TN0003 /technotes/TN0003-opentelemetry-traces-to-prometheus

--- a/src/content/technotes/config.json
+++ b/src/content/technotes/config.json
@@ -3,8 +3,10 @@
   "algoliaFilters": ["docset:technotes"],
   "sidebar": {
     "Home": "/",
-    "TN0001 - Client ID Enforcement": "/TN0001-client-id-enforcement",
-    "TN0002 - Schema Naming Conventions": "/TN0002-schema-naming-conventions",
-    "TN0003 - Connecting OpenTelemetry Traces to Prometheus": "TN0003-opentelemetry-traces-to-prometheus"
+    "Tags": {
+      "Observability": "/tags/observability",
+      "Schema design": "/tags/schema-design",
+      "Server": "/tags/server"
+    }
   }
 }

--- a/src/content/technotes/index.mdx
+++ b/src/content/technotes/index.mdx
@@ -4,7 +4,16 @@ title: Apollo tech notes
 
 This documentation set provides technical articles on specialized topics for Apollo tools and libraries. It is currently under development.
 
-See the left navigation for all available tech notes.
+import RecentNotes from '../../components/TechNotes/RecentNotes';
+import TagList from '../../components/TechNotes/TagList';
+
+## Recently updated
+
+<RecentNotes />
+
+## All tags
+
+<TagList />
 
 ## Reporting issues
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -48,6 +48,7 @@ export const pageQuery = graphql`
           title
           description
           toc
+          tags
         }
       }
       childMarkdownRemark {

--- a/src/templates/technotes/tag.js
+++ b/src/templates/technotes/tag.js
@@ -1,0 +1,178 @@
+import DocsetMenu from '../../components/DocsetMenu';
+import Footer from '../../components/Footer';
+import Header, {TOTAL_HEADER_HEIGHT} from '../../components/Header';
+import MobileNav from '../../components/MobileNav';
+import PropTypes from 'prop-types';
+import React, {useCallback} from 'react';
+import Sidebar, {
+  SIDEBAR_WIDTH_BASE,
+  SIDEBAR_WIDTH_XL,
+  SidebarNav
+} from '../../components/Sidebar';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import {
+  Box,
+  Divider,
+  Fade,
+  Flex,
+  HStack,
+  Heading,
+  IconButton,
+  Tooltip,
+  useToken
+} from '@chakra-ui/react';
+import {FiChevronsRight} from 'react-icons/fi';
+import {PathContext} from '../../utils';
+import {PrimaryLink} from '../../components/RelativeLink';
+import {graphql} from 'gatsby';
+
+export const pageQuery = graphql`
+  query ($tag: String) {
+    allMdx(
+      filter: {frontmatter: {tags: {in: [$tag]}}}
+      sort: {fields: frontmatter___title, order: ASC}
+      limit: 2000
+    ) {
+      totalCount
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+          }
+          parent {
+            ... on File {
+              changeTime
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+Tags.propTypes = {
+  data: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  pageContext: PropTypes.object.isRequired
+};
+
+export default function Tags(props) {
+  const {pageContext, data, location} = props;
+  const [sidebarHidden, setSidebarHidden] = useLocalStorage('sidebar');
+  const paddingTop = useToken('space', 10);
+  const paddingBottom = useToken('space', 12);
+
+  const {pathname: uri} = location;
+  const {docset, versions, currentVersion, navItems, algoliaFilters} =
+    pageContext;
+
+  const renderSwitcher = useCallback(
+    props => (
+      <DocsetMenu
+        docset={docset}
+        versions={versions ?? []}
+        currentVersion={currentVersion}
+        {...props}
+      />
+    ),
+    [docset, versions, currentVersion]
+  );
+
+  return (
+    <>
+      <PathContext.Provider
+        value={{
+          uri,
+          basePath: '/technotes',
+          path: '/technotes'
+        }}
+      >
+        <Header algoliaFilters={algoliaFilters}>
+          <MobileNav>
+            <SidebarNav navItems={navItems} darkBg="gray.700">
+              <Box px="3" pt="1" pb="3">
+                {renderSwitcher({size: 'sm'})}
+              </Box>
+            </SidebarNav>
+          </MobileNav>
+          {renderSwitcher({d: {base: 'none', md: 'flex'}})}
+        </Header>
+        <Fade in={sidebarHidden} unmountOnExit delay={0.25}>
+          <Tooltip placement="right" label="Show sidebar">
+            <IconButton
+              d={{base: 'none', md: 'flex'}}
+              pos="fixed"
+              mt="2"
+              left="2"
+              size="sm"
+              variant="outline"
+              fontSize="md"
+              icon={<FiChevronsRight />}
+              css={{top: TOTAL_HEADER_HEIGHT}}
+              onClick={() => setSidebarHidden(false)}
+            />
+          </Tooltip>
+        </Fade>
+        <Sidebar isHidden={sidebarHidden}>
+          <SidebarNav
+            navItems={navItems}
+            onHide={() => setSidebarHidden(true)}
+          />
+        </Sidebar>
+        <Box
+          marginLeft={{
+            base: 0,
+            md: sidebarHidden ? 0 : SIDEBAR_WIDTH_BASE,
+            xl: sidebarHidden ? 0 : SIDEBAR_WIDTH_XL
+          }}
+          transitionProperty="margin-left"
+          transitionDuration="normal"
+        >
+          <Flex
+            maxW="6xl"
+            mx="auto"
+            align="flex-start"
+            px={{base: 6, md: 10}}
+            as="main"
+            sx={{
+              paddingTop,
+              paddingBottom
+            }}
+          >
+            <Box flexGrow="1" w="0">
+              <Heading as="h1" size="2xl">
+                Tagged with &ldquo;{pageContext.tag}&rdquo;
+              </Heading>
+
+              <Divider my="8" />
+              <Box fontSize={{md: 'lg'}} lineHeight={{md: 1.7}}>
+                <Flex direction="column">
+                  {data.allMdx.edges.map(file => (
+                    <HStack
+                      key={file.node.fields.slug}
+                      justifyContent={'space-between'}
+                    >
+                      <PrimaryLink href={`../..${file.node.fields.slug}`}>
+                        {file.node.frontmatter.title}
+                      </PrimaryLink>
+                      <span>
+                        Last Updated{' '}
+                        {new Intl.DateTimeFormat('en-US').format(
+                          new Date(file.node.parent.changeTime)
+                        )}
+                      </span>
+                    </HStack>
+                  ))}
+                </Flex>
+              </Box>
+            </Box>
+          </Flex>
+          <Footer />
+        </Box>
+      </PathContext.Provider>
+    </>
+  );
+}


### PR DESCRIPTION
Create a new PR that:

* Adds `/technotes`to the main docs nav
* Redesigns the tech notes landing page
* Updates tech notes sidebar to be the list of tags
* Add the ability to filter tech notes by tags