### PR TITLE
Add Gitleaks allowlist file

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+
+[[ rules ]]
+    id = "generic-api-key"
+    [ rules.allowlist ]
+        commits = [
+            "5b47e0b5dc953d0b51b31594117cd76522b67a96",
+            
+        ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,6 +3,7 @@
     id = "generic-api-key"
     [ rules.allowlist ]
         commits = [
+	    # Allowlist some example authentication tokens
             "5b47e0b5dc953d0b51b31594117cd76522b67a96",
             
         ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,9 +1,26 @@
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs. 
+# This is an Apollo-Internal link, but more information about these scans is available here:
+# https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
+# 
+# Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
+# However, this file is not something that Gitleaks natively consumes. This file is an
+# Apollo-convention. Prior to scanning a repo, Apollo merges
+# our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
+# this file if it exists in a repo. The combined config is then used to scan a repo.
+# 
+# We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
+# or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
+# on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
+# This creates a fairly fragile allowlisting mechanism. This file allows us to leverage the full capabilities of the Gitleaks rule syntax
+# to create allowlisting functionality.
 
 [[ rules ]]
     id = "generic-api-key"
     [ rules.allowlist ]
         commits = [
-	    # Allowlist some example authentication tokens
+            # Allowlist https://github.com/apollographql/docs/blob/5b47e0b5dc953d0b51b31594117cd76522b67a96/src/content/basics/tutorial/mutation-resolvers.md?plain=1#L141 
+            # and https://github.com/apollographql/docs/blob/5b47e0b5dc953d0b51b31594117cd76522b67a96/src/content/basics/tutorial/mutation-resolvers.md?plain=1#L170
+	    # These are example authentication tokens
             "5b47e0b5dc953d0b51b31594117cd76522b67a96",
             
         ]


### PR DESCRIPTION
## Motivation / Implements

This PR adds `.gitleaks.toml` to the root of this repo. This file is consumed by the secret-scanning tool that Apollo's SecOps team uses to check for secrets in our source.

This file is being added with the required configuration to tell the scanning tool to ignore values that SecOps has confirmed as false positives.

I will follow up on this PR, but if a maintainer on this repo wants to get ahead of me, this PR is safe to merge at your convenience. Let us know in #security if you have any issues or questions!

Thank you!
