### PR TITLE
Create a callout for top-level await calls

### DIFF
--- a/src/content/shared/top-level-await.mdx
+++ b/src/content/shared/top-level-await.mdx
@@ -1,0 +1,1 @@
+> In the examples below, we use top-level [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) calls to start our server asynchronously. If you'd like to see how we set this up, check out the [Getting Started](/apollo-server/v4/getting-started#step-2-install-dependencies) guide for details.


### PR DESCRIPTION
I feel like I'll want to plug this in a lot of places in the v4 docs, so I went ahead and created a resuable component. 