### PR TITLE
Add docs about using the Apollo Server plugin for embeded explorer

### DIFF
--- a/src/content/studio/explorer/additional-features.mdx
+++ b/src/content/studio/explorer/additional-features.mdx
@@ -218,7 +218,7 @@ query StarWarsGenderStats {
 
 ### Is the Explorer available for on-prem distribution?
 
-Yes! Through the use of [Embeded Explorer](/studio/explorer/embed-explorer) you can now include Explorer on any site you might have internally.
+The Explorer is not currently available for download or on-prem hosting. However, you can embed the Apollo-hosted Explorer on your own internal websites. For details, see [Embedding the Explorer](/studio/explorer/embed-explorer).
 
 ### Do my Explorer operations pass through Apollo servers?
 

--- a/src/content/studio/explorer/additional-features.mdx
+++ b/src/content/studio/explorer/additional-features.mdx
@@ -218,7 +218,7 @@ query StarWarsGenderStats {
 
 ### Is the Explorer available for on-prem distribution?
 
-Not at this time. The Explorer is available for free, unlimited use in Apollo Studio, but it is not available for download or on-prem distribution. This might change in the future, but for now our goal is to provide the best possible Explorer experience from within Studio.
+Yes! Through the use of [Embeded Explorer](/studio/explorer/embed-explorer) you can now include Explorer on any site you might have internally.
 
 ### Do my Explorer operations pass through Apollo servers?
 

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -8,7 +8,7 @@ For example, here's an embedded Explorer for an Apollo example graph. Try it out
 
 <EmbeddableExplorer />
 
-## Apollo Server plugin
+## Embedding on the Apollo Server landing page
 As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there is now a built-in plugin that will include the embeded Explorer for you.
 
 You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost development, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -8,7 +8,32 @@ For example, here's an embedded Explorer for an Apollo example graph. Try it out
 
 <EmbeddableExplorer />
 
-## Setup
+## Apollo Server plugin
+As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there now a built-in plugin that will include the embeded Explorer for you.
+
+You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost developement, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.
+
+```js
+import {
+  ApolloServerPluginLandingPageProductionDefault,
+  ApolloServerPluginLandingPageLocalDefault
+} from 'apollo-server-core';
+
+let plugins = [];
+if (process.env.NODE_ENV === 'production') {
+  plugins = [ApolloServerPluginLandingPageProductionDefault({embed: true, graphRef: 'myGraph@prod'})]
+} else {
+  plugins = [ApolloServerPluginLandingPageLocalDefault({ embed: true })]
+}
+
+const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    plugins
+});
+```
+
+## Custom setup
 
 1. <a href="https://studio.apollographql.com/" target="_blank">
      Go to Apollo Studio

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -66,7 +66,7 @@ For more information, see the [landing page plugin API reference](/apollo-server
 
 > For descriptions of options shown in the dialog (along with advanced options that _aren't_ shown), [see below](#options).
 
-### Embedding with a default operation
+### Setting a default operation
 
 You can prepopulate your embedded Explorer with an operation from one of your existing Explorer tabs. If you do, the embedded Explorer includes all of the following automatically on load:
 

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -11,7 +11,7 @@ For example, here's an embedded Explorer for an Apollo example graph. Try it out
 ## Apollo Server plugin
 As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there is now a built-in plugin that will include the embeded Explorer for you.
 
-You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost developement, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.
+You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost development, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.
 
 ```js
 const {

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -9,19 +9,19 @@ For example, here's an embedded Explorer for an Apollo example graph. Try it out
 <EmbeddableExplorer />
 
 ## Apollo Server plugin
-As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there now a built-in plugin that will include the embeded Explorer for you.
+As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there is now a built-in plugin that will include the embeded Explorer for you.
 
 You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost developement, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.
 
 ```js
-import {
-  ApolloServerPluginLandingPageProductionDefault,
-  ApolloServerPluginLandingPageLocalDefault
-} from 'apollo-server-core';
+const {
+ ApolloServerPluginLandingPageProductionDefault,
+ ApolloServerPluginLandingPageLocalDefault
+} = require('apollo-server-core');
 
 let plugins = [];
 if (process.env.NODE_ENV === 'production') {
-  plugins = [ApolloServerPluginLandingPageProductionDefault({embed: true, graphRef: 'myGraph@prod'})]
+  plugins = [ApolloServerPluginLandingPageProductionDefault({ embed: true, graphRef: 'myGraph@prod' })]
 } else {
   plugins = [ApolloServerPluginLandingPageLocalDefault({ embed: true })]
 }

--- a/src/content/studio/explorer/embed-explorer.mdx
+++ b/src/content/studio/explorer/embed-explorer.mdx
@@ -9,9 +9,9 @@ For example, here's an embedded Explorer for an Apollo example graph. Try it out
 <EmbeddableExplorer />
 
 ## Embedding on the Apollo Server landing page
-As of Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) there is now a built-in plugin that will include the embeded Explorer for you.
+In Apollo Server [v3.8.0](https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380) and later, you can use a built-in plugin to embed the Explorer directly on your server's landing page.
 
-You can use `ApolloServerPluginLandingPageLocalDefault` plugin for localhost development, or `ApolloServerPluginLandingPageProductionDefault` for use in a production environment.
+You use the `ApolloServerPluginLandingPageLocalDefault` plugin to configure the landing page in your local development environment, and you use `ApolloServerPluginLandingPageProductionDefault` for production environments:
 
 ```js
 const {
@@ -33,7 +33,9 @@ const server = new ApolloServer({
 });
 ```
 
-## Custom setup
+For more information, see the [landing page plugin API reference](/apollo-server/api/plugin/landing-pages/#default-behavior).
+
+## Embedding on an arbitrary webpage
 
 1. <a href="https://studio.apollographql.com/" target="_blank">
      Go to Apollo Studio


### PR DESCRIPTION
We mentioned this feature in blog posts and release notes but it has been missing from docs

* https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v380
* https://www.apollographql.com/blog/tooling/graphql-ide/how-to-use-apollo-sandbox-on-your-localhost/