### PR TITLE
Update technote tags, remove best-practices

### DIFF
--- a/src/content/technotes/TN0002-schema-naming-conventions.mdx
+++ b/src/content/technotes/TN0002-schema-naming-conventions.mdx
@@ -2,7 +2,7 @@
 title: Schema naming conventions
 id: TN0002
 description: Conventions for types, fields, and arguments
-tags: [schema design]
+tags: [schema-design]
 ---
 
 ## High-level guidance

--- a/src/content/technotes/TN0008-production-readiness-checklist.mdx
+++ b/src/content/technotes/TN0008-production-readiness-checklist.mdx
@@ -1,7 +1,7 @@
 ---
 title: Production readiness checklist
 id: TN0008
-tags: [server, sre, client, best practices]
+tags: [server, sre, client]
 ---
 
 We recommend that you complete this checklist before your supergraph begins handling production traffic from clients.

--- a/src/content/technotes/TN0010-reponse-type-pattern.mdx
+++ b/src/content/technotes/TN0010-reponse-type-pattern.mdx
@@ -1,7 +1,7 @@
 ---
 title: Designing response types
 id: TN0010
-tags: [schema design, best practices]
+tags: [schema-design]
 ---
 
 Let's say we have a basic GraphQL API that defines the following `Query` type:

--- a/src/content/technotes/TN0012-namespacing-by-separation-of-concern.mdx
+++ b/src/content/technotes/TN0012-namespacing-by-separation-of-concern.mdx
@@ -1,7 +1,7 @@
 ---
 title: Namespacing by separation of concerns
 id: TN0012
-tags: [schema design, best practices]
+tags: [schema-design]
 ---
 
 Most GraphQL APIs provide their capabilities as root-level fields of the `Query` and `Mutation` types, resulting in a flat structure. For example, the GitHub GraphQL API has approximately 200 of these root-level fields! Even with tools like the Apollo Explorer, navigating and understanding larger "flat" graphs can be difficult.
