### PR TITLE
Update editor-plugins.md

### DIFF
--- a/src/content/basics/devtools/editor-plugins.md
+++ b/src/content/basics/devtools/editor-plugins.md
@@ -150,4 +150,4 @@ Sometimes errors will show up as a notification at the bottom of your editor. Ot
 
 <img src="../img/editors/stats.gif" width="80%" style="margin: 5%" alt="Clicking the status bar icon to open the output pane">
 
-If problems persist or the error messages are unhelpful, an [issue](https://github.com/apollographql/apollo-tooling/issues) can be opened on the `apollo-tooling` repository.
+If problems persist or the error messages are unhelpful, an [issue](https://github.com/apollographql/vscode-graphql/issues) can be opened on the `apollo-tooling` repository.


### PR DESCRIPTION
This is linking to the deprecated plugin repo, I've updated it to new location. I stumbled upon this while reviewing the extension documentation and noticed a few frustrated users on the deprecated repo -- I think this might help reduce frustration.