### PR TITLE
Fixed in-page anchor link for composition checks

### DIFF
--- a/src/content/graphos/delivery/schema-checks.mdx
+++ b/src/content/graphos/delivery/schema-checks.mdx
@@ -22,12 +22,12 @@ GraphOS can perform the following types of schema checks:
 
 - **Operation checks.** Compare your proposed schema changes against historical operations to verify whether the changes will break any of your graph's active clients.
 
-- [**Composition checks.**](#federated-composition-checks) For supergraphs, verify whether your proposed changes to a subgraph schema will successfully compose with your _other_ subgraph schemas.
+- [**Composition checks.**](#composition-checks) For supergraphs, verify whether your proposed changes to a subgraph schema will successfully compose with your _other_ subgraph schemas.
 
 - **[Contract checks](../delivery/contracts/) (enterprise only).** When running schema checks on a source variant, also check whether your proposed schema changes will break any downstream contract variants.
 
 > **Most of this article covers operation checks.**
-> * For details on composition checks, [see this section](#federated-composition-checks).
+> * For details on composition checks, [see this section](#composition-checks).
 > * For details on contract checks, [see this article](./contracts/).
 
 ## Prerequisites


### PR DESCRIPTION
The link to the composition checks type was set to #federated-composition-checks. It should be #composition-checks. I fixed this in two places.