### PR TITLE
Document use of staging credentials for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ You can publish docsets that are viewable only by Apollo team members by setting
 
 If a visitor to that page is logged in to Apollo Studio **and** is a member of one of our internal orgs, the page content will be rendered normally. If neither of those conditions are true, a 404 page will be shown. Internal-only pages are excluded from the sitemap and won't be indexed by Google.
 
-It's important to note that you must sign in to and out of your account using Studio or Odyssey, as the docs don't currently have their own sign in form.
+It's important to note that you must sign in to and out of your account using Studio or Odyssey, as the docs don't currently have their own sign in form. For local development, sign in to the staging Studio.
 
 ### Redirect rules
 


### PR DESCRIPTION
Internal-only docsets can be accessed locally using staging credentials.