### PR TITLE
Fix color flash

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -38,33 +38,6 @@ const headComponents = [
           root.style.setProperty('${DOCS_PAGE_WIDTH_VAR}', pageWidthPx);
         `
     }}
-  />,
-  <script
-    key="color-mode"
-    dangerouslySetInnerHTML={{
-      __html: `
-          const initialColorMode = localStorage.getItem('chakra-ui-color-mode') ?? 'light';
-
-          let mutationCount = 0;
-
-          const mutationObserver = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-              if (mutation.type === 'attributes') {
-                if (mutation.attributeName === 'data-theme' && mutation.target === document.documentElement) {
-                  mutationObserver.disconnect();
-                  mutation.target.setAttribute('data-theme', initialColorMode);
-                  mutationCount++;
-                  if (mutationCount >= 2) {
-                    mutationObserver.observe(mutation.target, {attributes: true});
-                  }
-                }
-              }
-            }
-          });
-
-          mutationObserver.observe(document.documentElement, {attributes: true});
-        `
-    }}
   />
 ];
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -38,6 +38,33 @@ const headComponents = [
           root.style.setProperty('${DOCS_PAGE_WIDTH_VAR}', pageWidthPx);
         `
     }}
+  />,
+  <script
+    key="color-mode"
+    dangerouslySetInnerHTML={{
+      __html: `
+          const initialColorMode = localStorage.getItem('chakra-ui-color-mode') ?? 'light';
+
+          let mutationCount = 0;
+
+          const mutationObserver = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+              if (mutation.type === 'attributes') {
+                if (mutation.attributeName === 'data-theme' && mutation.target === document.documentElement) {
+                  mutationObserver.disconnect();
+                  mutation.target.setAttribute('data-theme', initialColorMode);
+                  mutationCount++;
+                  if (mutationCount >= 2) {
+                    mutationObserver.observe(mutation.target, {attributes: true});
+                  }
+                }
+              }
+            }
+          });
+
+          mutationObserver.observe(document.documentElement, {attributes: true});
+        `
+    }}
   />
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61183,7 +61183,7 @@
     },
     "packages/chakra-helpers": {
       "name": "@apollo/chakra-helpers",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/explorer": "^0.5.2",

--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -6,7 +6,6 @@ import {
   fonts
 } from '@apollo/chakra-helpers';
 import {extendTheme} from '@chakra-ui/react';
-import {mode} from '@chakra-ui/theme-tools';
 
 const {grey, silver, indigo, teal, blilet, midnight, yellow, orange} = colors;
 
@@ -15,7 +14,7 @@ const theme = extendTheme({
     initialColorMode: 'system'
   },
   styles: {
-    global: props => ({
+    global: {
       strong: {
         fontWeight: 'strong'
       },
@@ -24,9 +23,9 @@ const theme = extendTheme({
         color: 'text'
       },
       '*': {
-        borderColor: mode('gray.200', 'whiteAlpha.300')(props)
+        borderColor: 'border'
       }
-    })
+    }
   },
   semanticTokens: {
     fontWeights: {
@@ -43,6 +42,10 @@ const theme = extendTheme({
       text: {
         default: 'gray.800',
         _dark: 'whiteAlpha.900'
+      },
+      border: {
+        default: 'gray.200',
+        _dark: 'whiteAlpha.300'
       },
       primary: {
         default: 'indigo.500',

--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -6,6 +6,7 @@ import {
   fonts
 } from '@apollo/chakra-helpers';
 import {extendTheme} from '@chakra-ui/react';
+import {mode} from '@chakra-ui/theme-tools';
 
 const {grey, silver, indigo, teal, blilet, midnight, yellow, orange} = colors;
 
@@ -14,15 +15,18 @@ const theme = extendTheme({
     initialColorMode: 'system'
   },
   styles: {
-    global: {
+    global: props => ({
       strong: {
         fontWeight: 'strong'
       },
       body: {
         bg: 'bg',
         color: 'text'
+      },
+      '*': {
+        borderColor: mode('whiteAlpha.300', 'gray.200')(props)
       }
-    }
+    })
   },
   semanticTokens: {
     fontWeights: {

--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -17,6 +17,10 @@ const theme = extendTheme({
     global: {
       strong: {
         fontWeight: 'strong'
+      },
+      body: {
+        bg: 'bg',
+        color: 'text'
       }
     }
   },
@@ -31,6 +35,10 @@ const theme = extendTheme({
       bg: {
         default: 'white',
         _dark: 'gray.800'
+      },
+      text: {
+        default: 'gray.800',
+        _dark: 'whiteAlpha.900'
       },
       primary: {
         default: 'indigo.500',

--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -24,7 +24,7 @@ const theme = extendTheme({
         color: 'text'
       },
       '*': {
-        borderColor: mode('whiteAlpha.300', 'gray.200')(props)
+        borderColor: mode('gray.200', 'whiteAlpha.300')(props)
       }
     })
   },

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,16 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box, useColorModeValue} from '@chakra-ui/react';
+import {Box} from '@chakra-ui/react';
 
 export const Alert = ({children}) => {
-  const bgColor = useColorModeValue('yellow.200', 'yellow.600');
-
   return (
     <Box
       textAlign="center"
       py="3"
       px="4"
-      bgColor={bgColor}
+      bgColor="yellow.200"
+      _dark={{
+        bgColor: 'yellow.600'
+      }}
       style={{borderRadius: 4}}
     >
       {children}

--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -1,15 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button, useBreakpointValue} from '@chakra-ui/react';
+import {Button, Text} from '@chakra-ui/react';
 import {FiStar} from 'react-icons/fi';
 import {useUser} from '../utils';
 
 export const FeedbackButton = ({title}) => {
   const {user} = useUser();
-  const text = useBreakpointValue({
-    base: 'Rate',
-    lg: 'Rate article'
-  });
   return (
     <Button
       onClick={() => {
@@ -22,10 +18,19 @@ export const FeedbackButton = ({title}) => {
         });
       }}
       variant="link"
+      color="gray.500"
+      _dark={{
+        color: 'gray.200'
+      }}
       size="lg"
       leftIcon={<FiStar />}
     >
-      {text}
+      <Text as="span" display={{base: 'none', lg: 'inline'}}>
+        Rate article
+      </Text>
+      <Text as="span" display={{base: 'inline', lg: 'none'}}>
+        Rate
+      </Text>
     </Button>
   );
 };

--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -18,7 +18,6 @@ export const FeedbackButton = ({title}) => {
         });
       }}
       variant="link"
-      color="gray.500"
       _dark={{
         color: 'gray.200'
       }}

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -148,8 +148,11 @@ export function Header({children, algoliaFilters}) {
             variant="ghost"
             onClick={toggleColorMode}
             icon={colorMode === 'dark' ? <FiSun /> : <FiMoon />}
+            opacity={typeof window !== 'undefined' ? 1 : 0}
+            transition="opacity 0.2s"
           />
         </Tooltip>
+
         <StudioButton />
       </Flex>
     </Box>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -9,7 +9,9 @@ import {
   Center,
   Flex,
   HStack,
+  Icon,
   IconButton,
+  Text,
   Tooltip,
   useColorMode,
   useColorModeValue
@@ -54,7 +56,7 @@ Eyebrow.propTypes = {
 };
 
 export function Header({children, algoliaFilters}) {
-  const {toggleColorMode, colorMode} = useColorMode();
+  const {toggleColorMode} = useColorMode();
   const tagColorProps = useTagColorProps();
   const {pageWidth, togglePageWidth, showExpandButton} = usePageWidthContext();
 
@@ -138,21 +140,42 @@ export function Header({children, algoliaFilters}) {
         )}
         <Tooltip
           label={
-            colorMode === 'dark'
-              ? 'Switch to light mode'
-              : 'Switch to dark mode'
+            <Text>
+              <Text as="span" display="none" _dark={{display: 'inline'}}>
+                Switch to light mode
+              </Text>
+              <Text as="span" display="inline" _dark={{display: 'none'}}>
+                Switch to dark mode
+              </Text>
+            </Text>
           }
         >
-          <IconButton
-            fontSize="xl"
-            variant="ghost"
-            onClick={toggleColorMode}
-            icon={colorMode === 'dark' ? <FiSun /> : <FiMoon />}
-            opacity={typeof window !== 'undefined' ? 1 : 0}
-            transition="opacity 0.2s"
-          />
+          <Box>
+            <IconButton
+              fontSize="xl"
+              variant="ghost"
+              onClick={toggleColorMode}
+              icon={
+                <>
+                  <Icon
+                    as={FiSun}
+                    display="none"
+                    _dark={{
+                      display: 'block'
+                    }}
+                  />
+                  <Icon
+                    as={FiMoon}
+                    display="block"
+                    _dark={{
+                      display: 'none'
+                    }}
+                  />
+                </>
+              }
+            />
+          </Box>
         </Tooltip>
-
         <StudioButton />
       </Flex>
     </Box>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -18,7 +18,7 @@ import {FiMoon, FiSun} from 'react-icons/fi';
 import {Link as GatsbyLink} from 'gatsby';
 import {TbViewportNarrow, TbViewportWide} from 'react-icons/tb';
 import {usePageWidthContext} from '../PageWidthContext';
-import {useTagColors} from '../../utils';
+import {useTagColorProps} from '../../utils';
 
 const EYEBROW_HEIGHT = 0; // 32;
 const HEADER_HEIGHT = 60;
@@ -55,7 +55,7 @@ Eyebrow.propTypes = {
 
 export function Header({children, algoliaFilters}) {
   const {toggleColorMode, colorMode} = useColorMode();
-  const [tagBg, tagTextColor] = useTagColors();
+  const tagColorProps = useTagColorProps();
   const {pageWidth, togglePageWidth, showExpandButton} = usePageWidthContext();
 
   return (
@@ -99,9 +99,8 @@ export function Header({children, algoliaFilters}) {
               fontWeight="semibold"
               textTransform="uppercase"
               letterSpacing="widest"
-              bg={tagBg}
-              color={tagTextColor}
               rounded="sm"
+              {...tagColorProps}
             >
               Docs
             </Box>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -27,11 +27,13 @@ export const TOTAL_HEADER_HEIGHT =
   EYEBROW_HEIGHT + HEADER_HEIGHT + HEADER_BORDER_WIDTH;
 
 function Eyebrow({children}) {
-  const bg = useColorModeValue('indigo.50', 'indigo.800');
   const bgHover = useColorModeValue('indigo.100', 'indigo.700');
   return (
     <Center
-      bg={bg}
+      bg="indigo.50"
+      _dark={{
+        bg: 'indigo.800'
+      }}
       _hover={{bg: bgHover}}
       css={{height: EYEBROW_HEIGHT}}
       fontSize="sm"

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -20,7 +20,6 @@ import {FiMoon, FiSun} from 'react-icons/fi';
 import {Link as GatsbyLink} from 'gatsby';
 import {TbViewportNarrow, TbViewportWide} from 'react-icons/tb';
 import {usePageWidthContext} from '../PageWidthContext';
-import {useTagColorProps} from '../../utils';
 
 const EYEBROW_HEIGHT = 0; // 32;
 const HEADER_HEIGHT = 60;
@@ -57,7 +56,6 @@ Eyebrow.propTypes = {
 
 export function Header({children, algoliaFilters}) {
   const {toggleColorMode} = useColorMode();
-  const tagColorProps = useTagColorProps();
   const {pageWidth, togglePageWidth, showExpandButton} = usePageWidthContext();
 
   return (
@@ -102,7 +100,12 @@ export function Header({children, algoliaFilters}) {
               textTransform="uppercase"
               letterSpacing="widest"
               rounded="sm"
-              {...tagColorProps}
+              bg="indigo.50"
+              color="indigo.500"
+              _dark={{
+                bg: 'indigo.400',
+                color: 'inherit'
+              }}
             >
               Docs
             </Box>
@@ -150,39 +153,32 @@ export function Header({children, algoliaFilters}) {
             </Text>
           }
         >
-          <Box>
-            <IconButton
-              fontSize="xl"
-              variant="ghost"
-              onClick={toggleColorMode}
-              icon={
-                <>
-                  <Icon
-                    as={FiSun}
-                    display="none"
-                    _dark={{
-                      display: 'block'
-                    }}
-                  />
-                  <Icon
-                    as={FiMoon}
-                    display="block"
-                    _dark={{
-                      display: 'none'
-                    }}
-                  />
-                </>
-              }
-            />
-          </Box>
+          <IconButton
+            fontSize="xl"
+            variant="ghost"
+            onClick={toggleColorMode}
+            icon={
+              <>
+                <Icon
+                  as={FiSun}
+                  display="none"
+                  _dark={{
+                    display: 'block'
+                  }}
+                />
+                <Icon
+                  as={FiMoon}
+                  display="block"
+                  _dark={{
+                    display: 'none'
+                  }}
+                />
+              </>
+            }
+          />
         </Tooltip>
         <StudioButton />
       </Flex>
     </Box>
   );
 }
-
-Header.propTypes = {
-  children: PropTypes.node,
-  algoliaFilters: PropTypes.array
-};

--- a/src/components/Header/StudioButton.js
+++ b/src/components/Header/StudioButton.js
@@ -6,7 +6,7 @@ export default function StudioButton() {
   return (
     <Button
       flexShrink={0}
-      color="indigo.600"
+      colorScheme="indigo"
       _dark={{
         color: 'indigo.200'
       }}

--- a/src/components/Header/StudioButton.js
+++ b/src/components/Header/StudioButton.js
@@ -6,7 +6,10 @@ export default function StudioButton() {
   return (
     <Button
       flexShrink={0}
-      colorScheme="indigo"
+      color="indigo.600"
+      _dark={{
+        color: 'indigo.200'
+      }}
       variant="ghost"
       rightIcon={<FiArrowRight />}
       as="a"

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,10 +1,16 @@
 import React from 'react';
-import {Box, Heading, useColorModeValue} from '@chakra-ui/react';
+import {Box, Heading} from '@chakra-ui/react';
 
 export default function HomePage() {
-  const heroBg = useColorModeValue('indigo.200', 'indigo.600');
   return (
-    <Box py="16" px="10" bg={heroBg}>
+    <Box
+      py="16"
+      px="10"
+      bg="indigo.200"
+      _dark={{
+        bg: 'indigo.600'
+      }}
+    >
       <Heading mb="2" size="3xl">
         Welcome to Apollo Docs
       </Heading>

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -42,12 +42,7 @@ export function Odyssey() {
         <Button
           as="a"
           href="https://www.apollographql.com/tutorials"
-          bg="indigo.500"
-          color="white"
-          _dark={{
-            bg: 'indigo.200',
-            color: 'gray.800'
-          }}
+          colorScheme="indigo"
           rightIcon={<FiArrowRight />}
         >
           Explore Tutorials

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -42,7 +42,10 @@ export function Odyssey() {
         <Button
           as="a"
           href="https://www.apollographql.com/tutorials"
-          colorScheme="indigo"
+          bg="indigo.500"
+          _dark={{
+            bg: 'indigo.200'
+          }}
           rightIcon={<FiArrowRight />}
         >
           Explore Tutorials

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -10,7 +10,6 @@ import {
   Link,
   SimpleGrid,
   Text,
-  useColorModeValue,
   useToken
 } from '@chakra-ui/react';
 import {FiArrowRight} from 'react-icons/fi';
@@ -18,8 +17,8 @@ import {Link as GatsbyLink} from 'gatsby';
 import {PrimaryLink} from './RelativeLink';
 
 export function Odyssey() {
-  const shade = useColorModeValue(50, 600);
-  const gradient = useToken('colors', [`blue.${shade}`, `indigo.${shade}`]);
+  const lightGradient = useToken('colors', ['blue.50', 'indigo.50']);
+  const darkGradient = useToken('colors', ['blue.600', 'indigo.600']);
   return (
     <Grid
       gap={{base: 6, lg: 10}}
@@ -27,7 +26,10 @@ export function Odyssey() {
       alignItems="center"
       rounded="lg"
       p="6"
-      bgImage={`linear-gradient(${['to right', ...gradient]})`}
+      bgImage={`linear-gradient(${['to right', ...lightGradient]})`}
+      _dark={{
+        bgImage: `linear-gradient(${['to right', ...darkGradient]})`
+      }}
     >
       <div>
         <Text fontSize="md">

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -43,8 +43,10 @@ export function Odyssey() {
           as="a"
           href="https://www.apollographql.com/tutorials"
           bg="indigo.500"
+          color="white"
           _dark={{
-            bg: 'indigo.200'
+            bg: 'indigo.200',
+            color: 'gray.800'
           }}
           rightIcon={<FiArrowRight />}
         >

--- a/src/components/InlineCode.js
+++ b/src/components/InlineCode.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import {chakra, useColorModeValue} from '@chakra-ui/react';
+import {chakra} from '@chakra-ui/react';
 
 export default function InlineCode(props) {
-  const bgColor = useColorModeValue('gray.50', 'gray.700');
   return (
     <chakra.code
       fontFamily="mono"
@@ -11,7 +10,10 @@ export default function InlineCode(props) {
       py="0.5"
       rounded="sm"
       color="secondary"
-      bgColor={bgColor}
+      bgColor="gray.50"
+      _dark={{
+        bgColor: 'gray.700'
+      }}
       {...props}
     />
   );

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -228,7 +228,6 @@ export default function Page({file}) {
         as="a"
         href={`${repo}/${join(...repoPath)}`}
         variant="link"
-        color="gray.500"
         _dark={{
           color: 'gray.200'
         }}
@@ -431,7 +430,6 @@ export default function Page({file}) {
           href="https://community.apollographql.com/"
           variant="link"
           size="lg"
-          color="gray.500"
           _dark={{
             color: 'gray.200'
           }}
@@ -444,7 +442,6 @@ export default function Page({file}) {
           href="https://discord.gg/yFZJH2QYrK"
           variant="link"
           size="lg"
-          color="gray.500"
           _dark={{
             color: 'gray.200'
           }}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -208,11 +208,6 @@ export default function Page({file}) {
     [versions]
   );
 
-  const editText = useBreakpointValue({
-    base: 'Edit',
-    lg: 'Edit on GitHub'
-  });
-
   const editOnGitHub = useMemo(() => {
     const repo = `https://github.com/${
       gitRemote?.full_name ?? 'apollographql/docs'
@@ -233,13 +228,22 @@ export default function Page({file}) {
         as="a"
         href={`${repo}/${join(...repoPath)}`}
         variant="link"
+        color="gray.500"
+        _dark={{
+          color: 'gray.200'
+        }}
         size="lg"
         leftIcon={<FiGithub />}
       >
-        {editText}
+        <Text as="span" display={{base: 'none', lg: 'inline'}}>
+          Edit on GitHub
+        </Text>
+        <Text as="span" display={{base: 'inline', lg: 'none'}}>
+          Edit
+        </Text>
       </Button>
     );
-  }, [gitRemote, basePath, relativePath, editText]);
+  }, [gitRemote, basePath, relativePath]);
 
   return (
     <>
@@ -427,6 +431,10 @@ export default function Page({file}) {
           href="https://community.apollographql.com/"
           variant="link"
           size="lg"
+          color="gray.500"
+          _dark={{
+            color: 'gray.200'
+          }}
           leftIcon={<FiMessageCircle />}
         >
           Forums
@@ -436,6 +444,10 @@ export default function Page({file}) {
           href="https://discord.gg/yFZJH2QYrK"
           variant="link"
           size="lg"
+          color="gray.500"
+          _dark={{
+            color: 'gray.200'
+          }}
           onClick={() => window.gtag?.('event', 'discord_join_docs')}
           leftIcon={<SiDiscord />}
         >

--- a/src/components/Search/Highlight.js
+++ b/src/components/Search/Highlight.js
@@ -1,33 +1,31 @@
 import PropTypes from 'prop-types';
-import React, {useCallback} from 'react';
+import React from 'react';
 import {Markup} from 'interweave';
 import {chakra} from '@chakra-ui/react';
 
 export default function Highlight({value}) {
-  const transform = useCallback((node, children) => {
-    if (node.tagName === 'MARK') {
-      return (
-        <chakra.mark
-          bg="none"
-          color="indigo.500"
-          _dark={{
-            color: 'inherit'
-          }}
-          fontWeight="semibold"
-          textDecoration="underline"
-        >
-          {children}
-        </chakra.mark>
-      );
-    }
-  }, []);
-
   return (
     <Markup
       content={value}
       allowList={['mark']}
       transformOnlyAllowList
-      transform={transform}
+      transform={(node, children) => {
+        if (node.tagName === 'MARK') {
+          return (
+            <chakra.mark
+              bg="none"
+              color="indigo.500"
+              _dark={{
+                color: 'inherit'
+              }}
+              fontWeight="semibold"
+              textDecoration="underline"
+            >
+              {children}
+            </chakra.mark>
+          );
+        }
+      }}
     />
   );
 }

--- a/src/components/Search/Highlight.js
+++ b/src/components/Search/Highlight.js
@@ -1,28 +1,26 @@
 import PropTypes from 'prop-types';
 import React, {useCallback} from 'react';
 import {Markup} from 'interweave';
-import {chakra, useColorModeValue} from '@chakra-ui/react';
+import {chakra} from '@chakra-ui/react';
 
 export default function Highlight({value}) {
-  const markColor = useColorModeValue('indigo.500', 'inherit');
-
-  const transform = useCallback(
-    (node, children) => {
-      if (node.tagName === 'MARK') {
-        return (
-          <chakra.mark
-            bg="none"
-            color={markColor}
-            fontWeight="semibold"
-            textDecoration="underline"
-          >
-            {children}
-          </chakra.mark>
-        );
-      }
-    },
-    [markColor]
-  );
+  const transform = useCallback((node, children) => {
+    if (node.tagName === 'MARK') {
+      return (
+        <chakra.mark
+          bg="none"
+          color="indigo.500"
+          _dark={{
+            color: 'inherit'
+          }}
+          fontWeight="semibold"
+          textDecoration="underline"
+        >
+          {children}
+        </chakra.mark>
+      );
+    }
+  }, []);
 
   return (
     <Markup

--- a/src/components/Search/Preview.js
+++ b/src/components/Search/Preview.js
@@ -53,7 +53,6 @@ export default function Preview({preview}) {
     ? [...ancestors, {url, title: sectionTitle}]
     : ancestors;
 
-  const breadcrumbBg = useColorModeValue('gray.100', 'gray.800');
   const searchByAlgolia = useColorModeValue(
     searchByAlgoliaLight,
     searchByAlgoliaDark
@@ -88,7 +87,10 @@ export default function Preview({preview}) {
           px="2"
           rounded="sm"
           fontSize="sm"
-          bg={breadcrumbBg}
+          bg="gray.100"
+          _dark={{
+            bg: 'gray.800'
+          }}
           spacing="1"
           whiteSpace="nowrap"
           maxW="full"

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -2,14 +2,7 @@ import Highlight from './Highlight';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ResultIcon from './ResultIcon';
-import {
-  Box,
-  Flex,
-  chakra,
-  useColorMode,
-  useColorModeValue,
-  useTheme
-} from '@chakra-ui/react';
+import {Box, Flex, chakra, useColorMode, useTheme} from '@chakra-ui/react';
 
 export default function Result({item, ...props}) {
   const theme = useTheme();
@@ -22,7 +15,6 @@ export default function Result({item, ...props}) {
     colorScheme: 'indigo'
   });
 
-  const highlightColor = useColorModeValue('gray.500', 'gray.400');
   const {text, title, description} = item._highlightResult;
   const {'aria-selected': isSelected} = props;
 
@@ -36,11 +28,26 @@ export default function Result({item, ...props}) {
           <Box fontSize="lg">
             <Highlight value={title.value} />
           </Box>
-          <Box fontSize="sm" color={highlightColor} isTruncated>
+          <Box
+            fontSize="sm"
+            color="gray.500"
+            _dark={{
+              color: 'gray.400'
+            }}
+            isTruncated
+          >
             <Highlight value={(text || description).value} />
           </Box>
         </Box>
-        <Box ml="2" my="auto" d={!isSelected && 'none'} color={highlightColor}>
+        <Box
+          ml="2"
+          my="auto"
+          d={!isSelected && 'none'}
+          color="gray.500"
+          _dark={{
+            color: 'gray.400'
+          }}
+        >
           ⏎
         </Box>
       </Flex>

--- a/src/components/Search/SearchButton.js
+++ b/src/components/Search/SearchButton.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import {Box, useColorModeValue} from '@chakra-ui/react';
+import {Box} from '@chakra-ui/react';
 import {FiSearch} from 'react-icons/fi';
 
 export default function SearchButton(props) {
-  const bgColor = useColorModeValue('gray.50', 'gray.900');
-  const textColor = useColorModeValue('gray.400', 'gray.500');
   return (
     <Box
       d={{base: 'none', sm: 'flex'}}
@@ -16,7 +14,10 @@ export default function SearchButton(props) {
       w="full"
       as="button"
       rounded="md"
-      bg={bgColor}
+      bg="gray.50"
+      _dark={{
+        bg: 'gray.900'
+      }}
       _focus={{
         outline: 'none',
         shadow: 'outline'
@@ -24,7 +25,13 @@ export default function SearchButton(props) {
       {...props}
     >
       <FiSearch />
-      <Box ml="2" color={textColor}>
+      <Box
+        ml="2"
+        color="gray.400"
+        _dark={{
+          color: 'gray.500'
+        }}
+      >
         Search Apollo (Cmd+K or /)
       </Box>
     </Box>

--- a/src/components/Sidebar/LeftSidebarNav.js
+++ b/src/components/Sidebar/LeftSidebarNav.js
@@ -6,8 +6,7 @@ import {
   DarkMode,
   Stack,
   StackDivider,
-  chakra,
-  useColorModeValue
+  chakra
 } from '@chakra-ui/react';
 import {DOCSET_ICONS} from '../DocsetMenu';
 import {

--- a/src/components/Sidebar/LeftSidebarNav.js
+++ b/src/components/Sidebar/LeftSidebarNav.js
@@ -25,13 +25,14 @@ export const COLLAPSED_SIDEBAR_WIDTH = 93;
 export function LeftSidebarNav(props) {
   const {sidebarOpen, dismissSidebar} = useContext(DocsetContext);
 
-  const bgColor = useColorModeValue('gray.800', 'gray.900');
-
   return (
     <Box
       color="white"
       fontWeight="semibold"
-      bgColor={bgColor}
+      bgColor="gray.800"
+      _dark={{
+        bgColor: 'gray.900'
+      }}
       flexShrink="0"
       overflow="auto"
       overscrollBehavior="none"

--- a/src/components/Sidebar/SidebarNav.js
+++ b/src/components/Sidebar/SidebarNav.js
@@ -24,7 +24,6 @@ const SidebarButton = props => (
     size="xs"
     fontSize="md"
     isRound
-    bg="gray.100"
     _dark={{
       bg: 'whiteAlpha.200'
     }}

--- a/src/components/Sidebar/SidebarNav.js
+++ b/src/components/Sidebar/SidebarNav.js
@@ -20,7 +20,16 @@ import {FiChevronDown, FiChevronLeft, FiChevronsLeft} from 'react-icons/fi';
 import {flattenNavItems} from '../../utils';
 
 const SidebarButton = props => (
-  <IconButton size="xs" fontSize="md" isRound {...props} />
+  <IconButton
+    size="xs"
+    fontSize="md"
+    isRound
+    bg="gray.100"
+    _dark={{
+      bg: 'whiteAlpha.200'
+    }}
+    {...props}
+  />
 );
 
 const SidebarNav = forwardRef(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,17 +22,6 @@ export const flattenNavItems = items =>
     item.children ? [item, ...flattenNavItems(item.children)] : item
   );
 
-export function useTagColorProps() {
-  return {
-    bg: 'indigo.50',
-    color: 'indigo.500',
-    _dark: {
-      bg: 'indigo.400',
-      color: 'inherit'
-    }
-  };
-}
-
 export function useFieldTableStyles() {
   const teal = useColorModeValue('teal.600', 'teal.300');
   const requiredBg = useColorModeValue('blackAlpha.50', 'whiteAlpha.50');

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,10 +22,15 @@ export const flattenNavItems = items =>
     item.children ? [item, ...flattenNavItems(item.children)] : item
   );
 
-export function useTagColors() {
-  const bg = useColorModeValue('indigo.50', 'indigo.400');
-  const textColor = useColorModeValue('indigo.500', 'inherit');
-  return [bg, textColor];
+export function useTagColorProps() {
+  return {
+    bg: 'indigo.50',
+    color: 'indigo.500',
+    _dark: {
+      bg: 'indigo.400',
+      color: 'inherit'
+    }
+  };
 }
 
 export function useFieldTableStyles() {


### PR DESCRIPTION
Fixes color flash by replacing `useColorModeValue` where possible.

### Why?

`useColorModeValue` utilizes the runtime color mode, requiring the page to rehydrate to gain the proper color

### Fix

Switching to the `_dark` prop allows both colors to be statically available from SSR. When the `ColorModeScript` loads in, it sets `data-theme=dark|light` instantly before the page is shown to the user. Unlike `useColorModeValue`, `_dark` utilizes CSS rules that depend on `data-theme=dark` which is instantly available upon load.

### Other odds and ends

- Dark mode switcher fades in after loading so there is no light -> dark button icon change 