### PR TITLE
Dynamic API keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
         ExpansionPanel: 'readonly',
         MultiCodeBlock: 'readonly',
         YouTube: 'readonly',
-        EmbeddableExplorer: 'readonly'
+        EmbeddableExplorer: 'readonly',
+        ReplaceApiKey: 'readonly'
       },
       rules: {
         'react/no-unescaped-entities': 'off'

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "react-icons": "^4.6.0",
         "react-markdown": "^8.0.0",
         "react-player": "^2.10.1",
+        "react-string-replace": "^1.1.0",
         "react-use": "^17.3.2",
         "rehype": "^12.0.0",
         "rehype-autolink-headings": "^5.1.0",
@@ -39872,6 +39873,14 @@
         }
       }
     },
+    "node_modules/react-string-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-1.1.0.tgz",
+      "integrity": "sha512-N6RalSDFGbOHs0IJi1H611WbZsvk3ZT47Jl2JEXFbiS3kTwsdCYij70Keo/tWtLy7sfhDsYm7CwNM/WmjXIaMw==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.1.1",
       "license": "MIT",
@@ -72321,6 +72330,11 @@
         "react-style-singleton": "^2.1.0",
         "tslib": "^1.0.0"
       }
+    },
+    "react-string-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-1.1.0.tgz",
+      "integrity": "sha512-N6RalSDFGbOHs0IJi1H611WbZsvk3ZT47Jl2JEXFbiS3kTwsdCYij70Keo/tWtLy7sfhDsYm7CwNM/WmjXIaMw=="
     },
     "react-style-singleton": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-icons": "^4.6.0",
     "react-markdown": "^8.0.0",
     "react-player": "^2.10.1",
