### PR TITLE
Fixes MultiCodeBlock highlighting consistency issue

### DIFF
--- a/.changeset/tame-adults-press.md
+++ b/.changeset/tame-adults-press.md
@@ -1,0 +1,6 @@
+---
+"@apollo/chakra-helpers": minor
+---
+
+Updated MultiCodeBlock to support tabbed interface
+Updated parser to support ts to js highlighting preservation

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ This content will be hidden by default, but can be expanded if the user clicks o
 
 ##### MultiCodeBlock
 
-Wrap TypeScript code blocks in a `MultiCodeBlock` component to automatically transpile them into JavaScript. A language dropdown will be rendered in the top right corner of the code block for the user to switch between the two options. This feature works on code blocks tagged with `ts` or `tsx`.
+Wrap TypeScript code blocks in a `MultiCodeBlock` component to automatically transpile them into JavaScript. A languages will be rendered as tabs above the code block for the user to switch between the two options. This feature works on code blocks tagged with `ts` or `tsx`.
 
 You can also manually add multiple code blocks with different languages to the `MultiCodeBlock` to have them behave the same way.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,9 @@
 const {algoliaSettings} = require('apollo-algolia-transform');
+const {
+  remarkTypescript,
+  highlightPreservation,
+  isWrapped
+} = require('remark-typescript');
 const {query, transformer} = require('./algolia');
 const yaml = require('js-yaml');
 const fs = require('fs');
