### PR TITLE
Only render code block tabs if  is truthy

### DIFF
--- a/.changeset/pretty-waves-hug.md
+++ b/.changeset/pretty-waves-hug.md
@@ -1,0 +1,5 @@
+---
+"@apollo/chakra-helpers": patch
+---
+
+Only show code block tabs for multi code blocks

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -129,7 +129,7 @@ export const CodeBlock = ({
 
   return (
     <Box>
-      {!isPartOfMultiCode && (
+      {isPartOfMultiCode && (
         <CodeBlockTabs
           languages={[blockLanguage]}
           activeLanguage={blockLanguage}


### PR DESCRIPTION
This PR removes the bang to only render the `CodeBlockTabs` if `isPartOfMultiCode` is truthy. Otherwise an error throws for "normal" `CodeBlocks` that don't have a `MultiCodeBlockContext` needed in the `CodeBlockTabs` component.