### PR TITLE
Added reference and link to document option

### DIFF
--- a/src/content/graphos/explorer/embed-explorer.mdx
+++ b/src/content/graphos/explorer/embed-explorer.mdx
@@ -322,9 +322,9 @@ These are the fields you can include in the `initialState` option you pass to `n
 </td>
 <td>
 
-A URI-encoded operation to populate in the Explorer's editor on load.
+A URI-encoded operation to populate in the embedded Explorer's editor on load.
 
-If you omit this, the Explorer initially loads an example query based on your schema.
+If you omit this option, the Explorer initially loads an example query based on your schema. To tell the embedded Explorer the specific operation you'd like it to use in the editor, see [Setting a default operation](#setting-a-default-operation) above. 
 
 If [`persistExplorerState`](#persistexplorerstate) is `true` _and_ you provide this option, the Explorer loads any of the user's tabs from `localStorage`, and it _also_ opens a _new_ tab with this operation.
 

--- a/src/content/graphos/explorer/embed-explorer.mdx
+++ b/src/content/graphos/explorer/embed-explorer.mdx
@@ -324,7 +324,9 @@ These are the fields you can include in the `initialState` option you pass to `n
 
 A URI-encoded operation to populate in the embedded Explorer's editor on load.
 
-If you omit this option, the Explorer initially loads an example query based on your schema. To tell the embedded Explorer the specific operation you'd like it to use in the editor, see [Setting a default operation](#setting-a-default-operation) above. 
+If you omit this option, the Explorer initially loads an example query based on your schema.
+
+If you use one of the sharing methods described in [Setting a default operation](#setting-a-default-operation), the generated code snippet automatically sets this option with the details of the operation you used.
 
 If [`persistExplorerState`](#persistexplorerstate) is `true` _and_ you provide this option, the Explorer loads any of the user's tabs from `localStorage`, and it _also_ opens a _new_ tab with this operation.
 


### PR DESCRIPTION
The `document` option currently does not mention that you can set a default operation for the editor to show. I have added a new sentence to the `document` section and a link to another section of the page that details how to set a specific operation for the embedded Explorer to use in the editor. I also did some minor refactoring of the `document` section to improve readability after I added the new sentence.