### PR TITLE
(fix/UI): Fix z-index of the header so that it stays above the sidebar

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -52,7 +52,7 @@ export function Header({children, algoliaFilters}) {
   const {toggleColorMode, colorMode} = useColorMode();
   const [tagBg, tagTextColor] = useTagColors();
   return (
-    <Box pos="sticky" top="0" zIndex="1">
+    <Box pos="sticky" top="0" zIndex="10">
       <Flex
         align="center"
         as="header"

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -52,7 +52,7 @@ export function Header({children, algoliaFilters}) {
   const {toggleColorMode, colorMode} = useColorMode();
   const [tagBg, tagTextColor] = useTagColors();
   return (
-    <Box pos="sticky" top="0" zIndex="10">
+    <Box pos="sticky" top="0" zIndex="2">
       <Flex
         align="center"
         as="header"


### PR DESCRIPTION
## Current issue

If we go to a doc page and scroll to the top when we are already at the top, the sidebar will be over the header which is not correct.

<img width="643" alt="Screenshot 2022-08-14 at 16 34 21" src="https://user-images.githubusercontent.com/8011543/184531057-64c61417-86a5-4cb8-82d2-6ed7666bba62.png">

https://user-images.githubusercontent.com/8011543/184657849-7a0ed5ed-9437-494a-b7c8-f9a0ffa6a85e.mov

## Fix

The problem comes from the `z-index` value of the header is `1` and it comes before sidebar so the sidebar gets the higher `z-index`. This PR fixes by bumping the `z-index` value of the header to `10`, and the problem disappears.

<img width="678" alt="Screenshot 2022-08-14 at 16 37 38" src="https://user-images.githubusercontent.com/8011543/184531151-3bf64b94-ac23-4865-95aa-d81794554e13.png">

https://user-images.githubusercontent.com/8011543/184658054-12d1c5b8-13cf-4dff-9076-dfa7ce6db326.mov

## Reproduction

- On Firefox, on MacOS
- Got to a doc page (e.g., https://www.apollographql.com/docs/react/data/mutations)
- Stay at the top
- Scroll to the top to see the bounce effect
