### PR TITLE
Update to use common plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ local
 .env
 .volta
 .idea
+pnpm-lock.yaml

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -172,6 +172,14 @@ const plugins = [
         }
       ]
     }
+  },
+  {
+    resolve: '@colliercz/gatsby-transformer-gitinfo',
+    // Will match all .md* files, except README.md
+    options: {
+      include: /\.md.*$/i,
+      ignore: /README/i
+    }
   }
 ];
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -177,7 +177,7 @@ const plugins = [
     resolve: '@colliercz/gatsby-transformer-gitinfo',
     // Will match all .md* files, except README.md
     options: {
-      include: /\.md.*$/i,
+      include: /\.mdx?$/i,
       ignore: /README/i
     }
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,6 @@ const {
 const {join} = require('path');
 const {v5} = require('uuid');
 const {kebabCase} = require('lodash');
-const {execSync} = require('child_process');
 
 exports.sourceNodes = ({
   actions: {createNode},
@@ -66,20 +65,6 @@ exports.onCreateNode = async ({node, getNode, loadNodeContent, actions}) => {
         name: 'slug',
         // prefix slugs with their docset path (configured by source name)
         value: join('/', sourceInstanceName, filePath)
-      });
-
-      // Add Git info to MD/MDX files for recent updated info
-      // Can replace with '@colliercz/gatsby-transformer-gitinfo' once this issues is resolved
-      //  - https://github.com/CollierCZ/gatsby-transformer-gitinfo/issues/142
-      // For now see:
-      //  - https://stackoverflow.com/questions/56025679/how-to-get-last-update-date-of-a-blog-post-in-gatsby-js
-      const gitAuthorTime = execSync(
-        `git log -1 --pretty=format:%aI ${node.fileAbsolutePath}`
-      ).toString();
-      actions.createNodeField({
-        node,
-        name: 'gitAuthorTime',
-        value: gitAuthorTime
       });
       break;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@apollo/space-kit": "8.11.0",
         "@chakra-ui/gatsby-plugin": "^2.0.3",
         "@chakra-ui/react": "^1.8.3",
+        "@colliercz/gatsby-transformer-gitinfo": "^1.3.0",
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
         "@fec/remark-a11y-emoji": "^3.1.0",
@@ -1989,8 +1990,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "license": "MIT",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3343,6 +3345,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@colliercz/gatsby-transformer-gitinfo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@colliercz/gatsby-transformer-gitinfo/-/gatsby-transformer-gitinfo-1.3.0.tgz",
+      "integrity": "sha512-cz8lh9+y49MXDMu9p6wIq5q2OhXdEn6BFbJlSYZr6so5lxht1I1ijIkmuqsUse7AgknvJD7uq2w/bmCERw6CxA==",
+      "dependencies": {
+        "@babel/runtime": "7.18.9",
+        "simple-git": "3.12.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@ctrl/tinycolor": {
@@ -11368,8 +11385,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "license": "MIT",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -25872,17 +25890,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/netlify-cli/node_modules/@babel/runtime": {
-      "version": "7.17.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/netlify-cli/node_modules/@babel/template": {
       "version": "7.16.7",
       "dev": true,
@@ -30540,27 +30547,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/netlify-cli/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/netlify-cli/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/netlify-cli/node_modules/decache": {
       "version": "4.6.1",
@@ -37619,11 +37605,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/netlify-cli/node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/netlify-cli/node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -45520,6 +45501,20 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-git": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.12.0.tgz",
+      "integrity": "sha512-cy1RSRFHGZSrlYa3MnUuNVOXLUdifEZD2X8+AZjg8mKCdRvtCFSga6acq5N2g0ggb8lH3jBi369MrFZ+Y6sfsA==",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "license": "MIT",
@@ -50113,7 +50108,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -51072,6 +51069,15 @@
           "version": "0.1.2",
           "dev": true
         }
+      }
+    },
+    "@colliercz/gatsby-transformer-gitinfo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@colliercz/gatsby-transformer-gitinfo/-/gatsby-transformer-gitinfo-1.3.0.tgz",
+      "integrity": "sha512-cz8lh9+y49MXDMu9p6wIq5q2OhXdEn6BFbJlSYZr6so5lxht1I1ijIkmuqsUse7AgknvJD7uq2w/bmCERw6CxA==",
+      "requires": {
+        "@babel/runtime": "7.18.9",
+        "simple-git": "3.12.0"
       }
     },
     "@ctrl/tinycolor": {
@@ -56455,7 +56461,9 @@
       "version": "2.25.0"
     },
     "debug": {
-      "version": "4.3.2",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -65827,13 +65835,6 @@
             "esutils": "^2.0.2"
           }
         },
-        "@babel/runtime": {
-          "version": "7.17.0",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "@babel/template": {
           "version": "7.16.7",
           "dev": true,
@@ -68821,19 +68822,6 @@
           "dev": true,
           "requires": {
             "time-zone": "^1.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "dev": true
-            }
           }
         },
         "decache": {
@@ -73406,10 +73394,6 @@
           "requires": {
             "regenerate": "^1.4.2"
           }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.9",
-          "dev": true
         },
         "regenerator-transform": {
           "version": "0.14.5",
@@ -78328,6 +78312,16 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-git": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.12.0.tgz",
+      "integrity": "sha512-cy1RSRFHGZSrlYa3MnUuNVOXLUdifEZD2X8+AZjg8mKCdRvtCFSga6acq5N2g0ggb8lH3jBi369MrFZ+Y6sfsA==",
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
       }
     },
     "simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@apollo/space-kit": "8.11.0",
     "@chakra-ui/gatsby-plugin": "^2.0.3",
     "@chakra-ui/react": "^1.8.3",
