### PR TITLE
Fix date parsing in safari

### DIFF
--- a/src/components/TechNotes/NotesList.js
+++ b/src/components/TechNotes/NotesList.js
@@ -1,7 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import RelativeLink from '../RelativeLink';
+import moment from 'moment';
 import {Flex, List, ListItem} from '@chakra-ui/react';
+
+const getBrowserCompatibleDate = note => {
+  // The date string here look like "2022-11-01 16:39:41 -0400"
+  // This is not valid in Safari, so we are just splitting and selecting the date part
+  // since the time and timezone offset are not needed
+  const gitLogDate = note.fields?.gitLogLatestDate ?? '';
+  const simpleDate = gitLogDate.split(' ')[0] ?? Date.now();
+  return moment(simpleDate).format('YYYY-MM-DD');
+};
 
 export function NotesList({notes}) {
   return (
@@ -14,9 +24,7 @@ export function NotesList({notes}) {
             </RelativeLink>
             <span>
               Last Updated{' '}
-              {new Intl.DateTimeFormat('en-US').format(
-                new Date(note.fields?.gitLogLatestDate ?? Date.now())
-              )}
+              {getBrowserCompatibleDate(note)}
             </span>
           </Flex>
         </ListItem>


### PR DESCRIPTION
The tech notes page was failing with error in safari based browsers. This changes to use moment for formatting which is included in gatsby and parses out a simple date from the start