### PR TITLE
redirect schema-reporting links

### DIFF
--- a/src/content/graphos/_redirects
+++ b/src/content/graphos/_redirects
@@ -1,4 +1,5 @@
 /schema/registry/ /docs/graphos/org/graphs/
+/schema/schema-reporting /docs/graphos/schema/cli-registration/
 
 /dev-graphs/ /docs/graphos/
 /operation-registry/ /docs/graphos/


### PR DESCRIPTION
trying to pattern-match the other redirect  to redirect   

https://www.apollographql.com/docs/studio/schema/schema-reporting/#registering-to-a-variant-with-schema-reporting
 to 
https://www.apollographql.com/docs/graphos/schema/cli-registration/