### PR TITLE
Update Embedded explorer docs with config option changes

### DIFF
--- a/src/content/graphos/explorer/embed-explorer.mdx
+++ b/src/content/graphos/explorer/embed-explorer.mdx
@@ -277,7 +277,7 @@ If you pass the `handleRequest` option, this option is ignored.
 
 Read more about the `fetch` API and credentials [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials).
 
-This config option is **deprecated** in favor of using the includeCookies connection setting on your variant in Studio
+This config option is **deprecated** in favor of configuring the **Include cookies** setting for your variant in the _non_-embedded Explorer.
 </td>
 </tr>
 

--- a/src/content/graphos/explorer/embed-explorer.mdx
+++ b/src/content/graphos/explorer/embed-explorer.mdx
@@ -269,13 +269,15 @@ You might want to do this if you need to include specific headers in every reque
 </td>
 <td>
 
-By default, the embedded Explorer uses the default `fetch` function to make requests, which passes `{ credentials: 'omit' }`.
+By default, the embedded Explorer uses the includeCookies connection setting of your variant in studio.
 
 You can set `includeCookies` to `true` if you instead want the Explorer to pass `{ credentials: 'include' }` for its requests.
 
 If you pass the `handleRequest` option, this option is ignored.
 
 Read more about the `fetch` API and credentials [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials).
+
+This config option is **deprecated** in favor of using the includeCookies connection setting on your variant in Studio
 </td>
 </tr>
 

--- a/src/content/graphos/explorer/embed-explorer.mdx
+++ b/src/content/graphos/explorer/embed-explorer.mdx
@@ -269,7 +269,7 @@ You might want to do this if you need to include specific headers in every reque
 </td>
 <td>
 
-By default, the embedded Explorer uses the includeCookies connection setting of your variant in studio.
+By default, the embedded Explorer uses your variant's **Include cookies** setting, which you configure from the _non_-emedded Explorer in Studio.
 
 You can set `includeCookies` to `true` if you instead want the Explorer to pass `{ credentials: 'include' }` for its requests.
 

--- a/src/content/graphos/explorer/sandbox.mdx
+++ b/src/content/graphos/explorer/sandbox.mdx
@@ -271,9 +271,9 @@ You might want to do this if you need to include specific headers in every reque
 </td>
 <td>
 
-By default, the embedded Sandbox does not show the includeCookies toggle in the connection settings.
+By default, the embedded Sandbox does not show the **Include cookies** toggle in its connection settings.
 
-You can set `hideCookieToggle` to `false` if you want to let users of your embedded Sandbox instance to toggle the `includeCookies` setting in embedded Sandbox.
+Set `hideCookieToggle` to `false` to enable users of your embedded Sandbox instance to toggle the **Include cookes** setting.
 </td>
 </tr>
 
@@ -287,7 +287,7 @@ You can set `hideCookieToggle` to `false` if you want to let users of your embed
 </td>
 <td>
 
-By default, the embedded Sandbox uses your `includeCookies` value from your sandbox connection settings.
+By default, the embedded Sandbox uses your `includeCookies` value from your Sandbox connection settings.
 
 You can set `includeCookies` to `true` if you instead want the Explorer to pass `{ credentials: 'include' }` for its requests.
 
@@ -295,7 +295,7 @@ If you pass the `handleRequest` option, this option is ignored.
 
 Read more about the `fetch` API and credentials [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials).
 
-This config option is **deprecated** in using the sandbox connection settings cookie toggle and setting the default includeCookies value with `initialState.includeCookies`
+This config option is **deprecated** in favor of using the Sandbox connection settings cookie toggle and setting the default value via `initialState.includeCookies`.
 </td>
 </tr>
 

--- a/src/content/graphos/explorer/sandbox.mdx
+++ b/src/content/graphos/explorer/sandbox.mdx
@@ -205,7 +205,7 @@ The `EmbeddedSandbox` object takes an options object with the following structur
       },
     })
   },
-  includeCookies: false,
+  hideCookieToggle: true,
 }
 ```
 
@@ -264,6 +264,22 @@ You might want to do this if you need to include specific headers in every reque
 <tr>
 <td>
 
+##### `hideCookieToggle`
+
+`boolean`
+
+</td>
+<td>
+
+By default, the embedded Sandbox does not show the includeCookies toggle in the connection settings.
+
+You can set `hideCookieToggle` to `false` if you want to let users of your embedded Sandbox instance to toggle the `includeCookies` setting in embedded Sandbox.
+</td>
+</tr>
+
+<tr>
+<td>
+
 ##### `includeCookies`
 
 `boolean`
@@ -271,13 +287,15 @@ You might want to do this if you need to include specific headers in every reque
 </td>
 <td>
 
-By default, the embedded Sandbox uses the default `fetch` function to make requests, which passes `{ credentials: 'omit' }`.
+By default, the embedded Sandbox uses your `includeCookies` value from your sandbox connection settings.
 
 You can set `includeCookies` to `true` if you instead want the Explorer to pass `{ credentials: 'include' }` for its requests.
 
 If you pass the `handleRequest` option, this option is ignored.
 
 Read more about the `fetch` API and credentials [here](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials).
+
+This config option is **deprecated** in using the sandbox connection settings cookie toggle and setting the default includeCookies value with `initialState.includeCookies`
 </td>
 </tr>
 


### PR DESCRIPTION
(related PR)[https://github.com/apollographql/embeddable-explorer/pull/215]

We are updating embedded explorer and sandbox and deprecating their `includeCookies` fields. For embedded sandbox we are also adding a `hideCookieToggle` config option. This PR introduces docs changes to clarify how these fields are used now and that the `includeCookies` ones are now deprecated.

This will need copy tweaks but I put a little bit in to get a start on it.