### PR TITLE
Add clarification on usage reporting requirements

### DIFF
--- a/src/content/studio/metrics/field-usage.mdx
+++ b/src/content/studio/metrics/field-usage.mdx
@@ -186,7 +186,7 @@ Your GraphQL server can report metrics for field executions, referencing operati
 
 ### Prerequisites
 
-> ⚠️ Before continuing, make sure you've configured your GraphQL server to [push metrics to Apollo Studio](./usage-reporting/) .
+> ⚠️ Before continuing, make sure you've configured your Apollo Gateway or individual GraphQL server to [push metrics to Apollo Studio](./usage-reporting/) .
 
 To report each type of field usage metric to Apollo, make sure your graph meets the prerequisites for that metric:
 

--- a/src/content/studio/metrics/field-usage.mdx
+++ b/src/content/studio/metrics/field-usage.mdx
@@ -206,7 +206,7 @@ If you have a [federated graph](https://apollographql.com/docs/federation), your
 
 ### Reporting with Federation
 
-If you are using [Apollo Federation](https://apollographql.com/docs/federation), only the [Gateway](https://www.apollographql.com/docs/federation/gateway) or [Router](https://www.apollographql.com/docs/router/) needs to be configured to [send metrics to Studio](./usage-reporting/). Subgraphs do not need to send any metrics to Studio directly. They will send GraphQL specific metrics to the Gateway/Router which will then be responsible for publishing data.
+If you are using [Apollo Federation](https://apollographql.com/docs/federation), only the [Gateway](https://www.apollographql.com/docs/federation/gateway) or [Router](https://www.apollographql.com/docs/router/) needs to be configured to [send metrics to Studio](./usage-reporting/). Subgraphs do not need to send any metrics to Studio directly, as they will send GraphQL specific metrics to the Gateway/Router which will then be responsible for publishing data.
 
 ### Performance considerations
 

--- a/src/content/studio/metrics/field-usage.mdx
+++ b/src/content/studio/metrics/field-usage.mdx
@@ -205,7 +205,8 @@ If you have a [federated graph](https://apollographql.com/docs/federation), your
 > If _some_ of your subgraphs support federated tracing and others _don't_, only field executions in compatible subgraphs are reported to Apollo.
 
 ### Reporting with Federation
-If you are using [Apollo Federation](https://apollographql.com/docs/federation), only the Gateway or Router needs to be configured to [send metrics to Studio](./usage-reporting/). Subgraphs do not need to send any metrics to Studio directly. They will send GraphQL specific metrics to the Gateway/Router which will then be responsible for publishing data.
+
+If you are using [Apollo Federation](https://apollographql.com/docs/federation), only the [Gateway](https://www.apollographql.com/docs/federation/gateway) or [Router](https://www.apollographql.com/docs/router/) needs to be configured to [send metrics to Studio](./usage-reporting/). Subgraphs do not need to send any metrics to Studio directly. They will send GraphQL specific metrics to the Gateway/Router which will then be responsible for publishing data.
 
 ### Performance considerations
 

--- a/src/content/studio/metrics/field-usage.mdx
+++ b/src/content/studio/metrics/field-usage.mdx
@@ -204,6 +204,9 @@ If you have a [federated graph](https://apollographql.com/docs/federation), your
 
 > If _some_ of your subgraphs support federated tracing and others _don't_, only field executions in compatible subgraphs are reported to Apollo.
 
+### Reporting with Federation
+If you are using [Apollo Federation](https://apollographql.com/docs/federation), only the Gateway or Router needs to be configured to [send metrics to Studio](./usage-reporting/). Subgraphs do not need to send any metrics to Studio directly. They will send GraphQL specific metrics to the Gateway/Router which will then be responsible for publishing data.
+
 ### Performance considerations
 
 Calculating field execution metrics can affect performance for large queries or high-traffic graphs. This is especially true for [federated graphs](https://apollographql.com/docs/federation), because a subgraph includes each operation's full trace data in its response to the gateway.


### PR DESCRIPTION
Some companies are confused if the gateway or subgraphs need to send metrics