### PR TITLE
Refactor Docs to CSS Variable to Stop Size Jumping

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,9 @@
 import React from 'react';
+import {
+  DOCS_PAGE_WIDTH_VAR,
+  PAGE_JUMBO_WIDTH,
+  PAGE_NORMAL_WIDTH
+} from './src/components/PageWidthContext';
 
 export const onRenderBody = ({setHeadComponents}) =>
   setHeadComponents([
@@ -11,6 +16,22 @@ export const onRenderBody = ({setHeadComponents}) =>
           ffWidgetScript.type = 'text/javascript';
           ffWidgetScript.src = 'https://freddyfeedback.com/widget/freddyfeedback.js';
           document.head.appendChild(ffWidgetScript);
+        `
+      }}
+    />,
+    <script
+      key="extend-fix"
+      dangerouslySetInnerHTML={{
+        __html: `
+          const pageWidth = JSON.parse(localStorage.getItem('page-width2') ?? "\\"normal\\"");
+          
+          const PAGE_NORMAL_WIDTH = ${PAGE_NORMAL_WIDTH};
+          const PAGE_JUMBO_WIDTH = ${PAGE_JUMBO_WIDTH};
+
+          const pageWidthPx = (pageWidth === 'normal' ? PAGE_NORMAL_WIDTH : PAGE_JUMBO_WIDTH) + 'px';
+
+          const root = document.querySelector(':root');
+          root.style.setProperty('${DOCS_PAGE_WIDTH_VAR}', pageWidthPx + 'px');
         `
       }}
     />

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -31,7 +31,7 @@ export const onRenderBody = ({setHeadComponents}) =>
           const pageWidthPx = (pageWidth === 'normal' ? PAGE_NORMAL_WIDTH : PAGE_JUMBO_WIDTH) + 'px';
 
           const root = document.querySelector(':root');
-          root.style.setProperty('${DOCS_PAGE_WIDTH_VAR}', pageWidthPx + 'px');
+          root.style.setProperty('${DOCS_PAGE_WIDTH_VAR}', pageWidthPx);
         `
       }}
     />

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -23,7 +23,7 @@ export const onRenderBody = ({setHeadComponents}) =>
       key="extend-fix"
       dangerouslySetInnerHTML={{
         __html: `
-          const pageWidth = JSON.parse(localStorage.getItem('page-width2') ?? "\\"normal\\"");
+          const pageWidth = JSON.parse(localStorage.getItem('page-width') ?? "\\"normal\\"");
           
           const PAGE_NORMAL_WIDTH = ${PAGE_NORMAL_WIDTH};
           const PAGE_JUMBO_WIDTH = ${PAGE_JUMBO_WIDTH};

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -27,11 +27,11 @@ import {
   Tooltip,
   useToken
 } from '@chakra-ui/react';
+import {DOCS_PAGE_WIDTH_VAR, usePageWidthContext} from './PageWidthContext';
 import {FiChevronsRight} from 'react-icons/fi';
 import {GatsbySeo} from 'gatsby-plugin-next-seo';
 import {PathContext} from '../utils';
 import {graphql, useStaticQuery} from 'gatsby';
-import {usePageWidthContext} from './PageWidthContext';
 
 export function usePageLayoutProps(props) {
   const paddingTop = useToken('space', 10);

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -75,7 +75,7 @@ export default function Page({
     `
   );
 
-  const {pageRefCallback, pageWidthPx} = usePageWidthContext();
+  const {pageRefCallback} = usePageWidthContext();
 
   const {docset, versions, currentVersion, navItems, algoliaFilters} =
     pageContext;
@@ -169,7 +169,7 @@ export default function Page({
         <Flex
           key={now}
           ref={pageRefCallback}
-          maxW={pageWidthPx}
+          maxW={'var(--docs-page-width)'}
           mx="auto"
           align="flex-start"
           px={{base: 6, md: 10}}

--- a/src/components/PageLayout.js
+++ b/src/components/PageLayout.js
@@ -169,7 +169,7 @@ export default function Page({
         <Flex
           key={now}
           ref={pageRefCallback}
-          maxW={'var(--docs-page-width)'}
+          maxW={`var(${DOCS_PAGE_WIDTH_VAR})`}
           mx="auto"
           align="flex-start"
           px={{base: 6, md: 10}}

--- a/src/components/PageWidthContext.js
+++ b/src/components/PageWidthContext.js
@@ -3,6 +3,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useRef,
   useState
 } from 'react';
@@ -40,6 +41,7 @@ export const usePageWidthContext = () => {
 
 export const PAGE_NORMAL_WIDTH = 1120;
 export const PAGE_JUMBO_WIDTH = 1800;
+export const DOCS_PAGE_WIDTH_VAR = '--docs-page-width';
 
 /**
  * PageWidthProvider that must be used
@@ -109,6 +111,11 @@ export const PageWidthProvider = ({children}) => {
   // Calculate the page width in pixels from the current state
   const pageWidthPx =
     pageWidth === 'normal' ? PAGE_NORMAL_WIDTH : PAGE_JUMBO_WIDTH;
+
+  useEffect(() => {
+    const root = document.querySelector(':root');
+    root.style.setProperty(DOCS_PAGE_WIDTH_VAR, pageWidthPx + 'px');
+  }, [pageWidthPx]);
 
   // Create a context provider with values
   return (


### PR DESCRIPTION
By utilizing a css variable calculated on page load, the docs will no longer "jump" to extended mode once react takes over.