### PR TITLE
Detect file links (for xml reference documents)

### DIFF
--- a/src/components/RelativeLink.js
+++ b/src/components/RelativeLink.js
@@ -34,10 +34,12 @@ function useLinkProps(href) {
   }
 
   const isExternal = isUrl(href);
-  if (isExternal || href.startsWith('#')) {
+  const isHash = href.startsWith('#');
+  const isFile = href.match(/\.[a-z]+$/);
+  if (isExternal || isHash || isFile) {
     return {
       href,
-      target: isExternal ? '_blank' : null
+      target: isExternal || (isFile && !isHash) ? '_blank' : null
     };
   }
 


### PR DESCRIPTION
The xml links here (https://www.apollographql.com/docs/graphos/sso/saml-integration-guide/) would redirect to a 404 if clicked on, but valid if the page refreshed. This is because the file link would be treated as a `GatsbyLink` and the internal router was unaware of the file.

This update introduces a file detector which looks for an extension on the URL. When such a link is encountered, it is treated as external and a new tab is opened with it.