### PR TITLE
Accept `hidden` and `disableCopy` props in MarkdownCodeBlock

### DIFF
--- a/.changeset/kind-wasps-tap.md
+++ b/.changeset/kind-wasps-tap.md
@@ -1,0 +1,5 @@
+---
+"@apollo/chakra-helpers": minor
+---
+
+Add disableCopy and hidden props to MarkdownCodeBlock

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -52,11 +52,14 @@ const getCodeWithoutHighlightComments = (code: string) => {
 type MarkdownCodeBlockProps = {
   children: ReactNode;
   isPartOfMultiCode?: boolean;
+  disableCopy?: boolean;
+  hidden?: boolean;
 };
 
 export const MarkdownCodeBlock = ({
   children,
-  isPartOfMultiCode
+  isPartOfMultiCode,
+  ...props
 }: MarkdownCodeBlockProps): JSX.Element => {
   const defaultShowLineNumbers = useContext(LineNumbersContext);
   const [child] = Array.isArray(children) ? children : [children];
@@ -64,17 +67,37 @@ export const MarkdownCodeBlock = ({
     className = 'language-text',
     children: innerChildren,
     metastring,
-    'data-meta': dataMeta,
-    hidden = false
+    'data-meta': dataMeta
   } = child.props;
+
+  // prioritize markdown hidden prop from child.props
+  // then look at parent props
+  // else default to false
+  const hidden =
+    child.props.hidden !== undefined
+      ? child.props.hidden
+      : props.hidden !== undefined
+      ? props.hidden
+      : false;
 
   const meta = metastring || dataMeta;
   const {
     title = null,
     highlight = null,
     showLineNumbers = defaultShowLineNumbers,
-    disableCopy = false
+    ...rest
   } = meta ? fenceparser(meta) : {};
+
+  // prioritize markdown disableCopy prop from meta
+  // then look at parent props
+  // else default to false
+  const disableCopy =
+    rest.disableCopy !== undefined
+      ? rest.disableCopy
+      : props.disableCopy !== undefined
+      ? props.disableCopy
+      : false;
+
   const linesToHighlight = highlight
     ? rangeParser(Object.keys(highlight).toString())
     : [];

--- a/packages/chakra-helpers/src/CodeBlock.tsx
+++ b/packages/chakra-helpers/src/CodeBlock.tsx
@@ -67,36 +67,17 @@ export const MarkdownCodeBlock = ({
     className = 'language-text',
     children: innerChildren,
     metastring,
-    'data-meta': dataMeta
+    'data-meta': dataMeta,
+    hidden = props.hidden ?? false // prioritize markdown hidden prop from child.props, then look at parent props. else default to false
   } = child.props;
-
-  // prioritize markdown hidden prop from child.props
-  // then look at parent props
-  // else default to false
-  const hidden =
-    child.props.hidden !== undefined
-      ? child.props.hidden
-      : props.hidden !== undefined
-      ? props.hidden
-      : false;
 
   const meta = metastring || dataMeta;
   const {
     title = null,
     highlight = null,
     showLineNumbers = defaultShowLineNumbers,
-    ...rest
+    disableCopy = props.disableCopy ?? false // prioritize markdown disableCopy prop from meta, then look at parent props. else default to false
   } = meta ? fenceparser(meta) : {};
-
-  // prioritize markdown disableCopy prop from meta
-  // then look at parent props
-  // else default to false
-  const disableCopy =
-    rest.disableCopy !== undefined
-      ? rest.disableCopy
-      : props.disableCopy !== undefined
-      ? props.disableCopy
-      : false;
 
   const linesToHighlight = highlight
     ? rangeParser(Object.keys(highlight).toString())


### PR DESCRIPTION
This PR addresses some [exam feedback for Odyssey v2](https://apollographql.quip.com/cOPoA9D1Otz9/Odyssey-v2-Feedback#temp:C:DVZa24fae17d007448ab7c0ce025) by adding optional `hidden` and `disableCopy` props in the `MarkdownCodeBlock` to allow for broader usage in Odyssey. For Odyssey exams, we want to always set `disableCopy` to true. To avoid having to pass a `disableCopy` prop to every single `MarkdownCodeBlock` in exam `.mdx` files, we want to be able to set the value of that prop up in the [`components` prop level of `MarkdownRenderer`](https://github.com/apollographql/odyssey/blob/v2/src/components/MarkdownRenderer.tsx#L9), which requires us to be able to pass the `disableCopy` prop directly to the `MarkdownCodeBlock` component.


[Exam component](https://github.com/apollographql/odyssey/blob/v2/src/components/Exam/Exam.tsx):
```js
// Odyssey src/components/Exam/Exam.tsx
...
export const ExamCodeBlock = (props) => <MarkdownCodeBlock {...props} disableCopy />
```

[Exam question](https://github.com/apollographql/odyssey/blob/v2/src/components/Exam/QuestionPrompt.tsx#L85): 
```js
// Odyssey src/components/QuestionPrompt.tsx

...
return (
  ...
   <MarkdownRenderer components={{ pre: ExamCodeBlock }}>{children}</MarkdownRenderer>
)
```