### PR TITLE
Add git info to MDX for recent updated date

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,6 +5,7 @@ const {
 const {join} = require('path');
 const {v5} = require('uuid');
 const {kebabCase} = require('lodash');
+const {execSync} = require('child_process');
 
 exports.sourceNodes = ({
   actions: {createNode},
@@ -65,6 +66,20 @@ exports.onCreateNode = async ({node, getNode, loadNodeContent, actions}) => {
         name: 'slug',
         // prefix slugs with their docset path (configured by source name)
         value: join('/', sourceInstanceName, filePath)
+      });
+
+      // Add Git info to MD/MDX files for recent updated info
+      // Can replace with '@colliercz/gatsby-transformer-gitinfo' once this issues is resolved
+      //  - https://github.com/CollierCZ/gatsby-transformer-gitinfo/issues/142
+      // For now see:
+      //  - https://stackoverflow.com/questions/56025679/how-to-get-last-update-date-of-a-blog-post-in-gatsby-js
+      const gitAuthorTime = execSync(
+        `git log -1 --pretty=format:%aI ${node.fileAbsolutePath}`
+      ).toString();
+      actions.createNodeField({
+        node,
+        name: 'gitAuthorTime',
+        value: gitAuthorTime
       });
       break;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27612,21 +27612,6 @@
         "@netlify/local-functions-proxy-win32-x64": "1.1.1"
       }
     },
-    "node_modules/netlify-cli/node_modules/@netlify/local-functions-proxy-darwin-x64": {
-      "version": "1.1.1",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "local-functions-proxy": "bin/local-functions-proxy"
-      }
-    },
     "node_modules/netlify-cli/node_modules/@netlify/open-api": {
       "version": "2.8.0",
       "dev": true,
@@ -27706,18 +27691,6 @@
         "@netlify/routing-local-proxy-linux-x64": "^0.34.1",
         "@netlify/routing-local-proxy-win32-x64": "^0.34.1"
       }
-    },
-    "node_modules/netlify-cli/node_modules/@netlify/routing-local-proxy-darwin-x64": {
-      "version": "0.34.1",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
     },
     "node_modules/netlify-cli/node_modules/@netlify/run-utils": {
       "version": "4.0.1",
@@ -48920,7 +48893,7 @@
     },
     "packages/chakra-helpers": {
       "name": "@apollo/chakra-helpers",
-      "version": "1.3.7",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/explorer": "^0.5.2",
@@ -49095,7 +49068,7 @@
         "@apollo/explorer": "^0.5.2",
         "@apollo/space-kit": "8.11.0",
         "@chakra-ui/react": "^1.6.10",
-        "@ctrl/tinycolor": "*",
+        "@ctrl/tinycolor": "^3.4.1",
         "@react-icons/all-files": "^4.1.0",
         "@types/gtag.js": "^0.0.10",
         "@types/prismjs": "^1.26.0",
@@ -66847,11 +66820,6 @@
             "@netlify/local-functions-proxy-win32-x64": "1.1.1"
           }
         },
-        "@netlify/local-functions-proxy-darwin-x64": {
-          "version": "1.1.1",
-          "dev": true,
-          "optional": true
-        },
         "@netlify/open-api": {
           "version": "2.8.0",
           "dev": true
@@ -66905,11 +66873,6 @@
             "@netlify/routing-local-proxy-linux-x64": "^0.34.1",
             "@netlify/routing-local-proxy-win32-x64": "^0.34.1"
           }
-        },
-        "@netlify/routing-local-proxy-darwin-x64": {
-          "version": "0.34.1",
-          "dev": true,
-          "optional": true
         },
         "@netlify/run-utils": {
           "version": "4.0.1",

--- a/src/components/TechNotes/NotesList.js
+++ b/src/components/TechNotes/NotesList.js
@@ -15,7 +15,7 @@ export function NotesList({notes}) {
             <span>
               Last Updated{' '}
               {new Intl.DateTimeFormat('en-US').format(
-                new Date(note.parent.changeTime)
+                new Date(note.fields.gitAuthorTime)
               )}
             </span>
           </Flex>

--- a/src/components/TechNotes/RecentNotes.js
+++ b/src/components/TechNotes/RecentNotes.js
@@ -6,35 +6,24 @@ export function RecentNotes() {
   const data = useStaticQuery(
     graphql`
       query RecentTechNotes {
-        allFile(
-          filter: { childMdx: { slug: { regex: "/^TN\\d{4}/" } } }
-          sort: { fields: changeTime, order: DESC }
+        notes: allMdx(
+          filter: {slug: {regex: "/^TN\\d{4}/"}}
+          sort: {fields: fields___gitAuthorTime, order: DESC}
           limit: 10
         ) {
           nodes {
-            changeTime
-            childMdx {
-              id
-              fields {
-                slug
-              }
-              frontmatter {
-                title
-              }
+            id
+            fields {
+              gitAuthorTime
+              slug
+            }
+            frontmatter {
+              title
             }
           }
         }
       }
     `
   );
-  return (
-    <NotesList
-      notes={data.allFile.nodes.map(({childMdx, changeTime}) => ({
-        ...childMdx,
-        parent: {
-          changeTime
-        }
-      }))}
-    />
-  );
+  return <NotesList notes={data.notes.nodes} />;
 }

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -6,25 +6,20 @@ import {PathContext} from '../utils';
 import {graphql} from 'gatsby';
 
 export const pageQuery = graphql`
-  query ($tag: String) {
+  query AllTechNotesWithTag($tag: String) {
     notes: allMdx(
       filter: {frontmatter: {tags: {in: [$tag]}}}
       sort: {fields: frontmatter___title, order: ASC}
       limit: 2000
     ) {
-      totalCount
       nodes {
         id
         fields {
+          gitAuthorTime
           slug
         }
         frontmatter {
           title
-        }
-        parent {
-          ... on File {
-            changeTime
-          }
         }
       }
     }


### PR DESCRIPTION
The current `Last Updated` text all has the same date for tech notes. I assume this is due to the builds/deploys where all the files are updated so it clears any info we have locally


Before

![Screen Shot 2022-08-24 at 9 58 48 AM](https://user-images.githubusercontent.com/2446877/186478462-e8bc0b41-953b-433a-9f92-ed8cdbef950f.jpg)

-------------


Per some helpful StackOverflow: https://stackoverflow.com/questions/56025679/how-to-get-last-update-date-of-a-blog-post-in-gatsby-js

Add git info to MDX files so we have the accurate recent updated info for Tech Notes

After
![Screen Shot 2022-08-24 at 10 00 36 AM](https://user-images.githubusercontent.com/2446877/186478864-c0c23e67-4b71-4143-bb69-9bf56aeeae24.jpg)
