### PR TITLE
Updated remark parsing and added extra code block props

### DIFF
--- a/.changeset/cool-badgers-cover.md
+++ b/.changeset/cool-badgers-cover.md
@@ -1,0 +1,5 @@
+---
+"@apollo/chakra-helpers": patch
+---
+
+Added additional props for better tab control and a fallback to local tabs if a global context does not exist

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "rehype-react": "^7.0.3",
         "remark": "^14.0.2",
         "remark-react": "^9.0.1",
-        "remark-typescript": "^0.5.3",
+        "remark-typescript": "^0.5.4",
         "search-insights": "^1.8.0",
         "stream-http": "^3.2.0",
         "unist-util-visit": "^2.0.3",
@@ -44598,9 +44598,9 @@
       }
     },
     "node_modules/remark-typescript": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.3.tgz",
-      "integrity": "sha512-KsiKSgqGwmq4n3hxPvo6/BHDeFXyKJ/j7g+wEQ1IS+mqDRbh0qBQEWGY+zDMZnYTaXrDJgL6xHQUJaUroTF7Fg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.4.tgz",
+      "integrity": "sha512-aHVtTPpMOTCB/c3eRJETsCiUIxFTEyUDs7K/MN7syB6RY43XuSZ1XE7M7Brq1Z9mfmuQZr5+6Jai19RtBMOtXA==",
       "dependencies": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",
@@ -77864,9 +77864,9 @@
       }
     },
     "remark-typescript": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.3.tgz",
-      "integrity": "sha512-KsiKSgqGwmq4n3hxPvo6/BHDeFXyKJ/j7g+wEQ1IS+mqDRbh0qBQEWGY+zDMZnYTaXrDJgL6xHQUJaUroTF7Fg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/remark-typescript/-/remark-typescript-0.5.4.tgz",
+      "integrity": "sha512-aHVtTPpMOTCB/c3eRJETsCiUIxFTEyUDs7K/MN7syB6RY43XuSZ1XE7M7Brq1Z9mfmuQZr5+6Jai19RtBMOtXA==",
       "requires": {
         "@babel/core": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "rehype-react": "^7.0.3",
     "remark": "^14.0.2",
     "remark-react": "^9.0.1",
-    "remark-typescript": "^0.5.3",
+    "remark-typescript": "^0.5.4",
     "search-insights": "^1.8.0",
     "stream-http": "^3.2.0",
     "unist-util-visit": "^2.0.3",

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -101,6 +101,7 @@ export type CodeBlockProps = {
   hidden?: boolean;
   code: string;
   isPartOfMultiCode?: boolean;
+  disableTabs?: boolean;
 };
 
 export const CodeBlock = ({
@@ -111,7 +112,8 @@ export const CodeBlock = ({
   linesToHighlight = [],
   hidden: defaultHidden = false,
   disableCopy = false,
-  isPartOfMultiCode = false
+  isPartOfMultiCode = false,
+  disableTabs = false
 }: CodeBlockProps): JSX.Element => {
   const {onCopy, hasCopied} = useClipboard(
     getCodeWithoutHighlightComments(code)
@@ -129,7 +131,7 @@ export const CodeBlock = ({
 
   return (
     <Box>
-      {!isPartOfMultiCode && (
+      {!isPartOfMultiCode && !disableTabs && (
         <CodeBlockTabs
           languages={[blockLanguage]}
           activeLanguage={blockLanguage}
@@ -214,7 +216,7 @@ export const CodeBlock = ({
                       )
                       .map((line, i) => {
                         const shouldHighlight =
-                          // if the line number exists in the metastring or highlight comment ranges
+                          // if the line number exists in the meta string or highlight comment ranges
                           linesToHighlight
                             .concat(highlightRange)
                             .includes(i + 1) ||

--- a/packages/chakra-helpers/src/CodeBlockTabs.tsx
+++ b/packages/chakra-helpers/src/CodeBlockTabs.tsx
@@ -48,11 +48,13 @@ function getTabButtonProps(
 interface CodeBlockTabsProps {
   languages: string[];
   activeLanguage: string;
+  setLanguage?: (language: string) => void;
 }
 
 export const CodeBlockTabs = ({
   languages,
-  activeLanguage
+  activeLanguage,
+  setLanguage
 }: CodeBlockTabsProps): JSX.Element => {
   // Track inner (infinite width) and outer (container width) boxes using refs
   const outerRef = useRef<HTMLDivElement>(null);
@@ -77,13 +79,11 @@ export const CodeBlockTabs = ({
   // Allow for arrow presses to induce a short scroll left or right
   const bumpScroll = (distance: number) => () => {
     if (!outerRef) return;
-    outerRef.current.scrollBy({
+    outerRef.current?.scrollBy({
       left: distance,
       behavior: 'smooth'
     });
   };
-
-  const {setLanguage} = useContext(MultiCodeBlockContext);
 
   const theme = usePrismTheme();
   const bgColor = useToken('colors', 'gray.800');
@@ -136,7 +136,9 @@ export const CodeBlockTabs = ({
               leftIcon={getIconComponent(language)}
               key={language}
               onClick={() => {
-                setLanguage(language);
+                if (setLanguage) {
+                  setLanguage(language);
+                }
                 window.gtag?.('event', 'Change language', {
                   event_category: GA_EVENT_CATEGORY_CODE_BLOCK,
                   event_label: language

--- a/packages/chakra-helpers/src/MultiCodeBlock.tsx
+++ b/packages/chakra-helpers/src/MultiCodeBlock.tsx
@@ -2,7 +2,8 @@ import React, {
   ReactNode,
   createContext,
   isValidElement,
-  useContext
+  useContext,
+  useState
 } from 'react';
 import {Box, Flex} from '@chakra-ui/react';
 import {CodeBlockProps} from './CodeBlock';
@@ -32,17 +33,26 @@ export const MultiCodeBlock = ({
     });
   }, {});
 
-  const {language} = useContext(MultiCodeBlockContext);
+  const codeBlockContext = useContext(MultiCodeBlockContext);
 
   const languages = Object.keys(codeBlocks);
   const defaultLanguage = languages[0];
+  const [localLanguage, setLocalLanguage] = useState(languages[0]);
+  const language = codeBlockContext ? codeBlockContext.language : localLanguage;
+  const setLanguage = codeBlockContext
+    ? codeBlockContext.setLanguage
+    : setLocalLanguage;
   const renderedLanguage = languages.includes(language)
     ? language
     : defaultLanguage;
 
   return (
     <Flex flexDir="column" pt="6">
-      <CodeBlockTabs languages={languages} activeLanguage={renderedLanguage} />
+      <CodeBlockTabs
+        languages={languages}
+        activeLanguage={renderedLanguage}
+        setLanguage={setLanguage}
+      />
       {languages.map(language => (
         <Box
           key={language}


### PR DESCRIPTION
Updated typescript remark parser to fix pattern matching issue found in some imports for TS code blocks. See below (yes there are import statements at the end of a couple hundred comment tokens 😄 )

<img width="774" alt="Screen Shot 2022-09-01 at 5 22 01 PM" src="https://user-images.githubusercontent.com/4239999/188015426-39e0dc92-364b-4769-90f4-c0e6e713e9fe.png">

This update also introduces additional props to the `CodeBlock` component and implements a fallback to "local" tabs if the global context is not available. Useful for things other than the docs!
