### PR TITLE
[TN0001] Update client ID enforcement to include router

### DIFF
--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -11,6 +11,8 @@ Clients can (and should) also [name their GraphQL operations](/react/data/operat
 
 Together, these pieces of information help teams monitor their graph and make changes to it safely. We strongly encourage that your GraphQL gateway _require_ client details _and_ operation names from all requesting clients.
 
+Customers using Apollo Router and Managed Federation should enable client awareness through the [router configuration file](/router/managed-federation/client-awareness/) directly.
+
 ## Enforcing in Apollo Server
 
 If you're using Apollo Server for your gateway, you can require client metadata in every incoming request with a [custom plugin](/apollo-server/integrations/plugins/):
@@ -60,6 +62,83 @@ const server = new ApolloServer({
   resolvers,
   plugins: [clientEnforcementPlugin()],
 });
+```
+```js title="index.js"
+function clientEnforcementPlugin() {
+  return {
+    async requestDidStart() {
+      return {
+        async didResolveOperation(requestContext) {
+          const clientName = requestContext.request.http.headers.get('apollographql-client-name');
+
+          const clientVersion = requestContext.request.http.headers.get('apollographql-client-version');
+
+          if (!clientName) {
+            const logString = `Execution Denied: Operation has no identified client`;
+            requestContext.logger.debug(logString);
+            throw new GraphQLError(logString);
+          }
+
+          if (!clientVersion) {
+            const logString = `Execution Denied: Client ${clientName} has no identified version`;
+            requestContext.logger.debug(logString);
+            throw new GraphQLError(logString);
+          }
+
+          if (!requestContext.operationName) {
+            const logString = `Unnamed Operation: ${requestContext.queryHash}. All operations must be named`;
+            requestContext.logger.debug(logString);
+
+            throw new GraphQLError(logString);
+          }
+        },
+      };
+    },
+  };
+}
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  plugins: [clientEnforcementPlugin()],
+});
+```
+
+```rhai title="client-id.rhai"
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+  }
+
+fn process_request(request) {
+    let valid_clients = ["1", "2"];
+    let valid_client_names = ["apollo-client"];
+    if ("apollographql-client-version" in request.headers && "apollographql-client-name" in request.headers) {
+      let client_header = request.headers["apollographql-client-version"];
+      let name_header = request.headers["apollographql-client-name"];
+    
+    if !valid_clients.contains(client_header) {
+      log_error("Invalid client ID provided");
+      throw #{
+        status: 401,
+        message: "Invalid client ID provided"
+      };
+    }
+    if !valid_client_names.contains(name_header) {
+      log_error("Invalid client name provided");
+      throw #{
+        status: 401,
+        message: "Invalid client name provided"
+      };
+    }
+  }
+  else {
+    log_error("No client headers set");
+    throw #{
+      status: 401,
+      message: "No client headers set"
+    };
+  }    
+}
 ```
 
 </MultiCodeBlock>

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -2,7 +2,7 @@
 title: Client ID enforcement
 id: TN0001
 description: Require client details and operation names to help monitor schema usage
-tags: [server, observability]
+tags: [server, observability, router]
 ---
 
 As part of Apollo Studio metrics reporting, servers can [tag reported operations with the requesting client's name and version](/graphos/metrics/client-awareness). This helps graph maintainers understand which clients are using which fields in the schema.
@@ -11,15 +11,12 @@ Clients can (and should) also [name their GraphQL operations](/react/data/operat
 
 Together, these pieces of information help teams monitor their graph and make changes to it safely. We strongly encourage that your GraphQL gateway _require_ client details _and_ operation names from all requesting clients.
 
-Customers using Apollo Router and Managed Federation should enable client awareness through the [router configuration file](/router/managed-federation/client-awareness/) directly.
+## Enforcing in Apollo Router
 
-## Enforcing in Apollo Server
+Customers using Apollo Router and Managed Federation should enable client awareness through the [router configuration file](/router/managed-federation/client-awareness/) directly. 
 
-If you're using Apollo Server for your gateway, you can require client metadata in every incoming request with a [custom plugin](/apollo-server/integrations/plugins/):
+Client headers can also be enforced using a [Rhai script](/router/customizations/rhai) on every incoming request.
 
-> The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses. Additionally, these changes should be reflected in the [usage reporting plugin](/apollo-server/api/plugin/usage-reporting/#generateclientinfo).
-
-<MultiCodeBlock>
 ```rhai title="client-id.rhai"
 fn supergraph_service(service) {
     const request_callback = Fn("process_request");
@@ -30,6 +27,7 @@ fn process_request(request) {
   log_info("processing request");
   let valid_clients = ["1", "2"];
   let valid_client_names = ["apollo-client"];
+
   if ("apollographql-client-version" in request.headers && "apollographql-client-name" in request.headers) {
     let client_header = request.headers["apollographql-client-version"];
     let name_header = request.headers["apollographql-client-name"];
@@ -59,6 +57,14 @@ fn process_request(request) {
 }
 ```
 
+## Enforcing in Apollo Server
+
+If you're using Apollo Server for your gateway, you can require client metadata in every incoming request with a [custom plugin](/apollo-server/integrations/plugins/):
+
+> The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses. Additionally, these changes should be reflected in the [usage reporting plugin](/apollo-server/api/plugin/usage-reporting/#generateclientinfo).
+
+<MultiCodeBlock>
+
 ```ts title="index.ts"
 function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext> {
   return {
@@ -71,46 +77,6 @@ function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext> {
           const clientVersion = requestContext.request.http.headers.get(
             "apollographql-client-version"
           );
-
-          if (!clientName) {
-            const logString = `Execution Denied: Operation has no identified client`;
-            requestContext.logger.debug(logString);
-            throw new GraphQLError(logString);
-          }
-
-          if (!clientVersion) {
-            const logString = `Execution Denied: Client ${clientName} has no identified version`;
-            requestContext.logger.debug(logString);
-            throw new GraphQLError(logString);
-          }
-
-          if (!requestContext.operationName) {
-            const logString = `Unnamed Operation: ${requestContext.queryHash}. All operations must be named`;
-            requestContext.logger.debug(logString);
-
-            throw new GraphQLError(logString);
-          }
-        },
-      };
-    },
-  };
-}
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  plugins: [clientEnforcementPlugin()],
-});
-```
-
-```js title="index.js"
-function clientEnforcementPlugin() {
-  return {
-    async requestDidStart() {
-      return {
-        async didResolveOperation(requestContext) {
-          const clientName = requestContext.request.http.headers.get('apollographql-client-name');
-
-          const clientVersion = requestContext.request.http.headers.get('apollographql-client-version');
 
           if (!clientName) {
             const logString = `Execution Denied: Operation has no identified client`;

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -20,6 +20,44 @@ If you're using Apollo Server for your gateway, you can require client metadata 
 > The header names used below are the default headers sent by Apollo Client, but you can change them to whatever names your client uses. Additionally, these changes should be reflected in the [usage reporting plugin](/apollo-server/api/plugin/usage-reporting/#generateclientinfo).
 
 <MultiCodeBlock>
+```rhai title="client-id.rhai"
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+  }
+
+fn process_request(request) {
+  log_info("processing request");
+  let valid_clients = ["1", "2"];
+  let valid_client_names = ["apollo-client"];
+  if ("apollographql-client-version" in request.headers && "apollographql-client-name" in request.headers) {
+    let client_header = request.headers["apollographql-client-version"];
+    let name_header = request.headers["apollographql-client-name"];
+  
+    if !valid_clients.contains(client_header) {
+      log_error("Invalid client ID provided");
+      throw #{
+        status: 401,
+        message: "Invalid client ID provided"
+      };
+    }
+    if !valid_client_names.contains(name_header) {
+      log_error("Invalid client name provided");
+      throw #{
+        status: 401,
+        message: "Invalid client name provided"
+      };
+    }
+  }
+  else {
+    log_error("No client headers set");
+    throw #{
+      status: 401,
+      message: "No client headers set"
+    };
+  }    
+}
+```
 
 ```ts title="index.ts"
 function clientEnforcementPlugin(): ApolloServerPlugin<BaseContext> {
@@ -63,6 +101,7 @@ const server = new ApolloServer({
   plugins: [clientEnforcementPlugin()],
 });
 ```
+
 ```js title="index.js"
 function clientEnforcementPlugin() {
   return {
@@ -102,45 +141,6 @@ const server = new ApolloServer({
   plugins: [clientEnforcementPlugin()],
 });
 ```
-
-```rhai title="client-id.rhai"
-fn supergraph_service(service) {
-    const request_callback = Fn("process_request");
-    service.map_request(request_callback);
-  }
-
-fn process_request(request) {
-    let valid_clients = ["1", "2"];
-    let valid_client_names = ["apollo-client"];
-    if ("apollographql-client-version" in request.headers && "apollographql-client-name" in request.headers) {
-      let client_header = request.headers["apollographql-client-version"];
-      let name_header = request.headers["apollographql-client-name"];
-    
-    if !valid_clients.contains(client_header) {
-      log_error("Invalid client ID provided");
-      throw #{
-        status: 401,
-        message: "Invalid client ID provided"
-      };
-    }
-    if !valid_client_names.contains(name_header) {
-      log_error("Invalid client name provided");
-      throw #{
-        status: 401,
-        message: "Invalid client name provided"
-      };
-    }
-  }
-  else {
-    log_error("No client headers set");
-    throw #{
-      status: 401,
-      message: "No client headers set"
-    };
-  }    
-}
-```
-
 </MultiCodeBlock>
 
 ## Adding enforcement for existing clients

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -15,7 +15,7 @@ Together, these pieces of information help teams monitor their graph and make ch
 
 Apollo router supports client awareness by default if the client sets the `apollographql-client-name` and `apollographql-client-id` in their requests. These values can be overriden using the [router configuration file](/router/managed-federation/client-awareness/) directly.
 
-Client headers can also be enforced using a [Rhai script](/router/customizations/rhai) on every incoming request.
+Client headers can also be enforced using a [Rhai script](/router/customizations/rhai) on every incoming request. 
 
 ```rhai title="client-id.rhai"
 fn supergraph_service(service) {

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -13,7 +13,7 @@ Together, these pieces of information help teams monitor their graph and make ch
 
 ## Enforcing in Apollo Router
 
-Customers using Apollo Router and Managed Federation should enable client awareness through the [router configuration file](/router/managed-federation/client-awareness/) directly. 
+Apollo router supports client awareness by default if the client sets the `apollographql-client-name` and `apollographql-client-id` in their requests. These values can be overriden using the [router configuration file](/router/managed-federation/client-awareness/) directly.
 
 Client headers can also be enforced using a [Rhai script](/router/customizations/rhai) on every incoming request.
 
@@ -117,6 +117,10 @@ If clients are already consuming your graph and _are not_ providing client metad
 
 If you have other existing headers in your HTTP requests that can be parsed to extract some client info, you can extract the info from there.
 
+#### Apollo Router
+Client awareness headers should be overridden using the [router configuration file](/router/managed-federation/client-awareness/#overriding-client-awareness-headers) to use the appropriate header names.
+
+#### Apollo Server
 If you do change the identifying headers, also update the [Usage Reporting Plugin](/apollo-server/api/plugin/usage-reporting) to use the new headers so that the proper client info is also sent to Studio.
 
 ### Ask clients to update their requests


### PR DESCRIPTION
Changes include:
* Include a rhai script example for client ID enforcement
* Callout for managed fed users to use router config directly

Note: The `<MultiCodeBlock>` component wouldn't automatically transpile the `ts` script to `js` so this PR includes the transpiled `js` output as well.