### PR TITLE
[TN0038] New technote: Keeping client schemas up to date

### DIFF
--- a/src/content/technotes/TN0038-updating-client-schema.mdx
+++ b/src/content/technotes/TN0038-updating-client-schema.mdx
@@ -1,0 +1,17 @@
+---
+title: Keeping schemas up-to-date in client apps
+id: TN0038
+tags: [federation, best-practices, client]
+---
+
+Client apps need to keep their schemas up-to-date whenever changes are made to the supergraph. In order to facilitate this Apollo recommends setting up the following:
+
+- [Schema change notifications](/graphos/metrics/notifications/notification-setup) and ensure messages are sent to the appropriate channels
+- [Apollo Swift](/ios/code-generation/codegen-cli#fetch-schema) and [Apollo Kotlin](/kotlin/advanced/plugin-configuration#downloading-a-schema) build tasks to fetch the latest API schema
+- [`rover graph fetch`](/rover/commands/graphs#graph-fetch) to fetch API schema for any other applications
+
+Apollo also recommends setting up your client applications' build pipeline with the following tasks:
+
+1. Fetch the latest production schema using any of the methods described above, prior to merging any changes to your client code
+1. Run codegen against this schema
+1. The codegen task will validate that any operations used by the client application are compatible with this schema.

--- a/src/content/technotes/TN0038-updating-client-schema.mdx
+++ b/src/content/technotes/TN0038-updating-client-schema.mdx
@@ -8,13 +8,11 @@ Client apps need to keep their schemas up-to-date whenever changes are made to t
 
 - [Schema change notifications](/graphos/metrics/notifications/notification-setup) and ensure messages are sent to the appropriate channels
 - Configure [Apollo Swift](/ios/code-generation/codegen-cli#fetch-schema) and [Apollo Kotlin](/kotlin/advanced/plugin-configuration#downloading-a-schema) build tasks to fetch the latest API schema
-- [`rover graph fetch`](/rover/commands/graphs#graph-fetch) to fetch API schema for any other applications.
+- [`rover graph fetch`](/rover/commands/graphs#graph-fetch) to fetch the API schema for any other applications.
 - Configure codgeneration tools for [Swift](/ios/code-generation/codegen-cli), [Kotlin](/kotlin/advanced/response-based-codegen) and [other platforms](https://github.com/dotansimha/graphql-code-generator)
 
-Apollo also recommends setting up your client applications' local and CI build pipeline with the following tasks:
+To ensure that your client operations are valid against the most recent schema, we recommend re-running code generation in your continuous integration system before merging client changes. The specific steps required are as follows:
 
 1. Fetch the latest production schema using any of the methods described above, prior to merging any changes to your client code
 2. Run codegen against this schema
 3. The codegen task will validate that any operations used by the client application are compatible with this schema.
-
-To ensure that your client operations are valid against the most recent schema, we recommend re-running code generation in your continuous integration system before merging client changes.

--- a/src/content/technotes/TN0038-updating-client-schema.mdx
+++ b/src/content/technotes/TN0038-updating-client-schema.mdx
@@ -16,3 +16,5 @@ Apollo also recommends setting up your client applications' local and CI build p
 1. Fetch the latest production schema using any of the methods described above, prior to merging any changes to your client code
 2. Run codegen against this schema
 3. The codegen task will validate that any operations used by the client application are compatible with this schema.
+
+To ensure that your client operations are valid against the most recent schema, we recommend re-running code generation in your continuous integration system before merging client changes.

--- a/src/content/technotes/TN0038-updating-client-schema.mdx
+++ b/src/content/technotes/TN0038-updating-client-schema.mdx
@@ -7,11 +7,12 @@ tags: [federation, best-practices, client]
 Client apps need to keep their schemas up-to-date whenever changes are made to the supergraph. In order to facilitate this Apollo recommends setting up the following:
 
 - [Schema change notifications](/graphos/metrics/notifications/notification-setup) and ensure messages are sent to the appropriate channels
-- [Apollo Swift](/ios/code-generation/codegen-cli#fetch-schema) and [Apollo Kotlin](/kotlin/advanced/plugin-configuration#downloading-a-schema) build tasks to fetch the latest API schema
-- [`rover graph fetch`](/rover/commands/graphs#graph-fetch) to fetch API schema for any other applications
+- Configure [Apollo Swift](/ios/code-generation/codegen-cli#fetch-schema) and [Apollo Kotlin](/kotlin/advanced/plugin-configuration#downloading-a-schema) build tasks to fetch the latest API schema
+- [`rover graph fetch`](/rover/commands/graphs#graph-fetch) to fetch API schema for any other applications.
+- Configure codgeneration tools for [Swift](/ios/code-generation/codegen-cli), [Kotlin](/kotlin/advanced/response-based-codegen) and [other platforms](https://github.com/dotansimha/graphql-code-generator)
 
-Apollo also recommends setting up your client applications' build pipeline with the following tasks:
+Apollo also recommends setting up your client applications' local and CI build pipeline with the following tasks:
 
 1. Fetch the latest production schema using any of the methods described above, prior to merging any changes to your client code
-1. Run codegen against this schema
-1. The codegen task will validate that any operations used by the client application are compatible with this schema.
+2. Run codegen against this schema
+3. The codegen task will validate that any operations used by the client application are compatible with this schema.

--- a/src/content/technotes/_redirects
+++ b/src/content/technotes/_redirects
@@ -39,3 +39,4 @@
 /TN0035 /docs/technotes/TN0035-load-testing-graphql
 /TN0036 /docs/technotes/TN0036-owner-pattern
 /TN0037 /docs/technotes/TN0036-api-gateways
+/TN0038 /docs/technotes/TN0038-updating-client-schema


### PR DESCRIPTION
### Problem

Client application teams aren't aware of the tooling provided by Apollo to ensure that their client applications' API schemas are up to date and the various build tasks available for Apollo OSS clients to facilitate schema checks and validation for their client schemas. Some of this functionality is used in replacement of the now deprecated [apollo client check](https://www.apollographql.com/docs/graphos/delivery/validating-client-operations/) command. 

This TN documents the recommended approach along with suggest build pipeline changes.