### PR TITLE
[TN02] Fix broken link

### DIFF
--- a/src/content/technotes/TN0002-schema-naming-conventions.mdx
+++ b/src/content/technotes/TN0002-schema-naming-conventions.mdx
@@ -122,7 +122,7 @@ type AddCustomerResponse {
 
 ### Enforcing conventions
 
-Use GraphQL-ESLint's [naming-convention rule](https://github.com/B2o5T/graphql-eslint/blob/master/docs/rules/naming-convention.md) to catch violations.
+Use GraphQL-ESLint's [naming-convention rule](https://github.com/B2o5T/graphql-eslint/blob/master/website/src/pages/rules/naming-convention.md) to catch violations.
 
 ### Namespacing
 


### PR DESCRIPTION
Current link redirects to 404.
The `md` file with rule documentation has been moved.