### PR TITLE
Add note about usage reporting time skew limitation

### DIFF
--- a/src/content/studio/metrics/usage-reporting.mdx
+++ b/src/content/studio/metrics/usage-reporting.mdx
@@ -139,6 +139,8 @@ Only graph-level API keys (starting with the prefix `service:`) are supported.
 
 The request can also optionally include a `Content-Type` header with value `application/protobuf`, but this is not required.
 
+Reports more than 50 minutes old will be rejected by the reporting endpoint. If you see an error like `Rejecting report from service <your service> with skewed timestamp`, ensure your traces are current and that your timestamp calculations are accurate.
+
 For a reference implementation, see the `sendReport()` function in the [TypeScript reference agent](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts).
 
 #### Tuning reporting behavior

--- a/src/content/studio/metrics/usage-reporting.mdx
+++ b/src/content/studio/metrics/usage-reporting.mdx
@@ -139,7 +139,7 @@ Only graph-level API keys (starting with the prefix `service:`) are supported.
 
 The request can also optionally include a `Content-Type` header with value `application/protobuf`, but this is not required.
 
-Reports more than 50 minutes old will be rejected by the reporting endpoint. If you see an error like `Rejecting report from service <your service> with skewed timestamp`, ensure your traces are current and that your timestamp calculations are accurate.
+> ⚠️ **The reporting endpoint rejects reports that are older than 50 minutes.** If you see an error like `Rejecting report from service <your service> with skewed timestamp`, make sure your traces are current and that your timestamp calculations are accurate.
 
 For a reference implementation, see the `sendReport()` function in the [TypeScript reference agent](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts).
 


### PR DESCRIPTION
Reference:
https://community.apollographql.com/t/3rd-party-tracing-apollo-studio-skewed-timestamp-error/4073