### PR TITLE
`PostEdge` is unreferenced in code example: "An example without edges"

### DIFF
--- a/src/content/technotes/TN0029-relay-style-connections.mdx
+++ b/src/content/technotes/TN0029-relay-style-connections.mdx
@@ -238,11 +238,6 @@ type PostConnection {
   pageInfo: PageInfo!
 }
 
-type PostEdge {
-  node: Post
-  cursor: String!
-}
-
 type Post {
   id: ID!
   title: String


### PR DESCRIPTION
In the section here:
https://www.apollographql.com/docs/technotes/TN0029-relay-style-connections/#do-i-have-to-implement-the-entire-connection-specification
Under "An example without edges", it seems that `PostEdge` is included, but unreferenced, it also seems unclear which element should be used for the `cursor` in the next call, maybe it's `endCursor`, but that seems inconsistent with the previous examples.