### PR TITLE
update referenced property from table (federated_tracing)

### DIFF
--- a/src/content/graphos/metrics/field-usage.mdx
+++ b/src/content/graphos/metrics/field-usage.mdx
@@ -208,7 +208,7 @@ If you have a [federated graph](https://apollographql.com/docs/federation), your
 
 To report metrics for field executions, your GraphQL server can run any recent version of Apollo Server 2.x or 3.x.
 
-If you have a [federated graph](https://apollographql.com/docs/federation), your subgraphs must support federated tracing. For compatible libraries, see the **FTV1** column of [this table](/federation/building-supergraphs/supported-subgraphs/).
+If you have a [federated graph](https://apollographql.com/docs/federation), your subgraphs must support federated tracing. For compatible libraries, see the `FEDERATED_TRACING` property of [this table](/federation/building-supergraphs/supported-subgraphs/).
 
 > If _some_ of your subgraphs support federated tracing and others _don't_, only field executions in compatible subgraphs are reported to Apollo.
 


### PR DESCRIPTION
The table was updated to look like this:

<img width="760" alt="Screenshot 2023-03-22 at 11 26 28 AM" src="https://user-images.githubusercontent.com/6900407/226954700-d25c40f4-c5e3-4e24-a520-bc2dd6073aa8.png">

"`FTV1` column" doesn't exist anymore. Updated to refer to `FEDERATED_TRACING` property.