### PR TITLE
Fix a typo in enterprise security guide

### DIFF
--- a/src/content/basics/enterprise-guide/graph-security.mdx
+++ b/src/content/basics/enterprise-guide/graph-security.mdx
@@ -91,7 +91,7 @@ query {
 }
 ```
 
-But what will happen when the orders of magnitude increase for each field argument and 1,000,000 posts are requested at once?
+But what will happen when the orders of magnitude increase for each field argument and 100,000 posts are requested at once?
 
 ```graphql
 query {


### PR DESCRIPTION
Could be that the numbers in the queries should be changed instead—but this was the simplest fix 😁 