### PR TITLE
Update Client ID Enforcement technote

### DIFF
--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -20,63 +20,54 @@ If you're using Apollo Server for your gateway, you can require client metadata 
 <MultiCodeBlock>
 
 ```ts title="index.ts"
-function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext>  {
-    return {
-        async requestDidStart(_) {
-            return {
-                async didResolveOperation(requestContext) {
-                    let clientName = requestContext.request.http.headers.get('apollographql-client-name');
-                    let clientVersion = requestContext.request.http.headers.get(
-                        'apollographql-client-version'
-                    );
-    
-                    if (!clientName) {
-                        let logString = `Execution Denied: Operation has no identified client`;
-                        requestContext.logger.debug(logString)
-                        throw new GraphQLError(logString);
-                    }
-    
-                    if (!clientVersion) {
-                        let logString = `Execution Denied: Client ${clientName} has no identified version`;
-                        requestContext.logger.debug(logString)
-                        throw new GraphQLError(logString);
-                    }
-    
-                    if (!requestContext.operationName) {
-                        let logString = `Unnamed Operation: ${requestContext.queryHash}`;
-                        requestContext.logger.debug(logString);
-    
-                        throw new GraphQLError(logString, {
-                            extensions: {
-                                queryHash: requestContext.queryHash,
-                                clientName: clientName,
-                                clientVersion: clientVersion,
-                                exception: {
-                                    message: `All operations must be named`
-                                }
-                            }
-                        });
-                    }
-                },
+function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext> {
+  return {
+    async requestDidStart() {
+      return {
+        async didResolveOperation(requestContext) {
+          let clientName = requestContext.request.http.headers.get(
+            "apollographql-client-name"
+          );
+          let clientVersion = requestContext.request.http.headers.get(
+            "apollographql-client-version"
+          );
 
-                async didEncounterErrors(requestContext) {
-                    requestContext.errors.forEach(error => {
-                        requestContext.logger.error(error)
-                        console.log(error.toString())
-                    });
-                }
-            };
+          if (!clientName) {
+            let logString = `Execution Denied: Operation has no identified client`;
+            requestContext.logger.debug(logString);
+            throw new GraphQLError(logString);
+          }
+
+          if (!clientVersion) {
+            let logString = `Execution Denied: Client ${clientName} has no identified version`;
+            requestContext.logger.debug(logString);
+            throw new GraphQLError(logString);
+          }
+
+          if (!requestContext.operationName) {
+            let logString = `Unnamed Operation: ${requestContext.queryHash}. All operations must be named`;
+            requestContext.logger.debug(logString);
+
+            throw new GraphQLError(logString, {
+              extensions: {
+                queryHash: requestContext.queryHash,
+                clientName,
+                clientVersion,
+              },
+            });
+          }
         },
-    
-    }
-};
-
+      };
+    },
+  };
+}
 const server = new ApolloServer({
-    typeDefs,
-    resolvers,
-    plugins: [clientEnforcementPlugin()]
+  typeDefs,
+  resolvers,
+  plugins: [clientEnforcementPlugin()],
 });
 ```
+
 </MultiCodeBlock>
 
 ## Adding enforcement for existing clients

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -17,56 +17,67 @@ If you're using Apollo Server for your gateway, you can require client metadata 
 
 > The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses.
 
