### PR TITLE
Add tooltips to docset switcher buttons

### DIFF
--- a/src/components/DocsetMenu/DocsetButton.js
+++ b/src/components/DocsetMenu/DocsetButton.js
@@ -1,23 +1,37 @@
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import path from 'path';
-import {Button} from '@chakra-ui/react';
+import {Button, Link, Tooltip} from '@chakra-ui/react';
 import {Link as GatsbyLink} from 'gatsby';
 import {PathContext} from '../../utils';
 
-export default function DocsetButton({to, ...props}) {
+export default function DocsetButton({to, tooltipLabel, ...props}) {
   const {basePath} = useContext(PathContext);
   const [docsetPath] = basePath.split(path.sep);
+
+  const linkProps = to?.startsWith('/')
+    ? {
+        as: GatsbyLink,
+        to
+      }
+    : {
+        as: Link,
+        href: to,
+        isExternal: true
+      };
+
   return (
-    <Button
-      as={GatsbyLink}
-      to={to}
-      colorScheme={path.join('/', docsetPath) === to ? 'indigo' : 'gray'}
-      {...props}
-    />
+    <Tooltip hasArrow label={tooltipLabel} placement="top">
+      <Button
+        {...linkProps}
+        colorScheme={path.join('/', docsetPath) === to ? 'indigo' : 'gray'}
+        {...props}
+      />
+    </Tooltip>
   );
 }
 
 DocsetButton.propTypes = {
-  to: PropTypes.string.isRequired
+  to: PropTypes.string.isRequired,
+  tooltipLabel: PropTypes.string.isRequired
 };

--- a/src/components/DocsetMenu/DocsetButton.js
+++ b/src/components/DocsetMenu/DocsetButton.js
@@ -15,9 +15,9 @@ export default function DocsetButton({to, tooltipLabel, ...props}) {
         to
       }
     : {
-        as: Link,
+        as: 'a',
         href: to,
-        isExternal: true
+        target: '_blank'
       };
 
   return (

--- a/src/components/DocsetMenu/DocsetButton.js
+++ b/src/components/DocsetMenu/DocsetButton.js
@@ -21,13 +21,7 @@ export default function DocsetButton({to, tooltipLabel, ...props}) {
       };
 
   return (
-    <Tooltip
-      hasArrow
-      label={tooltipLabel}
-      placement="top"
-      fontSize="md"
-      bg="primary"
-    >
+    <Tooltip hasArrow label={tooltipLabel} placement="bottom">
       <Button
         {...linkProps}
         colorScheme={path.join('/', docsetPath) === to ? 'indigo' : 'gray'}

--- a/src/components/DocsetMenu/DocsetButton.js
+++ b/src/components/DocsetMenu/DocsetButton.js
@@ -21,7 +21,13 @@ export default function DocsetButton({to, tooltipLabel, ...props}) {
       };
 
   return (
-    <Tooltip hasArrow label={tooltipLabel} placement="top">
+    <Tooltip
+      hasArrow
+      label={tooltipLabel}
+      placement="top"
+      fontSize="md"
+      bg="primary"
+    >
       <Button
         {...linkProps}
         colorScheme={path.join('/', docsetPath) === to ? 'indigo' : 'gray'}

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -147,7 +147,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-client']}
                 to="/react"
-                tooltipLabel="Apollo Client for React"
+                tooltipLabel="GraphQL client library for React and JavaScript"
               >
                 React
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -92,7 +92,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 to="https://www.apollographql.com/tutorials/"
                 leftIcon={DOCSET_ICONS.odyssey}
-                tooltipLabel="Apollo tutorials"
+                tooltipLabel="Fun, interactive courses with videos and assessments"
               >
                 Odyssey Tutorials
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -124,7 +124,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS.router}
                 to="/router"
-                tooltipLabel="Routing for supergraphs"
+                tooltipLabel="High-performance router executable for self-hosted supergraphs"
               >
                 Router
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -161,7 +161,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-kotlin']}
                 to="/kotlin"
-                tooltipLabel="Apollo Client for Kotlin"
+                tooltipLabel="GraphQL client library for Kotlin and Android"
               >
                 Kotlin
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -154,7 +154,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-ios']}
                 to="/ios"
-                tooltipLabel="Apollo Client for iOS"
+                tooltipLabel="GraphQL client library for iOS"
               >
                 iOS
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -85,7 +85,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 to="/"
                 leftIcon={DOCSET_ICONS.default}
-                tooltipLabel="Home page"
+                tooltipLabel="Introduction to Apollo"
               >
                 Docs Home
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -131,7 +131,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS.rover}
                 to="/rover"
-                tooltipLabel="CLI for managing graphs"
+                tooltipLabel="Command-line tool for managing graphs"
               >
                 Rover CLI
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -108,7 +108,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS.federation}
                 to="/federation"
-                tooltipLabel="Build a unified supergraph"
+                tooltipLabel="Architecture for building a unified supergraph from multiple GraphQL APIs"
               >
                 Federation
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -138,7 +138,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS.technotes}
                 to="/technotes"
