### PR TITLE
add note about client versions

### DIFF
--- a/src/content/graphos/metrics/client-awareness.mdx
+++ b/src/content/graphos/metrics/client-awareness.mdx
@@ -5,6 +5,8 @@ description: Understand how each of your clients is using your graph
 
 Apollo Studio enables you to view operation metrics for each of your application's different clients (such as `web` and `iOS`) and client _versions_ (such as `1.0` and `1.1`), helping you understand how each one interacts with your supergraph.
 
+> Client versions are only available on [Enterprise plans](https://www.apollographql.com/pricing/).
+
 You view these segmented metrics from your supergraph variant's **Clients** page:
 
 <img


### PR DESCRIPTION
Client versions are only available on Enterprise plans. This previously wasn't clear in the docs.