+    "@colliercz/gatsby-transformer-gitinfo": "^1.3.0",
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
     "@fec/remark-a11y-emoji": "^3.1.0",

--- a/src/components/TechNotes/NotesList.js
+++ b/src/components/TechNotes/NotesList.js
@@ -7,15 +7,15 @@ export function NotesList({notes}) {
   return (
     <List spacing="1">
       {notes.map(note => (
-        <ListItem key={note.id}>
+        <ListItem key={note.childMdx.id}>
           <Flex justify="space-between">
-            <RelativeLink href={note.fields.slug}>
-              {note.frontmatter.title}
+            <RelativeLink href={note.childMdx.fields.slug}>
+              {note.childMdx.frontmatter.title}
             </RelativeLink>
             <span>
               Last Updated{' '}
               {new Intl.DateTimeFormat('en-US').format(
-                new Date(note.fields.gitAuthorTime)
+                new Date(note.fields.gitLogLatestDate)
               )}
             </span>
           </Flex>

--- a/src/components/TechNotes/RecentNotes.js
+++ b/src/components/TechNotes/RecentNotes.js
@@ -6,19 +6,23 @@ export function RecentNotes() {
   const data = useStaticQuery(
     graphql`
       query RecentTechNotes {
-        notes: allMdx(
-          filter: {slug: {regex: "/^TN\\d{4}/"}}
-          sort: {fields: fields___gitAuthorTime, order: DESC}
+        notes: allFile(
+          filter: {childMdx: {slug: {regex: "/^TN\\d{4}/"}}}
+          sort: {fields: fields___gitLogLatestDate, order: DESC}
           limit: 10
         ) {
           nodes {
-            id
             fields {
-              gitAuthorTime
-              slug
+              gitLogLatestDate
             }
-            frontmatter {
-              title
+            childMdx {
+              id
+              fields {
+                slug
+              }
+              frontmatter {
+                title
+              }
             }
           }
         }

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -7,19 +7,23 @@ import {graphql} from 'gatsby';
 
 export const pageQuery = graphql`
   query AllTechNotesWithTag($tag: String) {
-    notes: allMdx(
-      filter: {frontmatter: {tags: {in: [$tag]}}}
-      sort: {fields: frontmatter___title, order: ASC}
+    notes: allFile(
+      filter: {childMdx: {frontmatter: {tags: {in: [$tag]}}}}
+      sort: {fields: childMdx___frontmatter___title, order: ASC}
       limit: 2000
     ) {
       nodes {
-        id
         fields {
-          gitAuthorTime
-          slug
+          gitLogLatestDate
         }
-        frontmatter {
-          title
+        childMdx {
+          id
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+          }
         }
       }
     }


### PR DESCRIPTION
Update to use a community plugin to get git info

https://github.com/CollierCZ/gatsby-transformer-gitinfo

From the original PR we were running some custom git commands from node. This plugin instead can be used which has some extra safety checks: https://github.com/apollographql/docs/pull/197

I needed to wait for this issue to be resolved first: https://github.com/CollierCZ/gatsby-transformer-gitinfo/issues/142