### PR TITLE
docs: Adds apollo-ios legacy version branch

### DIFF
--- a/sources/remote.js
+++ b/sources/remote.js
@@ -28,9 +28,9 @@ module.exports = {
     remote: 'https://github.com/apollographql/apollo-ios',
     branch: 'main'
   },
-  'ios/v1': {
+  'ios/v0-legacy': {
     remote: 'https://github.com/apollographql/apollo-ios',
-    branch: 'release/1.0'
+    branch: '0.x-legacy'
   },
   kotlin: {
     remote: 'https://github.com/apollographql/apollo-kotlin',


### PR DESCRIPTION
This adds a branch that points to the apollo-ios legacy documentation set branch; `0.x-legacy`.