@@ -106,9 +111,10 @@ const plugins = [
       gatsbyRemarkPlugins,
       remarkPlugins: [
         [
-          require('remark-typescript'),
+          remarkTypescript,
           {
-            wrapperComponent: 'MultiCodeBlock',
+            filter: isWrapped({wrapperComponent: 'MultiCodeBlock'}),
+            customTransformations: [highlightPreservation()],
             prettierOptions: {
               trailingComma: 'all',
               singleQuote: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -3346,8 +3346,9 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.4.0",
-      "license": "MIT",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
+      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==",
       "engines": {
         "node": ">=10"
       }
@@ -48923,6 +48924,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/explorer": "^0.5.2",
+        "@ctrl/tinycolor": "^3.4.1",
         "fenceparser": "^1.1.1",
         "outdent": "^0.8.0",
         "parse-numeric-range": "^1.3.0",
@@ -49093,6 +49095,7 @@
         "@apollo/explorer": "^0.5.2",
         "@apollo/space-kit": "8.11.0",
         "@chakra-ui/react": "^1.6.10",
+        "@ctrl/tinycolor": "*",
         "@react-icons/all-files": "^4.1.0",
         "@types/gtag.js": "^0.0.10",
         "@types/prismjs": "^1.26.0",
@@ -51099,7 +51102,9 @@
       }
     },
     "@ctrl/tinycolor": {
-      "version": "3.4.0"
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
+      "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "rehype-react": "^7.0.3",
         "remark": "^14.0.2",
         "remark-react": "^9.0.1",
-        "remark-typescript": "^0.4.1",
+        "remark-typescript": "^0.5.3",
         "search-insights": "^1.8.0",
         "stream-http": "^3.2.0",
         "unist-util-visit": "^2.0.3",
@@ -44643,13 +44643,14 @@
       }
     },
     "node_modules/remark-typescript": {
-      "version": "0.4.1",
-      "license": "MIT",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.3.tgz",
+      "integrity": "sha512-KsiKSgqGwmq4n3hxPvo6/BHDeFXyKJ/j7g+wEQ1IS+mqDRbh0qBQEWGY+zDMZnYTaXrDJgL6xHQUJaUroTF7Fg==",
       "dependencies": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",
         "prettier": "^1.18.2",
-        "unist-util-visit": "^1.4.1"
+        "unist-util-visit": "^2.0.3"
       }
     },
     "node_modules/remark-typescript/node_modules/prettier": {
@@ -44660,24 +44661,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/remark-typescript/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/remark-typescript/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/remark-typescript/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "node_modules/remark/node_modules/@types/debug": {
@@ -77929,31 +77912,18 @@
       }
     },
     "remark-typescript": {
-      "version": "0.4.1",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.3.tgz",
+      "integrity": "sha512-KsiKSgqGwmq4n3hxPvo6/BHDeFXyKJ/j7g+wEQ1IS+mqDRbh0qBQEWGY+zDMZnYTaXrDJgL6xHQUJaUroTF7Fg==",
       "requires": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",
         "prettier": "^1.18.2",
-        "unist-util-visit": "^1.4.1"
+        "unist-util-visit": "^2.0.3"
       },
       "dependencies": {
         "prettier": {
           "version": "1.19.1"
-        },
-        "unist-util-is": {
-          "version": "3.0.0"
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
-          "requires": {
-            "unist-util-visit-parents": "^2.0.0"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
-          "requires": {
-            "unist-util-is": "^3.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "rehype-react": "^7.0.3",
     "remark": "^14.0.2",
     "remark-react": "^9.0.1",
-    "remark-typescript": "^0.4.1",
+    "remark-typescript": "^0.5.3",
     "search-insights": "^1.8.0",
     "stream-http": "^3.2.0",
     "unist-util-visit": "^2.0.3",

--- a/packages/chakra-helpers/package.json
+++ b/packages/chakra-helpers/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@apollo/explorer": "^0.5.2",
+    "@ctrl/tinycolor": "^3.4.1",
     "fenceparser": "^1.1.1",
     "outdent": "^0.8.0",
     "parse-numeric-range": "^1.3.0",

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -13,10 +13,12 @@ import {
   useClipboard,
   useColorModeValue
 } from '@chakra-ui/react';
+import {CodeBlockTabs} from './CodeBlockTabs';
 import {FiCheck} from '@react-icons/all-files/fi/FiCheck';
 import {FiClipboard} from '@react-icons/all-files/fi/FiClipboard';
 import {FiEyeOff} from '@react-icons/all-files/fi/FiEyeOff';
 import {colors} from '@apollo/space-kit/colors';
+import {getNormalizedLanguage} from './helpers';
 import {usePrismTheme} from './prism';
 
 const CODE_BLOCK_SPACING = 4;
@@ -39,10 +41,12 @@ const isHighlightEnd = line => isHighlightStart(line, 'highlight-end');
 
 type MarkdownCodeBlockProps = {
   children: ReactNode;
+  isPartOfMultiCode?: boolean;
 };
 
 export const MarkdownCodeBlock = ({
-  children
+  children,
+  isPartOfMultiCode
 }: MarkdownCodeBlockProps): JSX.Element => {
   const defaultShowLineNumbers = useContext(LineNumbersContext);
   const [child] = Array.isArray(children) ? children : [children];
@@ -76,11 +80,12 @@ export const MarkdownCodeBlock = ({
       disableCopy={disableCopy === true}
       showLineNumbers={showLineNumbers === true}
       linesToHighlight={linesToHighlight}
+      isPartOfMultiCode={isPartOfMultiCode}
     />
   );
 };
 
-type CodeBlockProps = {
+export type CodeBlockProps = {
   language?: Language;
   title?: string;
   linesToHighlight?: number[];
@@ -88,6 +93,7 @@ type CodeBlockProps = {
   showLineNumbers?: boolean;
   hidden?: boolean;
   code: string;
+  isPartOfMultiCode?: boolean;
 };
 
 export const CodeBlock = ({
@@ -97,201 +103,212 @@ export const CodeBlock = ({
   showLineNumbers,
   linesToHighlight = [],
   hidden: defaultHidden = false,
-  disableCopy = false
+  disableCopy = false,
+  isPartOfMultiCode = false
 }: CodeBlockProps): JSX.Element => {
   const {onCopy, hasCopied} = useClipboard(code);
   const [hidden, setHidden] = useState(defaultHidden);
 
   const theme = usePrismTheme();
-  const languageMenu = useContext(CodeBlockContext);
   const highlightColor = useColorModeValue('gray.100', 'gray.700');
   const lineNumberColor = useColorModeValue(
     'gray.500',
     colors.midnight.lighter
   );
 
+  const blockLanguage = getNormalizedLanguage(language);
+
   return (
-    <Highlight
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      Prism={Prism}
-      theme={theme}
-      code={code}
-      language={language}
-    >
-      {({className, style, tokens, getLineProps, getTokenProps}) => {
-        // length of longest line number
-        // ex. if there are 28 lines in the code block, lineNumberOffset = 2ch
-        const lineNumberOffset = tokens.length.toString().length + 'ch';
+    <Box display="flex" flexDir="column">
+      {!isPartOfMultiCode && (
+        <CodeBlockTabs
+          languages={[blockLanguage]}
+          activeLanguage={blockLanguage}
+        />
+      )}
+      <Highlight
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        Prism={Prism}
+        theme={theme}
+        code={code}
+        language={language}
+      >
+        {({className, style, tokens, getLineProps, getTokenProps}) => {
+          // length of longest line number
+          // ex. if there are 28 lines in the code block, lineNumberOffset = 2ch
+          const lineNumberOffset = tokens.length.toString().length + 'ch';
 
-        // create an array of lines highlighted by "highlight-start" and
-        // "highlight-end" comments
-        const highlightRange = [];
-        let isHighlighting = false;
-        let highlightOffset = 0;
-        for (let i = 0; i < tokens.length; i++) {
-          const line = tokens[i];
-          if (isHighlightEnd(line)) {
-            // turn highlighting off
-            isHighlighting = false;
-            // account for the soon-to-be-missing start and end comments
-            highlightOffset += 2;
-          } else if (isHighlightStart(line)) {
-            // start highlighting
-            isHighlighting = true;
-          } else if (isHighlighting) {
-            // while highlighting, push the current index minus the offset into
-            // the array of highlighted lines
-            highlightRange.push(i - highlightOffset);
+          // create an array of lines highlighted by "highlight-start" and
+          // "highlight-end" comments
+          const highlightRange = [];
+          let isHighlighting = false;
+          let highlightOffset = 0;
+          for (let i = 0; i < tokens.length; i++) {
+            const line = tokens[i];
+            if (isHighlightEnd(line)) {
+              // turn highlighting off
+              isHighlighting = false;
+              // account for the soon-to-be-missing start and end comments
+              highlightOffset += 2;
+            } else if (isHighlightStart(line)) {
+              // start highlighting
+              isHighlighting = true;
+            } else if (isHighlighting) {
+              // while highlighting, push the current index minus the offset into
+              // the array of highlighted lines
+              highlightRange.push(i - highlightOffset);
+            }
           }
-        }
 
-        return (
-          <Box
-            rounded="md"
-            style={style}
-            pos="relative"
-            borderWidth="1px"
-            lineHeight="base"
-          >
-            <Box fontSize="md" fontFamily="mono">
-              {title && (
-                <Box
-                  px={CODE_BLOCK_SPACING}
-                  py="2"
-                  borderBottomWidth="1px"
-                  borderTopRadius="md"
+          return (
+            <Box
+              rounded="md"
+              borderTopLeftRadius="none"
+              borderTopRightRadius="none"
+              style={style}
+              pos="relative"
+              borderWidth="1px"
+              lineHeight="base"
+            >
+              <Box fontSize="md" fontFamily="mono">
+                {title && (
+                  <Box
+                    px={CODE_BLOCK_SPACING}
+                    py="2"
+                    borderBottomWidth="1px"
+                    borderTopRadius="md"
+                  >
+                    {title}
+                  </Box>
+                )}
+                <Flex
+                  overflow="auto"
+                  transition="filter 200ms"
+                  css={
+                    hidden && {
+                      filter: 'blur(8px)',
+                      pointerEvents: 'none',
+                      userSelect: 'none'
+                    }
+                  }
                 >
-                  {title}
-                </Box>
-              )}
-              <Flex
-                overflow="auto"
-                transition="filter 200ms"
+                  <chakra.pre
+                    d="inline-block"
+                    minW="full"
+                    className={className}
+                    py={CODE_BLOCK_SPACING}
+                    fontFamily="inherit"
+                  >
+                    {tokens
+                      .filter(
+                        line => !isHighlightStart(line) && !isHighlightEnd(line)
+                      )
+                      .map((line, i) => {
+                        const shouldHighlight =
+                          // if the line number exists in the metastring or highlight comment ranges
+                          linesToHighlight
+                            .concat(highlightRange)
+                            .includes(i + 1) ||
+                          // or if the line has a "highlight-line" comment in it
+                          line.some(token => isHighlightComment(token));
+                        return (
+                          <Flex
+                            key={i}
+                            px={CODE_BLOCK_SPACING}
+                            // for line highlighting to go all the way across code block
+                            minW="full"
+                            w="fit-content"
+                            bg={shouldHighlight && highlightColor}
+                          >
+                            {showLineNumbers && (
+                              <Box
+                                aria-hidden="true"
+                                userSelect="none"
+                                // line number alignment used in VS Code
+                                textAlign="right"
+                                w={lineNumberOffset}
+                                mr={CODE_BLOCK_SPACING}
+                                color={lineNumberColor}
+                              >
+                                {i + 1}
+                              </Box>
+                            )}
+                            <Box
+                              {...getLineProps({
+                                line,
+                                key: i
+                              })}
+                            >
+                              <Box>
+                                {line
+                                  // filter out "highlight-line" comments
+                                  .filter(token => !isHighlightComment(token))
+                                  .map((token, key) => (
+                                    <span
+                                      key={key}
+                                      {...getTokenProps({token, key})}
+                                    />
+                                  ))}
+                              </Box>
+                            </Box>
+                          </Flex>
+                        );
+                      })}
+                  </chakra.pre>
+                </Flex>
+              </Box>
+              <ButtonGroup
+                size="xs"
+                pos="absolute"
+                top="2"
+                right="2"
+                transition="opacity 200ms linear 200ms"
                 css={
                   hidden && {
-                    filter: 'blur(8px)',
-                    pointerEvents: 'none',
-                    userSelect: 'none'
+                    opacity: 0,
+                    transition: 'none'
                   }
                 }
               >
-                <chakra.pre
-                  d="inline-block"
-                  minW="full"
-                  className={className}
-                  py={CODE_BLOCK_SPACING}
-                  fontFamily="inherit"
-                >
-                  {tokens
-                    .filter(
-                      line => !isHighlightStart(line) && !isHighlightEnd(line)
-                    )
-                    .map((line, i) => {
-                      const shouldHighlight =
-                        // if the line number exists in the metastring or highlight comment ranges
-                        linesToHighlight
-                          .concat(highlightRange)
-                          .includes(i + 1) ||
-                        // or if the line has a "highlight-line" comment in it
-                        line.some(token => isHighlightComment(token));
-                      return (
-                        <Flex
-                          key={i}
-                          px={CODE_BLOCK_SPACING}
-                          // for line highlighting to go all the way across code block
-                          minW="full"
-                          w="fit-content"
-                          bg={shouldHighlight && highlightColor}
-                        >
-                          {showLineNumbers && (
-                            <Box
-                              aria-hidden="true"
-                              userSelect="none"
-                              // line number alignment used in VS Code
-                              textAlign="right"
-                              w={lineNumberOffset}
-                              mr={CODE_BLOCK_SPACING}
-                              color={lineNumberColor}
-                            >
-                              {i + 1}
-                            </Box>
-                          )}
-                          <Box
-                            {...getLineProps({
-                              line,
-                              key: i
-                            })}
-                          >
-                            <Box>
-                              {line
-                                // filter out "highlight-line" comments
-                                .filter(token => !isHighlightComment(token))
-                                .map((token, key) => (
-                                  <span
-                                    key={key}
-                                    {...getTokenProps({token, key})}
-                                  />
-                                ))}
-                            </Box>
-                          </Box>
-                        </Flex>
-                      );
-                    })}
-                </chakra.pre>
-              </Flex>
-            </Box>
-            <ButtonGroup
-              size="xs"
-              pos="absolute"
-              top="2"
-              right="2"
-              transition="opacity 200ms linear 200ms"
-              css={
-                hidden && {
-                  opacity: 0,
-                  transition: 'none'
-                }
-              }
-            >
-              {defaultHidden && (
-                <IconButton
-                  aria-label="Hide code"
-                  icon={<FiEyeOff />}
-                  onClick={() => setHidden(true)}
-                />
-              )}
-              {!disableCopy && (
+                {defaultHidden && (
+                  <IconButton
+                    aria-label="Hide code"
+                    icon={<FiEyeOff />}
+                    onClick={() => setHidden(true)}
+                  />
+                )}
+                {!disableCopy && (
+                  <Button
+                    leftIcon={hasCopied ? <FiCheck /> : <FiClipboard />}
+                    onClick={() => {
+                      onCopy();
+                      window.gtag?.('event', 'Copy', {
+                        event_category: GA_EVENT_CATEGORY_CODE_BLOCK
+                      });
+                    }}
+                  >
+                    {hasCopied ? 'Copied!' : 'Copy'}
+                  </Button>
+                )}
+              </ButtonGroup>
+              {hidden && (
                 <Button
-                  leftIcon={hasCopied ? <FiCheck /> : <FiClipboard />}
-                  onClick={() => {
-                    onCopy();
-                    window.gtag?.('event', 'Copy', {
-                      event_category: GA_EVENT_CATEGORY_CODE_BLOCK
-                    });
-                  }}
+                  pos="absolute"
+                  top="50%"
+                  left="50%"
+                  transform="translate(-50%, -50%)"
+                  onClick={() => setHidden(false)}
+                  rounded="full"
+                  colorScheme="indigo"
                 >
-                  {hasCopied ? 'Copied!' : 'Copy'}
+                  Show code
                 </Button>
               )}
-              {languageMenu}
-            </ButtonGroup>
-            {hidden && (
-              <Button
-                pos="absolute"
-                top="50%"
-                left="50%"
-                transform="translate(-50%, -50%)"
-                onClick={() => setHidden(false)}
-                rounded="full"
-                colorScheme="indigo"
-              >
-                Show code
-              </Button>
-            )}
-          </Box>
-        );
-      }}
-    </Highlight>
+            </Box>
+          );
+        }}
+      </Highlight>
+    </Box>
   );
 };

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -18,7 +18,7 @@ import {FiCheck} from '@react-icons/all-files/fi/FiCheck';
 import {FiClipboard} from '@react-icons/all-files/fi/FiClipboard';
 import {FiEyeOff} from '@react-icons/all-files/fi/FiEyeOff';
 import {colors} from '@apollo/space-kit/colors';
-import {getNormalizedLanguage} from './helpers';
+import {getNormalizedLanguage} from './language-util';
 import {usePrismTheme} from './prism';
 
 const CODE_BLOCK_SPACING = 4;
@@ -119,7 +119,7 @@ export const CodeBlock = ({
   const blockLanguage = getNormalizedLanguage(language);
 
   return (
-    <Box display="flex" flexDir="column">
+    <Box>
       {!isPartOfMultiCode && (
         <CodeBlockTabs
           languages={[blockLanguage]}
@@ -164,8 +164,7 @@ export const CodeBlock = ({
           return (
             <Box
               rounded="md"
-              borderTopLeftRadius="none"
-              borderTopRightRadius="none"
+              roundedTop="none"
               style={style}
               pos="relative"
               borderWidth="1px"

--- a/packages/chakra-helpers/src/CodeBlockTabs.tsx
+++ b/packages/chakra-helpers/src/CodeBlockTabs.tsx
@@ -1,0 +1,151 @@
+import React, {useContext, useEffect, useRef, useState} from 'react';
+import {Box, Button, ButtonGroup, Flex, FlexProps} from '@chakra-ui/react';
+import {BsChevronLeft} from '@react-icons/all-files/bs/BsChevronLeft';
+import {BsChevronRight} from '@react-icons/all-files/bs/BsChevronRight';
+import {GA_EVENT_CATEGORY_CODE_BLOCK} from './CodeBlock';
+import {MultiCodeBlockContext} from './MultiCodeBlock';
+import {getIconComponent} from './helpers';
+import {usePrismTheme} from './prism';
+
+function getTabButtonProps(loc: 'LEFT' | 'RIGHT', visible: boolean): FlexProps {
+  return {
+    pos: 'absolute',
+    left: loc === 'LEFT' ? 0 : undefined,
+    right: loc === 'RIGHT' ? 0 : undefined,
+    top: '0',
+    bottom: '0',
+    alignItems: 'center',
+    justifyContent: loc === 'LEFT' ? 'flex-start' : 'flex-end',
+    zIndex: '99',
+    width: '8',
+    background: `linear-gradient(${
+      loc === 'LEFT' ? '90deg' : '270deg'
+    }, rgba(255,255,255,0.9) 50%, rgba(255,255,255,0) 100%)`,
+    opacity: visible ? 1 : 0,
+    pointerEvents: visible ? 'all' : 'none',
+    transition: 'all 250ms ease-in-out',
+    cursor: 'pointer'
+  };
+}
+
+interface CodeBlockTabsProps {
+  languages: string[];
+  activeLanguage: string;
+}
+
+export const CodeBlockTabs = ({
+  languages,
+  activeLanguage
+}: CodeBlockTabsProps): JSX.Element => {
+  // Track inner (infinite width) and outer (container width) boxes using refs
+  const outerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  // Track the scroll position, represented as [0,1] inclusive
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  // Track tabs scroll position to determine if arrows are necessary
+  useEffect(() => {
+    if (!outerRef.current) return;
+    const el = outerRef.current;
+    const onScroll = () => {
+      const maxScroll = el.scrollWidth - el.clientWidth;
+      setScrollPosition(el.scrollLeft / maxScroll);
+    };
+    outerRef.current.addEventListener('scroll', onScroll);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+    };
+  }, [outerRef]);
+
+  // Allow for arrow presses to induce a short scroll left or right
+  const bumpScroll = (distance: number) => () => {
+    if (!outerRef) return;
+    outerRef.current.scrollBy({
+      left: distance,
+      behavior: 'smooth'
+    });
+  };
+
+  const {setLanguage} = useContext(MultiCodeBlockContext);
+
+  const theme = usePrismTheme();
+
+  // Determine which arrows (if any) need to be shown
+  let showArrows = false;
+  if (
+    innerRef.current &&
+    outerRef.current &&
+    innerRef.current.clientWidth > outerRef.current.clientWidth
+  ) {
+    showArrows = true;
+  }
+  // Determine if the left or right arrows should be shown based on overall
+  // visibility, and the scroll position
+  const showLeftArrow = showArrows && scrollPosition > 0;
+  const showRightArrow = showArrows && scrollPosition < 1;
+
+  return (
+    <Box pos="relative" pt="1">
+      <Flex
+        {...getTabButtonProps('LEFT', showLeftArrow)}
+        onClick={bumpScroll(-120)}
+      >
+        <BsChevronLeft />
+      </Flex>
+      <Box
+        overflowX="auto"
+        pos="relative"
+        css={{
+          '&::-webkit-scrollbar': {
+            display: 'none'
+          },
+          '-ms-overflow-style': 'none',
+          'scrollbar-width': 'none'
+        }}
+        ref={outerRef}
+      >
+        <ButtonGroup
+          size="xs"
+          role="tablist"
+          ref={innerRef}
+          display="flex"
+          flexDirection="row"
+          w="max-content"
+        >
+          {languages.map(language => (
+            <Button
+              leftIcon={getIconComponent(language)}
+              key={language}
+              onClick={() => {
+                setLanguage(language);
+                window.gtag?.('event', 'Change language', {
+                  event_category: GA_EVENT_CATEGORY_CODE_BLOCK,
+                  event_label: language
+                });
+              }}
+              borderBottomLeftRadius="none"
+              borderBottomRightRadius="none"
+              bg={
+                language !== activeLanguage
+                  ? theme.plain.backgroundColor
+                  : undefined
+              }
+              role="tab"
+              aria-selected="true"
+              mt="1"
+              flexShrink={0}
+            >
+              {language}
+            </Button>
+          ))}
+        </ButtonGroup>
+      </Box>
+      <Flex
+        {...getTabButtonProps('RIGHT', showRightArrow)}
+        onClick={bumpScroll(120)}
+      >
+        <BsChevronRight />
+      </Flex>
+    </Box>
+  );
+};

--- a/packages/chakra-helpers/src/CodeBlockTabs.tsx
+++ b/packages/chakra-helpers/src/CodeBlockTabs.tsx
@@ -3,10 +3,8 @@ import {
   Box,
   Button,
   ButtonGroup,
-  ColorMode,
   Flex,
   FlexProps,
-  useColorMode,
   useColorModeValue,
   useToken
 } from '@chakra-ui/react';
@@ -15,7 +13,7 @@ import {BsChevronRight} from '@react-icons/all-files/bs/BsChevronRight';
 import {GA_EVENT_CATEGORY_CODE_BLOCK} from './CodeBlock';
 import {MultiCodeBlockContext} from './MultiCodeBlock';
 import {TinyColor} from '@ctrl/tinycolor';
-import {getIconComponent} from './helpers';
+import {getIconComponent} from './language-util';
 import {usePrismTheme} from './prism';
 
 function getTabButtonProps(
@@ -23,8 +21,6 @@ function getTabButtonProps(
   visible: boolean,
   gradientColor: TinyColor
 ): FlexProps {
-  // const gradientColor = colorMode === 'light' ? '255,255,255' : '0,0,0';
-
   const endColor = gradientColor.clone().setAlpha(0);
 
   return {
@@ -97,21 +93,18 @@ export const CodeBlockTabs = ({
   );
 
   // Determine which arrows (if any) need to be shown
-  let showArrows = false;
-  if (
+  const showArrows = Boolean(
     innerRef.current &&
-    outerRef.current &&
-    innerRef.current.clientWidth > outerRef.current.clientWidth
-  ) {
-    showArrows = true;
-  }
+      outerRef.current &&
+      innerRef.current.clientWidth > outerRef.current.clientWidth
+  );
   // Determine if the left or right arrows should be shown based on overall
   // visibility, and the scroll position
   const showLeftArrow = showArrows && scrollPosition > 0;
   const showRightArrow = showArrows && scrollPosition < 1;
 
   return (
-    <Box pos="relative" pt="1">
+    <Box pos="relative" pt="1" zIndex="0">
       <Flex
         {...getTabButtonProps('LEFT', showLeftArrow, gradientColor)}
         onClick={bumpScroll(-120)}
@@ -149,8 +142,7 @@ export const CodeBlockTabs = ({
                   event_label: language
                 });
               }}
-              borderBottomLeftRadius="none"
-              borderBottomRightRadius="none"
+              roundedBottom="none"
               bg={
                 language !== activeLanguage
                   ? theme.plain.backgroundColor

--- a/packages/chakra-helpers/src/CodeBlockTabs.tsx
+++ b/packages/chakra-helpers/src/CodeBlockTabs.tsx
@@ -1,26 +1,47 @@
 import React, {useContext, useEffect, useRef, useState} from 'react';
-import {Box, Button, ButtonGroup, Flex, FlexProps} from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  ColorMode,
+  Flex,
+  FlexProps,
+  useColorMode,
+  useColorModeValue,
+  useToken
+} from '@chakra-ui/react';
 import {BsChevronLeft} from '@react-icons/all-files/bs/BsChevronLeft';
 import {BsChevronRight} from '@react-icons/all-files/bs/BsChevronRight';
 import {GA_EVENT_CATEGORY_CODE_BLOCK} from './CodeBlock';
 import {MultiCodeBlockContext} from './MultiCodeBlock';
+import {TinyColor} from '@ctrl/tinycolor';
 import {getIconComponent} from './helpers';
 import {usePrismTheme} from './prism';
 
-function getTabButtonProps(loc: 'LEFT' | 'RIGHT', visible: boolean): FlexProps {
+function getTabButtonProps(
+  loc: 'LEFT' | 'RIGHT',
+  visible: boolean,
+  gradientColor: TinyColor
+): FlexProps {
+  // const gradientColor = colorMode === 'light' ? '255,255,255' : '0,0,0';
+
+  const endColor = gradientColor.clone().setAlpha(0);
+
   return {
     pos: 'absolute',
-    left: loc === 'LEFT' ? 0 : undefined,
-    right: loc === 'RIGHT' ? 0 : undefined,
+    left: loc === 'LEFT' ? '-1px' : undefined,
+    right: loc === 'RIGHT' ? '-1px' : undefined,
     top: '0',
     bottom: '0',
     alignItems: 'center',
     justifyContent: loc === 'LEFT' ? 'flex-start' : 'flex-end',
     zIndex: '99',
     width: '8',
-    background: `linear-gradient(${
-      loc === 'LEFT' ? '90deg' : '270deg'
-    }, rgba(255,255,255,0.9) 50%, rgba(255,255,255,0) 100%)`,
+    background: `linear-gradient(${[
+      loc === 'LEFT' ? '90deg' : '270deg',
+      `${gradientColor.toRgbString()} 50%`,
+      endColor.toRgbString()
+    ]})`,
     opacity: visible ? 1 : 0,
     pointerEvents: visible ? 'all' : 'none',
     transition: 'all 250ms ease-in-out',
@@ -69,6 +90,11 @@ export const CodeBlockTabs = ({
   const {setLanguage} = useContext(MultiCodeBlockContext);
 
   const theme = usePrismTheme();
+  const bgColor = useToken('colors', 'gray.800');
+  const gradientColor = useColorModeValue(
+    new TinyColor('white'),
+    new TinyColor(bgColor)
+  );
 
   // Determine which arrows (if any) need to be shown
   let showArrows = false;
@@ -87,7 +113,7 @@ export const CodeBlockTabs = ({
   return (
     <Box pos="relative" pt="1">
       <Flex
-        {...getTabButtonProps('LEFT', showLeftArrow)}
+        {...getTabButtonProps('LEFT', showLeftArrow, gradientColor)}
         onClick={bumpScroll(-120)}
       >
         <BsChevronLeft />
@@ -141,7 +167,7 @@ export const CodeBlockTabs = ({
         </ButtonGroup>
       </Box>
       <Flex
-        {...getTabButtonProps('RIGHT', showRightArrow)}
+        {...getTabButtonProps('RIGHT', showRightArrow, gradientColor)}
         onClick={bumpScroll(120)}
       >
         <BsChevronRight />

--- a/packages/chakra-helpers/src/MultiCodeBlock.tsx
+++ b/packages/chakra-helpers/src/MultiCodeBlock.tsx
@@ -7,7 +7,7 @@ import React, {
 import {Box, Flex} from '@chakra-ui/react';
 import {CodeBlockProps} from './CodeBlock';
 import {CodeBlockTabs} from './CodeBlockTabs';
-import {getNormalizedLanguage} from './helpers';
+import {getNormalizedLanguage} from './language-util';
 
 export const MultiCodeBlockContext = createContext<{
   language: string | null;

--- a/packages/chakra-helpers/src/MultiCodeBlock.tsx
+++ b/packages/chakra-helpers/src/MultiCodeBlock.tsx
@@ -1,30 +1,18 @@
 import React, {
-  ReactChild,
   ReactNode,
   createContext,
   isValidElement,
   useContext
 } from 'react';
-import {Button, Menu, MenuButton, MenuItem, MenuList} from '@chakra-ui/react';
-import {CodeBlockContext, GA_EVENT_CATEGORY_CODE_BLOCK} from './CodeBlock';
-import {FiChevronDown} from '@react-icons/all-files/fi/FiChevronDown';
+import {Box, Flex} from '@chakra-ui/react';
+import {CodeBlockProps} from './CodeBlock';
+import {CodeBlockTabs} from './CodeBlockTabs';
+import {getNormalizedLanguage} from './helpers';
 
-export const MultiCodeBlockContext = createContext(null);
-
-function getLanguage(language: string): string {
-  switch (language) {
-    case 'language-js':
-    case 'language-jsx':
-    case 'language-javascript':
-      return 'JavaScript';
-    case 'language-ts':
-    case 'language-tsx':
-    case 'language-typescript':
-      return 'TypeScript';
-    default:
-      return language;
-  }
-}
+export const MultiCodeBlockContext = createContext<{
+  language: string | null;
+  setLanguage: React.Dispatch<string>;
+}>(null);
 
 type MultiCodeBlockProps = {
   children: ReactNode;
@@ -33,53 +21,40 @@ type MultiCodeBlockProps = {
 export const MultiCodeBlock = ({
   children
 }: MultiCodeBlockProps): JSX.Element => {
-  const codeBlocks = React.Children.toArray(children).reduce(
-    (acc: Record<string, ReactChild>, child) =>
-      isValidElement(child)
-        ? {
-            ...acc,
-            [getLanguage(child.props.children.props.className)]: child
-          }
-        : acc,
-    {}
-  );
+  const codeBlocks = React.Children.toArray(children).reduce<
+    Record<string, React.ReactElement<CodeBlockProps>>
+  >((acc, child) => {
+    if (!isValidElement(child)) {
+      return acc;
+    }
+    return Object.assign(acc, {
+      [getNormalizedLanguage(child.props.children.props.className)]: child
+    });
+  }, {});
+
+  const {language} = useContext(MultiCodeBlockContext);
 
   const languages = Object.keys(codeBlocks);
   const defaultLanguage = languages[0];
-  const {language, setLanguage} = useContext(MultiCodeBlockContext);
   const renderedLanguage = languages.includes(language)
     ? language
     : defaultLanguage;
 
   return (
-    <div>
-      <CodeBlockContext.Provider
-        value={
-          <Menu>
-            <MenuButton as={Button} rightIcon={<FiChevronDown />}>
-              {renderedLanguage}
-            </MenuButton>
-            <MenuList>
-              {languages.map(language => (
-                <MenuItem
-                  key={language}
-                  onClick={() => {
-                    setLanguage(language);
-                    window.gtag?.('event', 'Change language', {
-                      event_category: GA_EVENT_CATEGORY_CODE_BLOCK,
-                      event_label: language
-                    });
-                  }}
-                >
-                  {language}
-                </MenuItem>
-              ))}
-            </MenuList>
-          </Menu>
-        }
-      >
-        {codeBlocks[renderedLanguage]}
-      </CodeBlockContext.Provider>
-    </div>
+    <Flex flexDir="column" pt="6">
+      <CodeBlockTabs languages={languages} activeLanguage={renderedLanguage} />
+      {languages.map(language => (
+        <Box
+          key={language}
+          role="tabpanel"
+          tabIndex={0}
+          display={language === renderedLanguage ? 'block' : 'none'}
+        >
+          {React.cloneElement(codeBlocks[language], {
+            isPartOfMultiCode: true
+          })}
+        </Box>
+      ))}
+    </Flex>
   );
 };

--- a/packages/chakra-helpers/src/helpers.ts
+++ b/packages/chakra-helpers/src/helpers.ts
@@ -1,6 +1,22 @@
+import React, {Context, createContext, useContext} from 'react';
+import {BiText} from '@react-icons/all-files/bi/BiText';
 import {ColorHues} from '@chakra-ui/react';
 import {ColorPalette, MonochromePalette} from '@apollo/space-kit/colors';
+import {SiGnubash} from '@react-icons/all-files/si/SiGnubash';
+import {SiGraphql} from '@react-icons/all-files/si/SiGraphql';
+import {SiGroovy} from '@react-icons/all-files/si/SiGroovy';
+import {SiJava} from '@react-icons/all-files/si/SiJava';
+import {SiJavascript} from '@react-icons/all-files/si/SiJavascript';
+import {SiJson} from '@react-icons/all-files/si/SiJson';
+import {SiKotlin} from '@react-icons/all-files/si/SiKotlin';
+import {SiRuby} from '@react-icons/all-files/si/SiRuby';
+import {SiRust} from '@react-icons/all-files/si/SiRust';
+import {SiSwift} from '@react-icons/all-files/si/SiSwift';
+import {SiTypescript} from '@react-icons/all-files/si/SiTypescript';
+import {TiDocumentText} from '@react-icons/all-files/ti/TiDocumentText';
+
 import {mix} from 'polished';
+import type {IconType} from '@react-icons/all-files/lib';
 
 const body = "'Source Sans Pro', sans-serif";
 export const fonts = {
@@ -49,3 +65,67 @@ export const createColorPalette = (color: ColorPalette): ColorHues => ({
   800: mix(0.5, color.darker, color.darkest),
   900: color.darkest
 });
+
+export function getNormalizedLanguage(language: string): string {
+  const classless = language
+    .replace(/language-/g, '')
+    .toLocaleLowerCase()
+    .replace(/:.*/g, '');
+  switch (classless) {
+    case 'js':
+    case 'jsx':
+    case 'javascript':
+      return 'JavaScript';
+    case 'ts':
+    case 'tsx':
+    case 'typescript':
+      return 'TypeScript';
+    case 'graphql':
+      return 'GraphQL';
+    case 'json':
+      return 'JSON';
+    case 'yaml':
+      return 'YAML';
+    case 'text':
+    case 'swift':
+    case 'bash':
+    case 'groovy':
+    case 'java':
+    case 'kotlin':
+    case 'rust':
+    case 'ruby':
+      return classless[0].toLocaleUpperCase() + classless.slice(1);
+    default:
+      return classless;
+  }
+}
+
+export function getIconComponentType(language: string): IconType | undefined {
+  const normalizedLang = getNormalizedLanguage(language);
+  const componentMap: Record<string, IconType> = {
+    JavaScript: SiJavascript,
+    TypeScript: SiTypescript,
+    JSON: SiJson,
+    GraphQL: SiGraphql,
+    Text: BiText,
+    Bash: SiGnubash,
+    Groovy: SiGroovy,
+    Java: SiJava,
+    Kotlin: SiKotlin,
+    Ruby: SiRuby,
+    Rust: SiRust,
+    Swift: SiSwift,
+    YAML: TiDocumentText
+  };
+  const component = componentMap[normalizedLang];
+  return component;
+}
+
+export function getIconComponent(language: string): React.ReactElement {
+  const normalizedLang = getNormalizedLanguage(language);
+  const iconType = getIconComponentType(normalizedLang);
+  if (!iconType) {
+    return undefined;
+  }
+  return React.createElement(iconType);
+}

--- a/packages/chakra-helpers/src/helpers.ts
+++ b/packages/chakra-helpers/src/helpers.ts
@@ -66,11 +66,12 @@ export const createColorPalette = (color: ColorPalette): ColorHues => ({
   900: color.darkest
 });
 
-export function getNormalizedLanguage(language: string): string {
-  const classless = language
-    .replace(/language-/g, '')
-    .toLocaleLowerCase()
-    .replace(/:.*/g, '');
+export function getNormalizedLanguage(language?: string): string {
+  const classless =
+    language
+      ?.replace(/language-/g, '')
+      .toLocaleLowerCase()
+      .replace(/:.*/g, '') ?? '';
   switch (classless) {
     case 'js':
     case 'jsx':

--- a/packages/chakra-helpers/src/helpers.ts
+++ b/packages/chakra-helpers/src/helpers.ts
@@ -1,22 +1,6 @@
-import React, {Context, createContext, useContext} from 'react';
-import {BiText} from '@react-icons/all-files/bi/BiText';
 import {ColorHues} from '@chakra-ui/react';
 import {ColorPalette, MonochromePalette} from '@apollo/space-kit/colors';
-import {SiGnubash} from '@react-icons/all-files/si/SiGnubash';
-import {SiGraphql} from '@react-icons/all-files/si/SiGraphql';
-import {SiGroovy} from '@react-icons/all-files/si/SiGroovy';
-import {SiJava} from '@react-icons/all-files/si/SiJava';
-import {SiJavascript} from '@react-icons/all-files/si/SiJavascript';
-import {SiJson} from '@react-icons/all-files/si/SiJson';
-import {SiKotlin} from '@react-icons/all-files/si/SiKotlin';
-import {SiRuby} from '@react-icons/all-files/si/SiRuby';
-import {SiRust} from '@react-icons/all-files/si/SiRust';
-import {SiSwift} from '@react-icons/all-files/si/SiSwift';
-import {SiTypescript} from '@react-icons/all-files/si/SiTypescript';
-import {TiDocumentText} from '@react-icons/all-files/ti/TiDocumentText';
-
 import {mix} from 'polished';
-import type {IconType} from '@react-icons/all-files/lib';
 
 const body = "'Source Sans Pro', sans-serif";
 export const fonts = {
@@ -65,68 +49,3 @@ export const createColorPalette = (color: ColorPalette): ColorHues => ({
   800: mix(0.5, color.darker, color.darkest),
   900: color.darkest
 });
-
-export function getNormalizedLanguage(language?: string): string {
-  const classless =
-    language
-      ?.replace(/language-/g, '')
-      .toLocaleLowerCase()
-      .replace(/:.*/g, '') ?? '';
-  switch (classless) {
-    case 'js':
-    case 'jsx':
-    case 'javascript':
-      return 'JavaScript';
-    case 'ts':
-    case 'tsx':
-    case 'typescript':
-      return 'TypeScript';
-    case 'graphql':
-      return 'GraphQL';
-    case 'json':
-      return 'JSON';
-    case 'yaml':
-      return 'YAML';
-    case 'text':
-    case 'swift':
-    case 'bash':
-    case 'groovy':
-    case 'java':
-    case 'kotlin':
-    case 'rust':
-    case 'ruby':
-      return classless[0].toLocaleUpperCase() + classless.slice(1);
-    default:
-      return classless;
-  }
-}
-
-export function getIconComponentType(language: string): IconType | undefined {
-  const normalizedLang = getNormalizedLanguage(language);
-  const componentMap: Record<string, IconType> = {
-    JavaScript: SiJavascript,
-    TypeScript: SiTypescript,
-    JSON: SiJson,
-    GraphQL: SiGraphql,
-    Text: BiText,
-    Bash: SiGnubash,
-    Groovy: SiGroovy,
-    Java: SiJava,
-    Kotlin: SiKotlin,
-    Ruby: SiRuby,
-    Rust: SiRust,
-    Swift: SiSwift,
-    YAML: TiDocumentText
-  };
-  const component = componentMap[normalizedLang];
-  return component;
-}
-
-export function getIconComponent(language: string): React.ReactElement {
-  const normalizedLang = getNormalizedLanguage(language);
-  const iconType = getIconComponentType(normalizedLang);
-  if (!iconType) {
-    return undefined;
-  }
-  return React.createElement(iconType);
-}

--- a/packages/chakra-helpers/src/language-util.ts
+++ b/packages/chakra-helpers/src/language-util.ts
@@ -1,0 +1,80 @@
+import React from 'react';
+import {BiText} from '@react-icons/all-files/bi/BiText';
+import {SiGnubash} from '@react-icons/all-files/si/SiGnubash';
+import {SiGraphql} from '@react-icons/all-files/si/SiGraphql';
+import {SiGroovy} from '@react-icons/all-files/si/SiGroovy';
+import {SiJava} from '@react-icons/all-files/si/SiJava';
+import {SiJavascript} from '@react-icons/all-files/si/SiJavascript';
+import {SiJson} from '@react-icons/all-files/si/SiJson';
+import {SiKotlin} from '@react-icons/all-files/si/SiKotlin';
+import {SiRuby} from '@react-icons/all-files/si/SiRuby';
+import {SiRust} from '@react-icons/all-files/si/SiRust';
+import {SiSwift} from '@react-icons/all-files/si/SiSwift';
+import {SiTypescript} from '@react-icons/all-files/si/SiTypescript';
+import {TiDocumentText} from '@react-icons/all-files/ti/TiDocumentText';
+import type {IconType} from '@react-icons/all-files/lib';
+
+export function getNormalizedLanguage(language?: string): string {
+  const classless =
+    language
+      ?.replace(/language-/g, '')
+      .toLocaleLowerCase()
+      .replace(/:.*/g, '') ?? '';
+  switch (classless) {
+    case 'js':
+    case 'jsx':
+    case 'javascript':
+      return 'JavaScript';
+    case 'ts':
+    case 'tsx':
+    case 'typescript':
+      return 'TypeScript';
+    case 'graphql':
+      return 'GraphQL';
+    case 'json':
+      return 'JSON';
+    case 'yaml':
+      return 'YAML';
+    case 'text':
+    case 'swift':
+    case 'bash':
+    case 'groovy':
+    case 'java':
+    case 'kotlin':
+    case 'rust':
+    case 'ruby':
+      return classless[0].toLocaleUpperCase() + classless.slice(1);
+    default:
+      return classless;
+  }
+}
+
+export function getIconComponentType(language: string): IconType | undefined {
+  const normalizedLang = getNormalizedLanguage(language);
+  const componentMap: Record<string, IconType> = {
+    JavaScript: SiJavascript,
+    TypeScript: SiTypescript,
+    JSON: SiJson,
+    GraphQL: SiGraphql,
+    Text: BiText,
+    Bash: SiGnubash,
+    Groovy: SiGroovy,
+    Java: SiJava,
+    Kotlin: SiKotlin,
+    Ruby: SiRuby,
+    Rust: SiRust,
+    Swift: SiSwift,
+    YAML: TiDocumentText
+  };
+  const component = componentMap[normalizedLang];
+  return component;
+}
+
+export function getIconComponent(language: string): React.ReactElement {
+  const normalizedLang = getNormalizedLanguage(language);
+  const iconType = getIconComponentType(normalizedLang);
+  if (!iconType) {
+    return undefined;
+  }
+  return React.createElement(iconType);
+}


### PR DESCRIPTION
Highlighting line consistency was lost during the TS->JS transpilation.

````
```ts {2}
type Result = void;
const test = (): Result => {};
test();
```
````

In the old system, line 1 would be omitted in the JS output, leaving `test()` to be highlighted. This was incorrect behavior and is adjusted with this new system to track line highlights. 

More can be seen in the tests of the `remark-typescript` project [remark-typescript](https://github.com/trevorblades/remark-typescript)


https://user-images.githubusercontent.com/4239999/184240564-5414fec5-666d-4543-bf9b-14a06568e073.mov

The above video properly shows the new highlighting adjustment. Note how the interface is highlighted in TS, and is now properly adjusted for and collapsed for JS.
