### PR TITLE
Updated react contributing starter project

### DIFF
--- a/src/content/community/contributing.md
+++ b/src/content/community/contributing.md
@@ -20,7 +20,7 @@ Creating a good reproduction really helps contributors investigate and resolve y
 
 A good starting point for building reproductions are the "hello world" examples on the [developer home page](http://dev.apollodata.com):
 
-  - [React Version](https://github.com/apollostack/frontpage-react-app)
+  - [React Version](https://github.com/apollographql/react-apollo-error-template)
   - [Angular 2 Version](https://github.com/apollostack/frontpage-angular2-app)
 
 ### Suggesting features


### PR DESCRIPTION
The starter project for reporting a bug was outdated and thus, not found due to a broken and old link. I replaced that GitHub repo link with a newer start project found in the apollographql Github: https://github.com/apollographql/react-apollo-error-template. Regards the Angular starter project, I was not able to find an official starter for it so I left the old one there tho it does not work.