### PR TITLE
workflows: properly escape commit/PR messages

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,8 +41,11 @@ jobs:
 
       - name: Publish
         id: publish
+        env:
+           # Passing this through an env var allows for proper escaping.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          deploy_output=$( npx netlify deploy --json --message "${{ github.event.pull_request.title }}" )
+          deploy_output=$( npx netlify deploy --json --message "${PR_TITLE}" )
           deploy_url=$( echo $deploy_output | jq '.deploy_url' )
           echo "::set-output name=deploy_url::$deploy_url"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
           node-version: 14
 
       - name: Trigger deploy
-        run: npx netlify deploy --trigger --prod --message "${{ github.event.head_commit.message }}"
+        run: npx netlify deploy --trigger --prod --message "${COMMIT_MESSAGE}"
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          # Passing this through an env var allows for proper escaping.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Substituting directly into the command-line fails if there are quotes in the message, but going through an env var is OK:

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable