### PR TITLE
New page for adding subgraphs

### DIFF
--- a/src/content/graphos/config.json
+++ b/src/content/graphos/config.json
@@ -17,6 +17,7 @@
     },
     "Working with Supergraphs": {
       "Overview": "/graphs/overview",
+      "Adding a subgraph": "/graphs/adding-a-subgraph",
       "Publishing schemas": "/schema/cli-registration",
       "Local development": "/graphs/local-development",
       "Managing graphs in Studio": "/graphs/studio-features",

--- a/src/content/graphos/config.json
+++ b/src/content/graphos/config.json
@@ -17,8 +17,8 @@
     },
     "Working with Supergraphs": {
       "Overview": "/graphs/overview",
-      "Adding a subgraph": "/graphs/adding-a-subgraph",
       "Publishing schemas": "/schema/cli-registration",
+      "Creating a new subgraph": "/graphs/adding-a-subgraph",
       "Local development": "/graphs/local-development",
       "Managing graphs in Studio": "/graphs/studio-features",
       "Supergraph-specific Studio features": "/graphs/federated-graphs",

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -31,16 +31,16 @@ The fastest way to create a new subgraph is to start with one of the templates p
 
 Templates are currently available for the following libraries and languages:
 
-| Name                    | Language   | ID                                 | Repo                                                                                    |
-|-------------------------|------------|------------------------------------|-----------------------------------------------------------------------------------------|
-| Go (gqlgen)             | Go         | subgraph-go-gqlgen                 | https://github.com/apollographql/subgraph-template-go-gqlgen-boilerplate                |
-| Spring GraphQL          | Java       | subgraph-java-spring-graphql       | https://github.com/apollographql/subgraph-template-java-spring-graphql-boilerplate      |
-| Apollo Server (JS)      | JavaScript | subgraph-javascript-apollo-server  | https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate |
-| GraphQL Kotlin          | Kotlin     | subgraph-graphql-kotlin            | https://github.com/apollographql/subgraph-template-graphql-kotlin-boilerplate           |
-| Strawberry with FastAPI | Python     | subgraph-python-strawberry-fastapi | https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi              |
-| Ariadne with FastAPI    | Python     | subgraph-python-ariadne-fastapi    | https://github.com/patrick91/subgraph-template-ariadne-fastapi                          |
-| async-graphql with Axum | Rust       | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
-| Apollo Server (TS)      | TypeScript | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
+| Language   | Name                    | ID                                 | Repo                                                                                    |
+|------------|-------------------------|------------------------------------|-----------------------------------------------------------------------------------------|
+| Go         | Go (gqlgen)             | subgraph-go-gqlgen                 | https://github.com/apollographql/subgraph-template-go-gqlgen-boilerplate                |
+| Java       | Spring GraphQL          | subgraph-java-spring-graphql       | https://github.com/apollographql/subgraph-template-java-spring-graphql-boilerplate      |
+| JavaScript | Apollo Server (JS)      | subgraph-javascript-apollo-server  | https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate |
+| Kotlin     | GraphQL Kotlin          | subgraph-graphql-kotlin            | https://github.com/apollographql/subgraph-template-graphql-kotlin-boilerplate           |
+| Python     | Strawberry with FastAPI | subgraph-python-strawberry-fastapi | https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi              |
+| Python     | Ariadne with FastAPI    | subgraph-python-ariadne-fastapi    | https://github.com/patrick91/subgraph-template-ariadne-fastapi                          |
+| Rust       | async-graphql with Axum | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
+| TypeScript | Apollo Server (TS)      | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
 
 You start by running `rover template use`, providing it the ID of your chosen template. For example, the following command creates a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
 

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -68,4 +68,4 @@ When you're ready to add a new subgraph to your existing GraphOS supergraph, do 
 2. [Check your schema](/federation/managed-federation/federated-schema-checks) against your existing supergraph and handle any conflicts.
 3. Set up your CI/CD pipeline to perform checks and also [publish your subgraph schema](../../schemas/publishing).
 
-Once the schema is published—your graph is now a subgraph in your supergraph, and you can start using other federation features!
+After you publish your subgraph's schema for the first time, GraphOS recognizes it as part of your supergraph, and you can start querying your router for data from _all_ of your subgraphs!

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -45,7 +45,7 @@ Templates are currently available for the following libraries and languages:
 You start by running `rover template use`, providing it the ID of your chosen template. For example, the following command creates a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
 
 ```bash
-rover subgraph use subgraph-typescript-apollo-server my-subgraph
+rover template use subgraph-typescript-apollo-server my-subgraph
 ```
 
 After generating the boilerplate code, you can start filling in your business logic. The generated code includes example resolvers for `Query` and `Mutation`, along with some [entity types](/federation/entities/) to use as your starting point. All templates also come with example GitHub Actions workflows to help with [publishing your schema in CI/CD](../../schemas/publishing#publishing-with-continuous-delivery).

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -68,4 +68,4 @@ When you're ready to add a new subgraph to your existing GraphOS supergraph, do 
 2. [Check your schema](/federation/managed-federation/federated-schema-checks) against your existing supergraph and handle any conflicts.
 3. Set up your CI/CD pipeline to perform checks and also [publish your subgraph schema](../../schemas/publishing).
 
-After you publish your subgraph's schema for the first time, GraphOS recognizes it as part of your supergraph, and you can start querying your router for data from _all_ of your subgraphs!
+After you publish your subgraph's schema for the first time, GraphOS recognizes it as part of your supergraph, and you can start querying for data from _all_ of your subgraphs!

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -1,0 +1,57 @@
+---
+title: Adding a subgraph
+description: With the Rover CLI
+---
+
+One of the most powerful features of a supergraph is that it can combine _multiple_ GraphQL APIs into a _single_ graph:
+
+```mermaid
+flowchart LR;
+  clients(Clients);
+  subgraph "GraphOS";
+  router(["Router"]);
+  end;
+  subgraph "Your infrastructure";
+  api[Subgraph A];
+  secondapi[Subgraph B];
+  thirdapi[Subgraph C];
+  router --- api & secondapi & thirdapi
+  end;
+  clients --- router;
+  class clients secondary;
+```
+
+With this architecture, different teams in your organization can each maintain their own subgraph. This helps teams work in parallel, because they aren't all contributing to the same single codebase.
+
+## Starting from scratch
+
+The easiest way to get started with a new subgraph is to use the [Rover CLI's template command](/rover/commands/template). `rover template` generates the skeleton of a new subgraph so you can immediately begin implementing resolvers. Here are the templates available today:
+
+| Name                    | Language   | ID                                 | Repo                                                                                    |
+|-------------------------|------------|------------------------------------|-----------------------------------------------------------------------------------------|
+| Go (gqlgen)             | Go         | subgraph-go-gqlgen                 | https://github.com/apollographql/subgraph-template-go-gqlgen-boilerplate                |
+| Spring GraphQL          | Java       | subgraph-java-spring-graphql       | https://github.com/apollographql/subgraph-template-java-spring-graphql-boilerplate      |
+| Apollo Server (JS)      | JavaScript | subgraph-javascript-apollo-server  | https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate |
+| GraphQL Kotlin          | Kotlin     | subgraph-graphql-kotlin            | https://github.com/apollographql/subgraph-template-graphql-kotlin-boilerplate           |
+| Strawberry with FastAPI | Python     | subgraph-python-strawberry-fastapi | https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi              |
+| Ariadne with FastAPI    | Python     | subgraph-python-ariadne-fastapi    | https://github.com/patrick91/subgraph-template-ariadne-fastapi                          |
+| async-graphql with Axum | Rust       | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
+| Apollo Server (TS)      | TypeScript | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
+
+You start by generating boilerplate using `rover template use` with the ID of the template you want. For example, this command will create a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
+
+```bash
+rover subgraph use subgraph-typescript-apollo-server my-subgraph
+```
+
+Once the boilerplate is generated, you can start filling in your business logic. The generated code includes example resolvers for `Query`, `Mutation`, as well as entities to use as your starting point. All templates also come with example GitHub Actions workflows to make [publishing your schema in CI/CD](../../schemas/publishing#publishing-with-continuous-delivery) take only a couple steps.
+
+## Adding an existing graph
+
+As long as your graph was implemented using a [library which supports federation](/federation/building-supergraphs/supported-subgraphs), you can add your graph to a supergraph using these steps:
+
+1. Enable federation support via your implementing library.
+2. [Check your schema](/federation/managed-federation/federated-schema-checks) and handle any conflicts
+3. Set up your CI/CD to check and [publish schema](../../schemas/publishing) changes
+
+Once the schema is published—your graph is now a subgraph in your supergraph, and you can start using other federation features!

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -1,5 +1,5 @@
 ---
-title: Adding a subgraph
+title: Creating a new subgraph
 description: With the Rover CLI
 ---
 
@@ -23,9 +23,13 @@ flowchart LR;
 
 With this architecture, different teams in your organization can each maintain their own subgraph. This helps teams work in parallel, because they aren't all contributing to the same single codebase.
 
-## Starting from scratch
+## Starting from a template
 
-The easiest way to get started with a new subgraph is to use the [Rover CLI's template command](/rover/commands/template). `rover template` generates the skeleton of a new subgraph so you can immediately begin implementing resolvers. Here are the templates available today:
+The fastest way to create a new subgraph is to start with one of the templates provided by the [Rover CLI](/rover/commands/template). The `rover template` command generates the skeleton of a new subgraph for you, so you can immediately begin defining your schema and implementing your resolvers.
+
+> If your installed version of Rover doesn't include the `template` command (or if you don't have Rover installed at all), [install the latest version.](/rover/getting-started/)
+
+Templates are currently available for the following libraries and languages:
 
 | Name                    | Language   | ID                                 | Repo                                                                                    |
 |-------------------------|------------|------------------------------------|-----------------------------------------------------------------------------------------|
@@ -38,20 +42,29 @@ The easiest way to get started with a new subgraph is to use the [Rover CLI's te
 | async-graphql with Axum | Rust       | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
 | Apollo Server (TS)      | TypeScript | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
 
-You start by generating boilerplate using `rover template use` with the ID of the template you want. For example, this command will create a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
+You start by running `rover template use`, providing it the ID of your chosen template. For example, the following command creates a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
 
 ```bash
 rover subgraph use subgraph-typescript-apollo-server my-subgraph
 ```
 
-Once the boilerplate is generated, you can start filling in your business logic. The generated code includes example resolvers for `Query`, `Mutation`, as well as entities to use as your starting point. All templates also come with example GitHub Actions workflows to make [publishing your schema in CI/CD](../../schemas/publishing#publishing-with-continuous-delivery) take only a couple steps.
+After generating the boilerplate code, you can start filling in your business logic. The generated code includes example resolvers for `Query` and `Mutation`, along with some [entity types](/federation/entities/) to use as your starting point. All templates also come with example GitHub Actions workflows to help with [publishing your schema in CI/CD](../../schemas/publishing#publishing-with-continuous-delivery).
 
-## Adding an existing graph
+When you're ready to add your new subgraph to your supergraph, [see below](#adding-to-your-supergraph).
 
-As long as your graph was implemented using a [library which supports federation](/federation/building-supergraphs/supported-subgraphs), you can add your graph to a supergraph using these steps:
+## Starting with an existing API
 
-1. Enable federation support via your implementing library.
-2. [Check your schema](/federation/managed-federation/federated-schema-checks) and handle any conflicts
-3. Set up your CI/CD to check and [publish schema](../../schemas/publishing) changes
+If you have an existing GraphQL API that you want to use as a subgraph, confirm whether it uses a [subgraph-compatible library](/federation/building-supergraphs/supported-subgraphs).
+
+- **If it does,** consult the library's documentation to determine how to enable its support for Apollo Federation.
+- **If it doesn't,** first move the subgraph to a compatible library.
+## Adding to your supergraph
+
+When you're ready to add a new subgraph to your existing GraphOS supergraph, do the following:
+
+1. Enable federation support in your subgraph library.
+    - If you [built from a template](#starting-from-a-template), federation support is already enabled. Otherwise, consult the documentation for your chosen library.
+2. [Check your schema](/federation/managed-federation/federated-schema-checks) against your existing supergraph and handle any conflicts.
+3. Set up your CI/CD pipeline to perform checks and also [publish your subgraph schema](../../schemas/publishing).
 
 Once the schema is published—your graph is now a subgraph in your supergraph, and you can start using other federation features!

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -31,16 +31,16 @@ The fastest way to create a new subgraph is to start with one of the templates p
 
 Templates are currently available for the following libraries and languages:
 
-| Language   | Name                    | ID                                 | Repo                                                                                    |
-|------------|-------------------------|------------------------------------|-----------------------------------------------------------------------------------------|
-| Go         | Go (gqlgen)             | subgraph-go-gqlgen                 | https://github.com/apollographql/subgraph-template-go-gqlgen-boilerplate                |
-| Java       | Spring GraphQL          | subgraph-java-spring-graphql       | https://github.com/apollographql/subgraph-template-java-spring-graphql-boilerplate      |
-| JavaScript | Apollo Server (JS)      | subgraph-javascript-apollo-server  | https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate |
-| Kotlin     | GraphQL Kotlin          | subgraph-graphql-kotlin            | https://github.com/apollographql/subgraph-template-graphql-kotlin-boilerplate           |
-| Python     | Strawberry with FastAPI | subgraph-python-strawberry-fastapi | https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi              |
-| Python     | Ariadne with FastAPI    | subgraph-python-ariadne-fastapi    | https://github.com/patrick91/subgraph-template-ariadne-fastapi                          |
-| Rust       | async-graphql with Axum | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
-| TypeScript | Apollo Server (TS)      | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
+| Language   | Name                                                                                   | ID                                 | Repo                                                                                    |
+|------------|----------------------------------------------------------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------|
+| Go         | [Go (gqlgen)](https://gqlgen.com/getting-started/)                                     | subgraph-go-gqlgen                 | https://github.com/apollographql/subgraph-template-go-gqlgen-boilerplate                |
+| Java       | [Spring GraphQL](https://spring.io/projects/spring-graphql)                            | subgraph-java-spring-graphql       | https://github.com/apollographql/subgraph-template-java-spring-graphql-boilerplate      |
+| JavaScript | [Apollo Server (JS)](https://www.apollographql.com/docs/apollo-server/)                | subgraph-javascript-apollo-server  | https://github.com/apollographql/subgraph-template-javascript-apollo-server-boilerplate |
+| Kotlin     | [GraphQL Kotlin](https://opensource.expediagroup.com/graphql-kotlin/docs/)             | subgraph-graphql-kotlin            | https://github.com/apollographql/subgraph-template-graphql-kotlin-boilerplate           |
+| Python     | [Strawberry with FastAPI](https://strawberry.rocks)                                    | subgraph-python-strawberry-fastapi | https://github.com/strawberry-graphql/subgraph-template-strawberry-fastapi              |
+| Python     | [Ariadne with FastAPI](https://ariadnegraphql.org)                                     | subgraph-python-ariadne-fastapi    | https://github.com/patrick91/subgraph-template-ariadne-fastapi                          |
+| Rust       | [async-graphql with Axum](https://async-graphql.github.io/async-graphql/en/index.html) | subgraph-rust-async-graphql        | https://github.com/apollographql/subgraph-template-rust-async-graphql                   |
+| TypeScript | [Apollo Server (TS)](https://www.apollographql.com/docs/apollo-server/)                | subgraph-typescript-apollo-server  | https://github.com/apollographql/subgraph-template-typescript-apollo-server-boilerplate |
 
 You start by running `rover template use`, providing it the ID of your chosen template. For example, the following command creates a new directory called `my-subgraph` that contains the boilerplate code for a subgraph written in TypeScript using the Apollo Server library:
 

--- a/src/content/graphos/graphs/adding-a-subgraph.mdx
+++ b/src/content/graphos/graphs/adding-a-subgraph.mdx
@@ -57,7 +57,8 @@ When you're ready to add your new subgraph to your supergraph, [see below](#addi
 If you have an existing GraphQL API that you want to use as a subgraph, confirm whether it uses a [subgraph-compatible library](/federation/building-supergraphs/supported-subgraphs).
 
 - **If it does,** consult the library's documentation to determine how to enable its support for Apollo Federation.
-- **If it doesn't,** first move the subgraph to a compatible library.
+- **If it doesn't,** [open an issue to let us know](https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/new/choose) and we'll work with the library's maintainers to add support.
+
 ## Adding to your supergraph
 
 When you're ready to add a new subgraph to your existing GraphOS supergraph, do the following:

--- a/src/content/graphos/quickstart/next-steps.mdx
+++ b/src/content/graphos/quickstart/next-steps.mdx
@@ -45,27 +45,9 @@ After learning about the publishing process, you should [integrate it into your 
 
 ### Add a subgraph
 
-One of the most powerful features of a supergraph is that it can combine _multiple_ GraphQL APIs into a _single_ graph:
+See [this article](../graphs/adding-a-subgraph/).
 
-```mermaid
-flowchart LR;
-  clients(Clients);
-  subgraph "GraphOS";
-  router(["Router"]);
-  end;
-  subgraph "Your infrastructure";
-  api[Subgraph A];
-  secondapi[Subgraph B];
-  thirdapi[Subgraph C];
-  router --- api & secondapi & thirdapi
-  end;
-  clients --- router;
-  class clients secondary;
-```
 
-With this architecture, different teams in your organization can each maintain their own subgraph. This helps teams work in parallel, because they aren't all contributing to the same single codebase.
-
-**To add a subgraph to your supergraph, you publish its schema!** This uses the exact same Rover command as [updating an _existing_ subgraph](#update-a-subgraph-schema). The only difference is that you provide the name of the _new_ subgraph to the command. [Learn about publishing subgraph schemas.](../schema/cli-registration/#subgraph-schemas)
 
 ### Enable federation features
 


### PR DESCRIPTION
Very rough draft—but the idea is a new page that serves as a high-level guide to adding a subgraph to GraphOS. Specifically, it gives more visibility to `rover template` as a way to build _new_ subgraphs, differentiating from the workflow of adding existing graphs as subgraphs.