-```js title="index.js"
-const clientEnforcementPlugin = {
-  requestDidStart: ({request, logger}) => {
-    let clientName = request.http.headers.get('apollographql-client-name');
-    let clientVersion = request.http.headers.get(
-      'apollographql-client-version'
-    );
+<MultiCodeBlock>
 
-    if (!clientName) {
-      let logString = `Execution Denied: Operation has no identified client`;
-      logger.debug(logString);
-
-      throw new ApolloError(logString);
-    }
-
-    if (!clientVersion) {
-      let logString = `Execution Denied: Client ${clientName} has no identified version`;
-      logger.debug(logString);
-
-      throw new ApolloError(logString);
-    }
-
+```ts title="index.ts"
+function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext>  {
     return {
-      parsingDidStart({queryHash, request}) {
-        if (!request.operationName) {
-          logger.debug(`Unnamed Operation: ${queryHash}`);
+        async requestDidStart(_) {
+            return {
+                async didResolveOperation(requestContext) {
+                    let clientName = requestContext.request.http.headers.get('apollographql-client-name');
+                    let clientVersion = requestContext.request.http.headers.get(
+                        'apollographql-client-version'
+                    );
+    
+                    if (!clientName) {
+                        let logString = `Execution Denied: Operation has no identified client`;
+                        requestContext.logger.debug(logString)
+                        throw new GraphQLError(logString);
+                    }
+    
+                    if (!clientVersion) {
+                        let logString = `Execution Denied: Client ${clientName} has no identified version`;
+                        requestContext.logger.debug(logString)
+                        throw new GraphQLError(logString);
+                    }
+    
+                    if (!requestContext.operationName) {
+                        let logString = `Unnamed Operation: ${requestContext.queryHash}`;
+                        requestContext.logger.debug(logString);
+    
+                        throw new GraphQLError(logString, {
+                            extensions: {
+                                queryHash: requestContext.queryHash,
+                                clientName: clientName,
+                                clientVersion: clientVersion,
+                                exception: {
+                                    message: `All operations must be named`
+                                }
+                            }
+                        });
+                    }
+                },
 
-          let error = new ApolloError('Execution denied: Unnamed operation');
-
-          Object.assign(error.extensions, {
-            queryHash: queryHash,
-            clientName: clientName,
-            clientVersion: clientVersion,
-            exception: {
-              message: `All operations must be named`
-            }
-          });
-
-          throw error;
-        }
-      }
-    };
-  }
+                async didEncounterErrors(requestContext) {
+                    requestContext.errors.forEach(error => {
+                        requestContext.logger.error(error)
+                        console.log(error.toString())
+                    });
+                }
+            };
+        },
+    
+    }
 };
 
 const server = new ApolloServer({
-  gateway,
-  plugins: [clientEnforcementPlugin]
+    typeDefs,
+    resolvers,
+    plugins: [clientEnforcementPlugin()]
 });
 ```
+</MultiCodeBlock>
 
 ## Adding enforcement for existing clients
 

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -15,7 +15,7 @@ Together, these pieces of information help teams monitor their graph and make ch
 
 If you're using Apollo Server for your gateway, you can require client metadata in every incoming request with a [custom plugin](/apollo-server/integrations/plugins/):
 
-> The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses.
+> The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses. Additionally, these changes should be reflected in the [usage reporting plugin](/apollo-server/api/plugin/usage-reporting/#generateclientinfo).
 
 <MultiCodeBlock>
 

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -25,36 +25,30 @@ function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext> {
     async requestDidStart() {
       return {
         async didResolveOperation(requestContext) {
-          let clientName = requestContext.request.http.headers.get(
+          const clientName = requestContext.request.http.headers.get(
             "apollographql-client-name"
           );
-          let clientVersion = requestContext.request.http.headers.get(
+          const clientVersion = requestContext.request.http.headers.get(
             "apollographql-client-version"
           );
 
           if (!clientName) {
-            let logString = `Execution Denied: Operation has no identified client`;
+            const logString = `Execution Denied: Operation has no identified client`;
             requestContext.logger.debug(logString);
             throw new GraphQLError(logString);
           }
 
           if (!clientVersion) {
-            let logString = `Execution Denied: Client ${clientName} has no identified version`;
+            const logString = `Execution Denied: Client ${clientName} has no identified version`;
             requestContext.logger.debug(logString);
             throw new GraphQLError(logString);
           }
 
           if (!requestContext.operationName) {
-            let logString = `Unnamed Operation: ${requestContext.queryHash}. All operations must be named`;
+            const logString = `Unnamed Operation: ${requestContext.queryHash}. All operations must be named`;
             requestContext.logger.debug(logString);
 
-            throw new GraphQLError(logString, {
-              extensions: {
-                queryHash: requestContext.queryHash,
-                clientName,
-                clientVersion,
-              },
-            });
+            throw new GraphQLError(logString);
           }
         },
       };


### PR DESCRIPTION
Updated [client ID enforcement](https://www.apollographql.com/docs/technotes/TN0001-client-id-enforcement/) technote with the following:

* Replaced `ApolloError` with `GraphQLError`
* Moved implementation from `requestDidStart` to `didResolveOperation`
* Implemented `didEncounterErrors` to log errors
* Re-wrote example in `ts` which is cross-compiled to `js`