### PR TITLE
Remove out of date note

### DIFF
--- a/src/content/graphos/delivery/schema-checks.mdx
+++ b/src/content/graphos/delivery/schema-checks.mdx
@@ -131,8 +131,6 @@ You override flagged changes on an operation-by-operation basis. For each operat
 - **Ignore the operation.** In this case, schema checks will completely ignore the operation when checking _all_ changes in any future execution.
   - This option is useful when you know an operation originates _only_ from clients or client versions that you don't actively support.
 
-> Note that there is currently no way to remove an override from an operation, and future changes will not explicitly show the presence of operations that are omitted due to overrides.
-
 ### Rerunning checks
 
 You can rerun checks from inside Studio:


### PR DESCRIPTION
We do indeed represent overrides in checks where they are taken into account and customers can remove them from the check in question.