### PR TITLE
Disable the link checker

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,12 +31,12 @@ const plugins = [
   '@chakra-ui/gatsby-plugin',
   'gatsby-plugin-combine-redirects', // local plugin
   'gatsby-plugin-loadable-components-ssr',
-  {
-    resolve: 'gatsby-plugin-check-links', // local plugin
-    options: {
-      ignore: ['/react/api/core/ApolloClient', '/react/v2/api/apollo-client']
-    }
-  },
+  // {
+  //   resolve: 'gatsby-plugin-check-links', // local plugin
+  //   options: {
+  //     ignore: ['/react/api/core/ApolloClient', '/react/v2/api/apollo-client']
+  //   }
+  // },
   {
     resolve: 'gatsby-plugin-manifest',
     options: {


### PR DESCRIPTION
This is a temporary workaround to the issue that we've been having lately of builds hanging indefinitely. It appears to be due to the sheer size of the data requested during the link checker phase of the build.

The query at the top of our [custom link checker](https://github.com/apollographql/docs/blob/6ec6ac7a085e815e013c9aab1231f6e6b48dbf84/plugins/gatsby-plugin-check-links/gatsby-node.js#L11-L41) requests the MDX AST or raw markdown body (depending on what format the file is) for _every file_ in the docs.

This turns out to be an extremely large JSON blob. It was enough to crash my local graphiql interface when I ran the query through gatsby.

![Screenshot 2023-03-31 at 12 35 36 PM](https://user-images.githubusercontent.com/1216917/229213165-832e20a0-9428-4151-bbdf-10e0f845598e.png)

Disabling the link checker brought the `createPages` step (which is what used to hang indefinitely) down to less than 1 second.

The plan:
- Disable the link checker plugin
- Think of a better link checking strategy that consumes less memory??
- Turn link checking back on

In the meantime, we have a load of broken links to work through and fix in the various docsets.