### PR TITLE
Allow for optional `versionBanner` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ The `config.json` file lives at the root of its docset's content directory, and 
 {
   "title": "Apollo Server",
   "version": "v3",
+  "versionBanner": {
+    "link": "/v3-deprecation-page",
+    "content": "Check out the deprecation page."
+  },
   "algoliaFilters": ["docset:server", ["docset:react", "docset:federation"]],
   "sidebar": {
     "Introduction": "/",
@@ -152,6 +156,7 @@ The `config.json` file lives at the root of its docset's content directory, and 
 | version        | no        | A string representing the version of the software that is being documented, i.e. "v3". This value is shown in the version dropdown if multiple versions of a docset are configured.                                                                                                                               |
 | algoliaFilters | no        | An array of filters that affect the ranking of search results when a search is made within a particular docset. This is passed to Algolia as an `optionalFilters` parameter, which you can learn more about [here](https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/).                    |
 | internal       | no        | Set to `true` if you want your docset to be [internal-only](#internal-only-docsets).                                                                                                                                                                                                                              |
+| versionBanner  | no        | A JSON object used to customize the `VersionBanner` link url and text.                                                                                                                                                                                                                                            |
 
 ### Adding a local docset
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -131,9 +131,10 @@ exports.createPages = async ({actions, graphql}) => {
 
   const configs = data.configs.nodes.reduce((acc, node) => {
     // TODO: convert configs to YAML
-    const {title, version, sidebar, algoliaFilters, internal} = JSON.parse(
-      node.fields.content
-    );
+    const content = JSON.parse(node.fields.content);
+    const {title, version, sidebar, algoliaFilters, internal, versionBanner} =
+      content;
+
     return {
       ...acc,
       [node.sourceInstanceName]: {
@@ -141,7 +142,8 @@ exports.createPages = async ({actions, graphql}) => {
         currentVersion: version,
         navItems: getNavItems(sidebar),
         algoliaFilters,
-        internal
+        internal,
+        versionBanner
       }
     };
   }, {});

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -195,7 +195,7 @@ export default function Page({file, pageContext, uri}) {
 
   const {frontmatter, headings} = childMdx || childMarkdownRemark;
   const {title, description, toc, tags} = frontmatter;
-  const {versions, currentVersion, navItems} = pageContext;
+  const {versions, currentVersion, navItems, versionBanner} = pageContext;
 
   const pageProps = usePageLayoutProps({
     pageContext,
@@ -240,7 +240,6 @@ export default function Page({file, pageContext, uri}) {
       </Button>
     );
   }, [gitRemote, basePath, relativePath]);
-
   return (
     <>
       <Global
@@ -264,8 +263,11 @@ export default function Page({file, pageContext, uri}) {
             defaultVersion && defaultVersion.slug !== basePath ? (
               <VersionBanner
                 versionLabels={[defaultVersion.label, currentVersion]}
-                to={'/' + defaultVersion.slug}
-              />
+                to={versionBanner?.link ?? '/' + defaultVersion.slug}
+              >
+                {versionBanner?.content ??
+                  'Switch to the latest stable version.'}
+              </VersionBanner>
             ) : null
           }
           subtitle={

--- a/src/components/VersionBanner.js
+++ b/src/components/VersionBanner.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {Box, Link} from '@chakra-ui/react';
 import {Link as GatsbyLink} from 'gatsby';
 
-export default function VersionBanner({to, versionLabels}) {
+export default function VersionBanner({to, versionLabels, children}) {
   const [defaultVersionNumber, currentVersionNumber] = versionLabels.map(
     label => {
       // parse version number from label, i.e. "v2.6"
@@ -20,7 +20,7 @@ export default function VersionBanner({to, versionLabels}) {
         : 'a previous'}{' '}
       version of this software.{' '}
       <Link as={GatsbyLink} to={to} fontWeight="semibold">
-        Switch to the latest stable version
+        {children}
       </Link>
     </Box>
   );
@@ -28,5 +28,6 @@ export default function VersionBanner({to, versionLabels}) {
 
 VersionBanner.propTypes = {
   to: PropTypes.string.isRequired,
-  versionLabels: PropTypes.array.isRequired
+  versionLabels: PropTypes.array.isRequired,
+  children: PropTypes.node
 };


### PR DESCRIPTION
This PR adds an optional `versionBanner` config option for docsets' `config.json` file to make both the link and link text for the `VersionBanner` customizable.

```
"versionBanner": {
    "link": "/deprecation-page",
    "content": "Check out the deprecation page."
}
```