### PR TITLE
chore: single quote commit message

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: 14
 
       - name: Trigger deploy
-        run: npx netlify deploy --trigger --prod --message "${{ github.event.head_commit.message }}"
+        run: npx netlify deploy --trigger --prod --message $(echo ${{ github.event.head_commit.message }} | head -n 1)
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
a recent [rover deploy ](https://github.com/apollographql/rover/actions/runs/3161398091/jobs/5146937987)attempted to publish the docs, but the commit message was more than one line, so it failed with this output:

```
npx netlify deploy --trigger --prod --message "release: v0.9.1 (#1359)
  
  # [0.9.1] - 2022-09-30
  
  ## 🚀 Features
  
  - **Add templates for TypeScript, Go, Kotlin, and Java - @dbanty,
  #1347**
  
    The `rover template` commands now include four more languages.
  
  ## 🐛 Fixes
  
  - **Properly report errors when the first `rover dev` process starts up
  - @EverlastingBugstopper, #1342**
  
  If something went wrong while starting the first `rover dev` process, it
  would attempt to start an attached process, which would fail with an
  inscrutable `the main rover dev session is no longer active` error
  message. Now, Rover properly reports issues with starting up the first
  `rover dev` session.
  
  - **Properly report plugin installation errors on `rover dev` startup -
  @EverlastingBugstopper, #1357**
    
  If a plugin failed to install when starting `rover dev`, the error
  wouldn't be reported properly. Now, if something goes wrong, the error
  message will be printed properly.
  
  - **Replace some misleading error suggestions regarding ports with
  `rover dev` - @EverlastingBugstopper, #1340**
  
  Some errors suggested retrying the `rover dev` command with a different
  `--port` argument, which doesn't exist. In these cases, `rover dev` will
  suggest that you specify a different `--supergraph-port` argument
  instead.
  
  - **Don't exclude certain git remotes from `GitContext` -
  @EverlastingBugstopper, #1350 fixes #1349**
  
  In v0.8.2, we started normalizing git remotes for anonymized telemetry.
  Unfortunately we started excluding git remotes that were not one of
  BitBucket, GitLab, or GitHub. We now record all of these properly.
  
  ## 🛠 Maintenance
  
  - **Fix typo in `rover subgraph publish` output -
  @EverlastingBugstopper, #1358 fixes #1337**
  
  Instead of saying "Monitor your schema delivery progresson studio",
  `rover subgraph publish` outputs "You can monitor this launch in Apollo
  Studio".
  
  - **Improve caching in CI - @EverlastingBugstopper, #1351 and #1352**
  
  In CI builds, we now cache `/target` _and_ `~/.cargo`, instead of just
  `/target`.
  
  - **Specify all dependencies in root `Cargo.toml` -
  @EverlastingBugstopper, #1344**
  
  All of Rover's dependencies can now be viewed and updated in the root
  `Cargo.toml`, rather than needing to hunt around the workspace to update
  crates.
  
  - **Updates dependencies - @EverlastingBugstopper, #1346**
  
    - assert_cmd 1 -> 2
    - git2 0.14 -> 0.15
    - online 3.0.1 -> 4.0.0"
  shell: /usr/bin/bash -e {0}
  env:
    NETLIFY_SITE_ID: ***
    NETLIFY_AUTH_TOKEN: ***
##[debug]/usr/bin/bash -e /home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: the: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: --port: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: --supergraph-port: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: GitContext: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 1: rover: command not found
◈ Netlify Dev ◈ A new deployment was triggered successfully. Visit https://app.netlify.com/sites/apollo-monodocs/deploys/63374d61328e4[306](https://github.com/apollographql/rover/actions/runs/3161398091/jobs/5146937987#step:4:306)4d3ddf02 to see the logs.
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: /target: No such file or directory
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: /home/runner/.cargo: Is a directory
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: /target: No such file or directory
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: Cargo.toml: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: Cargo.toml: command not found
/home/runner/work/_temp/95223af1-cebb-4c5f-8f77-af4998885ba8.sh: line 70: $'Studio.\r\n\r\n- **Improve caching in CI - @EverlastingBugstopper, #1351 and #1352**\r\n\r\nIn CI builds, we now cache  _and_ , instead of just\r\n.\r\n\r\n- **Specify all dependencies in root  -\r\n@EverlastingBugstopper, #1344**\r\n\r\nAll of Rover\'s dependencies can now be viewed and updated in the root\r\n, rather than needing to hunt around the workspace to update\r\ncrates.\r\n\r\n- **Updates dependencies - @EverlastingBugstopper, #1346**\r\n\r\n  - assert_cmd 1 -> 2\r\n  - git2 0.14 -> 0.15\r\n  - online 3.0.1 -> 4.0.0': command not found
```

not great!

this PR _attempts_ to fix this by piping the output of the commit message to `head -n 1` which _should_ only take the first line of the output, and set that as the message for the deploy. 

i'm not sure the best way to go about testing this....