### PR TITLE
Allow changeset to write to the pull request API

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
The changeset errors out when calling the pull request API due to the GitHub job changes made earlier. See [here](https://github.com/apollographql/docs/runs/8240087228?check_suite_focus=true)

This change allows the changeset job to write (create) the pull request and _should_ fix the erroneous job.