### PR TITLE
Make algolia filter conditions exclusive

### DIFF
--- a/algolia/index.js
+++ b/algolia/index.js
@@ -40,19 +40,13 @@ async function transformer({data}) {
 
   const allPages = allMarkdownRemark.nodes.concat(allMdx.nodes);
   const records = allPages
-    .filter(page => {
-      // exclude internal-only pages
-      if (!isInternal[page.parent.sourceInstanceName]) {
-        return true;
-      }
-
-      // exclude ios API pages that match the pattern /ios/api/ or /ios/*/api/
-      if (!page.fields.slug.match(/\/ios\/(.*\/)?api\/?/)) {
-        return true;
-      }
-
-      return false;
-    })
+    .filter(
+      page =>
+        // pages must not be internal, AND
+        !isInternal[page.parent.sourceInstanceName] &&
+        // must also not match the pattern /ios/api/ or /ios/*/api/
+        !/\/ios\/(.*\/)?api\/?/.test(page.fields.slug)
+    )
     // create multiple records per page, but keep a flat array
     .flatMap(page => {
       const {


### PR DESCRIPTION
@jgarrow I picked up on this after we had already approved and merged your previous PR (#248), but I noticed the way the condition was refactored in that PR would actually cause all pages to be indexed.

The code now checks to see if a page is _not_ internal, and then include it in the array of pages to be indexed by returning `true`. If a page did not meet this condition, the next `if` statement would be evaluated, checking to see if the page in question matched a regex. That means that _only_ internal pages would be subject to this check, and since no internal pages have slugs that match `/ios/*/api`, the condition would be satisfied and the filter function would return `true`.

What we should do instead is check for the negative condition first, and exit early for pages that do not satisfy our requirements. So first checking to see if the page _is_ internal, and then returning `false`. Then, if the page is deemed not internal, checking to see if its slug matches the path that we don't want indexed, and again returning `false`. If the page passes both of those checks, we can finally return `true`.

Alternatively we could one-line this and just say the condition for pages to be indexed is they must be both external-facing AND not have the `/ios/*/api` path.