### PR TITLE
Prepare for Apollo Kotlin v4

### DIFF
--- a/sources/remote.js
+++ b/sources/remote.js
@@ -34,6 +34,10 @@ module.exports = {
   },
   kotlin: {
     remote: 'https://github.com/apollographql/apollo-kotlin',
+    branch: 'release-3.x'
+  },
+  'kotlin/v4': {
+    remote: 'https://github.com/apollographql/apollo-kotlin',
     branch: 'main'
   },
   'kotlin/v2': {


### PR DESCRIPTION
Not 100% sure if that'd work. What I would like is:

* `kotlin` => `release-3.x` Current stable (default)
* `kotlin/v2` => `release-2.x` Older version
* `kotlin/v4` => `main` Upcoming version (not stable)

Is that something the docs can do? Ideally with a banner "you're viewing the docs for the upcoming version blabla.."

Ping @BoD @bignimbus for awareness