### PR TITLE
Ensure extended width gets applied

### DIFF
--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -3,7 +3,13 @@ import Footer from './Footer';
 import Header, {TOTAL_HEADER_HEIGHT} from './Header';
 import MobileNav from './MobileNav';
 import PropTypes from 'prop-types';
-import React, {Fragment, useCallback, useContext} from 'react';
+import React, {
+  Fragment,
+  useCallback,
+  useContext,
+  useEffect,
+  useState
+} from 'react';
 import Sidebar, {
   SIDEBAR_WIDTH_BASE,
   SIDEBAR_WIDTH_XL,
@@ -87,6 +93,12 @@ export default function Page({
     [docset, versions, currentVersion]
   );
 
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    setNow(Date.now());
+  }, []);
+
   return (
     <>
       <GatsbySeo
@@ -155,6 +167,7 @@ export default function Page({
       >
         {banner}
         <Flex
+          key={now}
           ref={pageRefCallback}
           maxW={pageWidthPx}
           mx="auto"

--- a/src/components/PageWidthContext.js
+++ b/src/components/PageWidthContext.js
@@ -3,7 +3,6 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useRef,
   useState
 } from 'react';
@@ -47,10 +46,6 @@ export const PAGE_JUMBO_WIDTH = 1800;
  * @param {{children: React.ReactNode}} props
  */
 export const PageWidthProvider = ({children}) => {
-  const [, tick] = useState(0);
-  useEffect(() => {
-    tick(t => t + 1);
-  }, []);
   const [pageWidth, setPageWidth] = useLocalStorage('page-width', 'normal');
   const [showExpandButton, setShowExpandButton] = useState(false);
   /**


### PR DESCRIPTION
This PR adds a unique `key` to the page wrapper div that changes when the component mounts, ensuring that the div gets rerendered with the appropriate max width.