-                tooltipLabel="Technical articles for specialized topics"
+                tooltipLabel="In-depth articles on specialized topics"
               >
                 Tech Notes
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -101,7 +101,7 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS.graphos}
                 to="/graphos"
-                tooltipLabel="A cloud platform for your supergraph"
+                tooltipLabel="Cloud platform for building, managing, and collaborating on your supergraph"
               >
                 GraphOS
               </DocsetButton>

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -82,21 +82,34 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
           <ModalCloseButton />
           <Stack spacing="4" p="6">
             <DocsetGroup title="Get started">
-              <DocsetButton to="/" leftIcon={DOCSET_ICONS.default}>
+              <DocsetButton
+                to="/"
+                leftIcon={DOCSET_ICONS.default}
+                tooltipLabel="Home page"
+              >
                 Docs Home
               </DocsetButton>
               <DocsetButton
                 to="https://www.apollographql.com/tutorials/"
                 leftIcon={DOCSET_ICONS.odyssey}
+                tooltipLabel="Apollo tutorials"
               >
                 Odyssey Tutorials
               </DocsetButton>
             </DocsetGroup>
             <DocsetGroup title="Build your supergraph">
-              <DocsetButton leftIcon={DOCSET_ICONS.graphos} to="/graphos">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS.graphos}
+                to="/graphos"
+                tooltipLabel="A cloud platform for your supergraph"
+              >
                 GraphOS
               </DocsetButton>
-              <DocsetButton leftIcon={DOCSET_ICONS.federation} to="/federation">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS.federation}
+                to="/federation"
+                tooltipLabel="Build a unified supergraph"
+              >
                 Federation
               </DocsetButton>
             </DocsetGroup>
@@ -104,16 +117,29 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-server']}
                 to="/apollo-server"
+                tooltipLabel="Apollo Server docs"
               >
                 Server
               </DocsetButton>
-              <DocsetButton leftIcon={DOCSET_ICONS.router} to="/router">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS.router}
+                to="/router"
+                tooltipLabel="Routing for supergraphs"
+              >
                 Router
               </DocsetButton>
-              <DocsetButton leftIcon={DOCSET_ICONS.rover} to="/rover">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS.rover}
+                to="/rover"
+                tooltipLabel="CLI for managing graphs"
+              >
                 Rover CLI
               </DocsetButton>
-              <DocsetButton leftIcon={DOCSET_ICONS.technotes} to="/technotes">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS.technotes}
+                to="/technotes"
+                tooltipLabel="Technical articles for specialized topics"
+              >
                 Tech Notes
               </DocsetButton>
             </DocsetGroup>
@@ -121,15 +147,21 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-client']}
                 to="/react"
+                tooltipLabel="Apollo Client for React"
               >
                 React
               </DocsetButton>
-              <DocsetButton leftIcon={DOCSET_ICONS['apollo-ios']} to="/ios">
+              <DocsetButton
+                leftIcon={DOCSET_ICONS['apollo-ios']}
+                to="/ios"
+                tooltipLabel="Apollo Client for iOS"
+              >
                 iOS
               </DocsetButton>
               <DocsetButton
                 leftIcon={DOCSET_ICONS['apollo-kotlin']}
                 to="/kotlin"
+                tooltipLabel="Apollo Client for Kotlin"
               >
                 Kotlin
               </DocsetButton>


### PR DESCRIPTION
This PR adds tooltips to the docset switcher buttons to provide brief descriptions. It also updates the `DocsetButton` component to handle internal vs external links (the Odyssey one has been throwing an error). `DocsetButtons` now accept an additional, required `tooltipLabel` string prop. 

https://user-images.githubusercontent.com/32886852/197271692-368fc112-7021-4503-9dcb-6b0db9b90817.mov