@@ -87,13 +87,13 @@ Unlike all other fields in a GraphQL operation, the root-level fields of the `Mu
 
 ```graphql
 mutation DoTwoThings {
-  one { 
-    success 
+  one {
+    success
   }
   # The `two` field is not resolved until after `one` is resolved.
   # It is not resolved at all if resolving `one` results in an error.
-  two { 
-    success 
+  two {
+    success
   }
 }
 ```

--- a/src/content/technotes/TN0014-contracts-patterns.mdx
+++ b/src/content/technotes/TN0014-contracts-patterns.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contracts usage patterns
 id: TN0014
-tags: [contracts, best practices]
+tags: [contracts, schema-design]
 ---
 
 [Contracts](/graphos/delivery/contracts/) enable teams to contribute to a single unified graph while also delivering use-case-specific schemas to different types of consumers. Graph administrators define filter rules to generate **contract schemas** that are a strict subset of the source supergraph.

--- a/src/content/technotes/TN0016-router-resource-management.mdx
+++ b/src/content/technotes/TN0016-router-resource-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Managing Apollo Router resources in Kubernetes
 id: TN0016
-tags: [router, best practices, kubernetes]
+tags: [router, kubernetes]
 ---
 
 > Self-hosting the Apollo Router is limited to Apollo Enterprise plans. Other plan types use [managed cloud routing with GraphOS](/graphos/routing/cloud/).

--- a/src/content/technotes/TN0017-interfaces.mdx
+++ b/src/content/technotes/TN0017-interfaces.mdx
@@ -1,7 +1,7 @@
 ---
 title: Recommended usage for GraphQL interfaces
 id: TN0017
-tags: [schema design, federation]
+tags: [schema-design, federation]
 ---
 
 GraphQL interfaces enable schema fields to return one of multiple object types, all of which must _implement_ that interface. To implement an interface, an object type must define all fields that are included in that interface (otherwise, the schema is invalid):

--- a/src/content/technotes/TN0018-aggregating-across-subgraphs.mdx
+++ b/src/content/technotes/TN0018-aggregating-across-subgraphs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Aggregating data across subgraphs
 id: TN0018
-tags: [federation, best practices]
+tags: [federation]
 ---
 
 A supergraph helps you orchestrate data fetches across multiple domains, however it _doesn't_ automatically solve some commonly encountered problems in distributed architectures:

--- a/src/content/technotes/TN0020-mocked-gateway-for-client-development.mdx
+++ b/src/content/technotes/TN0020-mocked-gateway-for-client-development.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Mocking graph functionality to unblock client development"
 id: TN0020
-tags: [gateway, best practices, schema design, federation]
+tags: [gateway, schema-design, federation]
 ---
 
 As your organization builds out its supergraph, you might discover that your client teams are often waiting on subgraph owners to make agreed-upon changes to their schemas. During this time, you can **mock** parts of your supergraph as you develop both your clients and subgraphs, enabling teams to work in parallel without blocking each other.

--- a/src/content/technotes/TN0023-nullability.mdx
+++ b/src/content/technotes/TN0023-nullability.mdx
@@ -1,7 +1,7 @@
 ---
 title: Nullability
 id: TN0023
-tags: [schema design, federation]
+tags: [schema-design, federation]
 ---
 
 ## Make intentional choices about nullability

--- a/src/content/technotes/TN0024-deprecations.mdx
+++ b/src/content/technotes/TN0024-deprecations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema deprecations
 id: TN0024
-tags: [schema design, best practices]
+tags: [schema-design]
 ---
 
 ## Leverage SDL and tooling to manage deprecations

--- a/src/content/technotes/TN0025-supergraph-stewardship.mdx
+++ b/src/content/technotes/TN0025-supergraph-stewardship.mdx
@@ -1,7 +1,7 @@
 ---
 title: Supergraph stewardship
 id: TN0025
-tags: [best practices]
+tags: [schema-design]
 ---
 
 Initial GraphQL adoption often emerges either from within a single team or a small number of teams, and at that scale, managing stewardship concerns may be handled on an informal basis. However, the move toward a unified supergraph requires a more intentional approach. Given the evolutionary nature of a supergraph, strong stewardship practices are needed to help maintain its integrity while simultaneously driving its adoption across teams.

--- a/src/content/technotes/TN0026-thinking-in-entities.mdx
+++ b/src/content/technotes/TN0026-thinking-in-entities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Thinking in entities
 id: TN0026
-tags: [federation, schema design]
+tags: [federation, schema-design]
 ---
 
 ## Thinking entities

--- a/src/content/technotes/TN0027-demand-oriented-schema-design.mdx
+++ b/src/content/technotes/TN0027-demand-oriented-schema-design.mdx
@@ -1,7 +1,7 @@
 ---
 title: Demand oriented schema design
 id: TN0027
-tags: [federation, schema design]
+tags: [federation, schema-design]
 ---
 
 ## Design schemas in a demand-oriented, abstract way

--- a/src/content/technotes/TN0028-change-management.mdx
+++ b/src/content/technotes/TN0028-change-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying API changes with Managed Federation and GraphOS
 id: TN0028
-tags: [federation, best practices]
+tags: [federation]
 ---
 
 A federated GraphQL API is a multi-tiered architecture made up of independent components. GraphQL requests flow through multiple components to construct a response, which in turn flow back through those same components to create a response to send back to the caller, as illustrated below:

--- a/src/content/technotes/TN0029-relay-style-connections.mdx
+++ b/src/content/technotes/TN0029-relay-style-connections.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relay-style connections and pagination FAQ
 id: TN0029
-tags: [best practices, schema design]
+tags: [best-practices, schema-design]
 ---
 
 [Relay](https://relay.dev) is an opinionated GraphQL client, and its associated [Connections specification](https://relay.dev/graphql/connections.htm) defines a pattern for expressing one-to-many relationships in a GraphQL schema:

--- a/src/content/technotes/TN0031-graph-identities.mdx
+++ b/src/content/technotes/TN0031-graph-identities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Graph Identities
 id: TN0031
-tags: [best practices, schema design]
+tags: [schema-design]
 ---
 
 The purpose of this technote is to demonstrate queries/mutations for identifying an actor attempting to use the graph. These examples can be useful for inspiring how the actor identity may be described in a GraphQL Schema and includes multiple use-cases for both users and services.

--- a/src/content/technotes/TN0032-sdui-and-graphql.mdx
+++ b/src/content/technotes/TN0032-sdui-and-graphql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server-Driven UI and GraphQL
 id: TN0032
-tags: [schema design, server-driven ui]
+tags: [schema-design, server-driven-ui]
 ---
 
 
@@ -64,7 +64,7 @@ query FeaturedProductsCollection {
     }
     ... on ProductsCarousel {
       products {
-        ...productFields			
+        ...productFields
       }
     }
     ... on ProductsError {

--- a/src/content/technotes/TN0033-sdui-patterns.mdx
+++ b/src/content/technotes/TN0033-sdui-patterns.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server-Driven UI Schema Patterns
 id: TN0033
-tags: [schema patterns]
+tags: [schema-design, server-driven-ui]
 ---
 
 

--- a/src/content/technotes/TN0036-owner-pattern.mdx
+++ b/src/content/technotes/TN0036-owner-pattern.mdx
@@ -1,7 +1,7 @@
 ---
 title: Enforcing entity ownership in Apollo Federation
 id: TN0030
-tags: [best practices, federation]
+tags: [federation]
 ---
 
 In Federation 2, the notion of "extending" an entity type is strictly conceptual. All definitions of a type in different subgraphs are merged according to the "shareability" of fields. In the following example, neither subgraph really _owns_ or _extends_ the `Product` entity. Instead, they both _contribute fields_ to it.

--- a/src/content/technotes/config.json
+++ b/src/content/technotes/config.json
@@ -5,7 +5,6 @@
     "Home": "/",
     "Tags": {
       "auth": "/tags/auth",
-      "best practices": "/tags/best-practices",
       "caching": "/tags/caching",
       "client": "/tags/client",
       "contracts": "/tags/contracts",
@@ -15,8 +14,7 @@
       "observability": "/tags/observability",
       "performance": "/tags/performance",
       "router": "/tags/router",
-      "schema design": "/tags/schema-design",
-      "schema patterns": "/tags/schema-patterns",
+      "schema-design": "/tags/schema-design",
       "security": "/tags/security",
       "server": "/tags/server",
       "server-driven-ui": "/tags/server-driven-ui",


### PR DESCRIPTION
All technotes are best practices. Remove this redundant tag and make sure the rest are properly used just by doing the `kebab-case`