+    "react-string-replace": "^1.1.0",
     "react-use": "^17.3.2",
     "rehype": "^12.0.0",
     "rehype-autolink-headings": "^5.1.0",

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -257,12 +257,15 @@ export const CodeBlock = ({
                                 {line
                                   // filter out "highlight-line" comments
                                   .filter(token => !isHighlightComment(token))
-                                  .map((token, key) => (
-                                    <span
-                                      key={key}
-                                      {...getTokenProps({token, key})}
-                                    />
-                                  ))}
+                                  .map((token, key) => {
+                                    console.log('token', token);
+                                    return (
+                                      <span
+                                        key={key}
+                                        {...getTokenProps({token, key})}
+                                      />
+                                    );
+                                  })}
                               </Box>
                             </Box>
                           </Flex>

--- a/src/components/Header/StudioButton.js
+++ b/src/components/Header/StudioButton.js
@@ -1,19 +1,10 @@
 import React from 'react';
 import {Button} from '@chakra-ui/react';
 import {FiArrowRight} from 'react-icons/fi';
-import {gql, useQuery} from '@apollo/client';
-
-const GET_USER = gql`
-  query GetUser {
-    me {
-      id
-      name
-    }
-  }
-`;
+import {useUser} from '../../utils';
 
 export default function StudioButton() {
-  const {data} = useQuery(GET_USER);
+  const {user} = useUser();
   return (
     <Button
       ml="2"
@@ -26,7 +17,7 @@ export default function StudioButton() {
       rel="noopener noreferrer"
       d={{base: 'none', lg: 'flex'}}
     >
-      {data?.me ? 'Launch' : 'Try'} Apollo Studio
+      {user ? 'Launch' : 'Try'} Apollo Studio
     </Button>
   );
 }

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -49,6 +49,7 @@ import {Global} from '@emotion/react';
 import {MDXProvider} from '@mdx-js/react';
 import {MDXRenderer} from 'gatsby-plugin-mdx';
 import {PathContext, useFieldTableStyles} from '../utils';
+import {ReplaceApiKey} from './ReplaceApiKey';
 import {TOTAL_HEADER_HEIGHT} from './Header';
 import {YouTube} from './YouTube';
 import {dirname, join} from 'path';
@@ -163,7 +164,8 @@ const mdxComponents = {
   TypeScriptApiBox,
   TypescriptApiBox: TypeScriptApiBox,
   EmbeddableExplorer,
-  ButtonLink
+  ButtonLink,
+  ReplaceApiKey
 };
 
 const {processSync} = rehype()

--- a/src/components/ReplaceApiKey.js
+++ b/src/components/ReplaceApiKey.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import reactStringReplace from 'react-string-replace';
+import {FiChevronDown} from 'react-icons/fi';
 import {useUser} from '../utils';
 
 function recursiveMap(
@@ -10,9 +12,15 @@ function recursiveMap(
   return React.Children.map(children, child => {
     if (!React.isValidElement(child)) {
       if (typeof child === 'string') {
-        return child
-          .replace(/% apiKey %/g, apiKey)
-          .replace(/% graphRef %/g, graphRef);
+        return (
+          <>
+            {reactStringReplace(child, /% apiKey %/g, () => (
+              <span>
+                {apiKey} <FiChevronDown />
+              </span>
+            ))}
+          </>
+        );
       }
 
       return child;

--- a/src/components/ReplaceApiKey.js
+++ b/src/components/ReplaceApiKey.js
@@ -9,9 +9,13 @@ function recursiveMap(
 ) {
   return React.Children.map(children, child => {
     if (!React.isValidElement(child)) {
-      return child
-        .replace(/% apiKey %/g, apiKey)
-        .replace(/% graphRef %/g, graphRef);
+      if (typeof child === 'string') {
+        return child
+          .replace(/% apiKey %/g, apiKey)
+          .replace(/% graphRef %/g, graphRef);
+      }
+
+      return child;
     }
 
     return React.cloneElement(

--- a/src/components/ReplaceApiKey.js
+++ b/src/components/ReplaceApiKey.js
@@ -28,13 +28,18 @@ function recursiveMap(
 
 function findApiKey(user) {
   if (user) {
-    for (const {account} of user.memberships) {
-      for (const {id, variants, apiKeys} of account.graphs) {
-        if (apiKeys?.length) {
-          const graphRef = `${id}@${variants[0].name}`;
-          return [graphRef, apiKeys[0].token];
-        }
-      }
+    const [graph] = user.memberships
+      .flatMap(({account}) => account.graphs)
+      .filter(graph => graph.apiKeys?.length)
+      .sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+
+    if (graph) {
+      const {id, variants, apiKeys} = graph;
+      const graphRef = `${id}@${variants[0].name}`;
+      return [graphRef, apiKeys[0].token];
     }
   }
 

--- a/src/components/ReplaceApiKey.js
+++ b/src/components/ReplaceApiKey.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {useUser} from '../utils';
+
+function recursiveMap(
+  children,
+  graphRef = '<YOUR_GRAPH_REF>',
+  apiKey = '<YOUR_API_KEY>'
+) {
+  return React.Children.map(children, child => {
+    if (!React.isValidElement(child)) {
+      return child
+        .replace(/% apiKey %/g, apiKey)
+        .replace(/% graphRef %/g, graphRef);
+    }
+
+    return React.cloneElement(
+      child,
+      child.props,
+      recursiveMap(child.props.children, graphRef, apiKey)
+    );
+  });
+}
+
+function findApiKey(user) {
+  if (user) {
+    for (const {account} of user.memberships) {
+      for (const {id, variants, apiKeys} of account.graphs) {
+        if (apiKeys?.length) {
+          const graphRef = `${id}@${variants[0].name}`;
+          return [graphRef, apiKeys[0].token];
+        }
+      }
+    }
+  }
+
+  return [];
+}
+
+export function ReplaceApiKey({children}) {
+  const {user} = useUser();
+  return <>{recursiveMap(children, ...findApiKey(user))}</>;
+}
+
+ReplaceApiKey.propTypes = {
+  children: PropTypes.node.isRequired
+};

--- a/src/content/graphos/metrics/sending-operation-metrics.mdx
+++ b/src/content/graphos/metrics/sending-operation-metrics.mdx
@@ -10,6 +10,8 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key.mdx';
 
 Both the Apollo Router and Apollo Server use the same mechanism to enable operation metrics reporting to GraphOS:
 
+<ReplaceApiKey>
+
 1. Obtain a **graph API key** from Studio.
 
    <ObtainGraphApiKey />
@@ -21,9 +23,11 @@ Both the Apollo Router and Apollo Server use the same mechanism to enable operat
 3. Use the obtained values to set the following environment variables in your environment _before_ starting up your router/server:
 
    ```bash
-   export APOLLO_KEY=<YOUR_GRAPH_API_KEY>
-   export APOLLO_GRAPH_REF=<YOUR_GRAPH_REF>
+   export APOLLO_KEY=% apiKey %
+   export APOLLO_GRAPH_REF=% graphRef %
    ```
+
+</ReplaceApiKey>
 
 > Consult your production environment's documentation to learn how to set its environment variables.
 

--- a/src/content/graphos/metrics/sending-operation-metrics.mdx
+++ b/src/content/graphos/metrics/sending-operation-metrics.mdx
@@ -10,8 +10,6 @@ import ObtainGraphApiKey from '../../shared/obtain-graph-api-key.mdx';
 
 Both the Apollo Router and Apollo Server use the same mechanism to enable operation metrics reporting to GraphOS:
 
-<ReplaceApiKey>
-
 1. Obtain a **graph API key** from Studio.
 
    <ObtainGraphApiKey />
@@ -23,11 +21,9 @@ Both the Apollo Router and Apollo Server use the same mechanism to enable operat
 3. Use the obtained values to set the following environment variables in your environment _before_ starting up your router/server:
 
    ```bash
-   export APOLLO_KEY=% apiKey %
-   export APOLLO_GRAPH_REF=% graphRef %
+   export APOLLO_KEY=<YOUR_API_KEY>
+   export APOLLO_GRAPH_REF=<YOUR_GRAPH_REF>
    ```
-
-</ReplaceApiKey>
 
 > Consult your production environment's documentation to learn how to set its environment variables.
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import {createContext} from 'react';
+import {gql, useQuery} from '@apollo/client';
 import {join, relative} from 'path';
 import {useColorModeValue} from '@chakra-ui/react';
 import {withPrefix} from 'gatsby';
@@ -63,5 +64,38 @@ export function useFieldTableStyles() {
         }
       }
     }
+  };
+}
+
+const GET_USER = gql`
+  query GetUser {
+    me {
+      ... on User {
+        id
+        name
+        memberships {
+          account {
+            graphs {
+              id
+              apiKeys {
+                token
+              }
+              variants {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function useUser() {
+  const {data, loading, error} = useQuery(GET_USER);
+  return {
+    user: data?.me,
+    loading,
+    error
   };
 }


### PR DESCRIPTION
This PR adds a component that replaces a placeholder with the user's real api key and graph ref, or a default string.

You can use the `<ReplaceApiKey>` component to wrap sections of markdown. It looks for the strings `% apiKey %` or `% graphRef %` and replaces them with the first api key and associated graph ref that we can find for the logged-in user.

````mdx
<ReplaceApiKey>

```bash
export APOLLO_KEY=% apiKey %
export APOLLO_GRAPH_REF=% graphRef %
```

</ReplaceApiKey>
````

Doing the above would result in the following if there is a logged in user with a graph:

![Screen Shot 2022-12-01 at 4 49 52 PM](https://user-images.githubusercontent.com/1216917/205189800-343a5ff3-41c3-42e8-b0bd-d4685e7c5f37.png)

If there is no user, or if the logged-in user has no graphs, then the default `<YOUR_API_KEY>` and `<YOUR_GRAPH_REF>` placeholders will show up.