### PR TITLE
Remove highlight line comments when copying to clipboard

### DIFF
--- a/.changeset/hip-snails-unite.md
+++ b/.changeset/hip-snails-unite.md
@@ -1,0 +1,5 @@
+---
+"@apollo/chakra-helpers": patch
+---
+
+Remove highlight line comments when copying code to clipboard

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -39,6 +39,14 @@ const isHighlightStart = (line, comment = 'highlight-start') =>
 
 const isHighlightEnd = line => isHighlightStart(line, 'highlight-end');
 
+const getCodeWithoutHighlightComments = (code: string) => {
+  const highlightRegex = new RegExp(
+    /\/\/ (highlight-line|highlight-start|highlight-end)$/gm
+  );
+
+  return code.replace(highlightRegex, '');
+};
+
 type MarkdownCodeBlockProps = {
   children: ReactNode;
   isPartOfMultiCode?: boolean;
@@ -106,7 +114,9 @@ export const CodeBlock = ({
   disableCopy = false,
   isPartOfMultiCode = false
 }: CodeBlockProps): JSX.Element => {
-  const {onCopy, hasCopied} = useClipboard(code);
+  const {onCopy, hasCopied} = useClipboard(
+    getCodeWithoutHighlightComments(code)
+  );
   const [hidden, setHidden] = useState(defaultHidden);
 
   const theme = usePrismTheme();

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -40,9 +40,8 @@ const isHighlightStart = (line, comment = 'highlight-start') =>
 const isHighlightEnd = line => isHighlightStart(line, 'highlight-end');
 
 const getCodeWithoutHighlightComments = (code: string) => {
-  const highlightRegex = new RegExp(
-    /\/\/ (highlight-line|highlight-start|highlight-end)$/gm
-  );
+  const highlightRegex =
+    /\/\/ (highlight-line|highlight-start|highlight-end)$/gm;
 
   return code.replace(highlightRegex, '');
 };


### PR DESCRIPTION
This PR runs the `code` string through a `.replace` to remove all of the `// highlight-line`, `// highlight-start`, and `// highlight-end` comments when clicking the copy to clipboard button.

e.g.
```js title="subgraph-locations/index.js"
    const {ApolloServer, gql} = require('apollo-server');
    const {readFileSync} = require('fs');
    const {buildSubgraphSchema} = require('@apollo/subgraph'); // highlight-line
```
when copied should only output:

```js title="subgraph-locations/index.js"
    const {ApolloServer, gql} = require('apollo-server');
    const {readFileSync} = require('fs');
    const {buildSubgraphSchema} = require('@apollo/subgraph');
```

## TODO
- [x] Cut new release of chakra-helpers package once changes are approved
