### PR TITLE
Update self-hosted quickstart to use Docker-based template

### DIFF
--- a/src/content/graphos/basics/quickstart/self-hosted.mdx
+++ b/src/content/graphos/basics/quickstart/self-hosted.mdx
@@ -179,17 +179,18 @@ First, let's create a project directory for your router:
 
 1. Open [this GitHub template](https://github.com/apollographql/router-template). It provides out-of-the box configuration for deploying and running the Apollo Router via a Dockerfile.
 2. On the template page, click **Use this template > Create a new repository** to copy the template into a new repository in your GitHub account.
+    - If you don't use GitHub, you can instead clone the template directly via the **Code** menu.
 3. Clone your new repository to your local machine.
 
 ## 3. Start the router with Docker
 
-To run the Apollo Router locally, you need a way to build and run Docker containers. Here are some popular options:
+To run the Apollo Router locally, you need a way to build and run containers. Here are some popular options:
 
 - [Docker Desktop](https://www.docker.com/products/personal/)
 - [Rancher](https://rancherdesktop.io)
 - [Podman](https://podman.io)
 
-> The rest of this tutorial uses the `docker` command. Alternative commands usually look very similar.
+> This tutorial uses the `docker` command. Alternative commands usually look similar.
 
 Try building and running your router container:
 
@@ -242,13 +243,13 @@ That's because we aren't currently providing a **supergraph schema** to the rout
 <blockquote>
 
 
-This quickstart uses two Apollo-hosted subgraphs (named **Locations** and **Reviews**) from an imaginary space tourism application called FlyBy. Here are their URLs and schemas for reference:
+This quickstart uses two Apollo-hosted subgraphs (named `locations` and `reviews`) from an imaginary space tourism application called FlyBy. Here are their URLs and schemas for reference:
 
-<ExpansionPanel title="Locations">
+<ExpansionPanel title="locations">
 
 URL: `https://flyby-locations-sub.herokuapp.com/`
 
-```graphql title="Locations"
+```graphql title="locations"
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0",
         import: ["@key"])
@@ -273,11 +274,11 @@ type Location @key(fields: "id"){
 
 </ExpansionPanel>
 
-<ExpansionPanel title="Reviews">
+<ExpansionPanel title="reviews">
 
 URL: `https://flyby-reviews-sub.herokuapp.com/`
 
-```graphql title="Reviews"
+```graphql title="reviews"
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0",
         import: ["@key"])
@@ -358,7 +359,7 @@ In [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content), cl
 
 To publish our subgraph schema, we'll first use Rover to **introspect** the running subgraph, then pass the obtained schema to `subgraph publish`.
 
-1. Copy the following multi-line command into your text editor so you can modify it:
+1. Copy the following multi-line command into your terminal, **but don't run it**—you need to modify it first.
 
     ```bash
     rover subgraph introspect https://flyby-locations-sub.herokuapp.com/ | \
@@ -367,7 +368,7 @@ To publish our subgraph schema, we'll first use Rover to **introspect** the runn
     --schema - <GRAPH_REF>
     ```
 
-2. In your editor, replace `<GRAPH_REF>` with the appropriate value for _your_ graph. In the screenshot above, this value is `MyGraph-1ncyus@current`, but **your value will be different**.
+2. In your terminal, replace the final value `<GRAPH_REF>` with the appropriate value for _your_ graph. In the screenshot above, this value is `MyGraph-1ncyus@current`, but **your value will be different**.
 
     <ExpansionPanel title="What's a graph ref?">
 
@@ -386,7 +387,7 @@ To publish our subgraph schema, we'll first use Rover to **introspect** the runn
 
     </ExpansionPanel>
 
-3. Paste the modified command into your terminal and run it.
+3. Run the modified command.
 
     - **If the command is successful,** you'll see output like the following:
 
@@ -397,11 +398,11 @@ To publish our subgraph schema, we'll first use Rover to **introspect** the runn
 
     - **If the command fails,** make sure you've [authenticated Rover with GraphOS](#authenticate-rover-with-graphos). All Rover commands that interact with GraphOS require a valid API key.
 
-    If you open your graph's details in Studio now, you'll see types and fields from the Locations subgraph listed on the Schema page:
+    If you open your graph's details in Studio now, you'll see types and fields from the `locations` subgraph listed on the Schema page:
 
-    <img class="screenshot" alt="Locations subgraph schema in Studio" src="../../img/qs-studio-schema.jpg" width="300"/>
+    <img class="screenshot" alt="locations subgraph schema in Studio" src="../../img/qs-studio-schema.jpg" width="300"/>
 
-4. Do the same thing for the Reviews subgraph, **again substituting your graph ref**:
+4. Do the same thing for the `reviews` subgraph, **again substituting your graph ref**:
 
     ```bash
     rover subgraph introspect https://flyby-reviews-sub.herokuapp.com/ | \
@@ -412,7 +413,7 @@ To publish our subgraph schema, we'll first use Rover to **introspect** the runn
 
     > You only need to provide a subgraph's `--routing-url` the _first_ time you publish that subgraph's schema to a particular variant (unless you need to change that URL later).
 
-    If you refresh the Schema page in Studio, you'll now see types and fields from the Reviews subgraph as well.
+    If you refresh the Schema page in Studio, you'll now see types and fields from the `reviews` subgraph as well.
 
 Every time we publish a subgraph schema, GraphOS automatically composes _all_ of our subgraph schemas into a **supergraph schema**! However, our router isn't yet _fetching_ that schema from Apollo. We'll tackle that next.
 

--- a/src/content/graphos/basics/quickstart/self-hosted.mdx
+++ b/src/content/graphos/basics/quickstart/self-hosted.mdx
@@ -11,6 +11,8 @@ description: Host your enterprise router in your own infrastructure
 
 This tutorial helps you get you up and running with GraphOS and a self-hosted supergraph. You can complete this tutorial even if your organization _doesn't_ currently have an Enterprise plan, enabling you to test out this functionality.
 
+> **Important:** This tutorial uses **Docker** for containerization of your supergraph's router.
+
 ## Supergraph concepts
 
 Before we get started, let's quickly cover what a self-hosted supergraph _is_.
@@ -44,7 +46,7 @@ We'll cover these concepts in more detail as we proceed through the steps below.
 
 This quickstart uses the following Apollo tools:
 
-* **Apollo Studio.** This is the primary web interface for GraphOS. Studio helps you monitor, manage, and collaborate on your supergraph.
+* **GraphOS Studio.** This is the primary web interface for GraphOS. Studio helps you monitor, manage, and collaborate on your supergraph.
 * **The Rover CLI.** This is the primary _command-line_ interface for GraphOS. Rover helps you interact with your graphs and their schemas.
 
 Let's set these up first.
@@ -55,15 +57,13 @@ To manage our supergraph with GraphOS, we need an Apollo account. Let's create o
 
 Complete the first step of <a href="./cloud/#1-create-your-apollo-account" target="_blank">Get started with GraphOS</a> (**Create your Apollo account**), then return here.
 
-#### Create a graph in Apollo Studio
+#### Create a graph in GraphOS Studio
 
-After you create your Apollo account, create your first graph in Apollo Studio by following the instructions for your organization's [plan type](../org/plans/):
-
-> If you just created your organization as part of creating your account, it's on a **Serverless** plan type.
+After you create your Apollo account, create your first graph in GraphOS Studio by following the instructions for your organization's [plan type](../org/plans/):
 
 <ExpansionPanel title="Serverless plans">
 
-1. Go to your organization's **Graphs** tab in [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content).
+1. Go to your organization's **Graphs** tab in [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content).
 
     - **If you see this dialog...**
 
@@ -117,7 +117,7 @@ Your graph has been created, and it appears in the **Classic Graphs** section of
 
 <ExpansionPanel title="Enterprise and legacy plans">
 
-1. Go to your organization's **Graphs** tab in [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content).
+1. Go to your organization's **Graphs** tab in [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content).
 
 2. Click **New Graph** in the top right. Studio displays the following dialog:
 
@@ -171,34 +171,27 @@ We'll use Rover to publish our subgraph schemas to GraphOS. To do that, we first
 
 Complete the first two steps of <a href="/rover/configuring/" target="_blank">Configuring Rover</a> (**Obtain an API key** and **Provide the API key to Rover**), then return here.
 
-## 2. Create a router project directory
-
-With a self-hosted supergraph, you're responsible for deploying and managing your supergraph's **router**. The router provides the public endpoint that clients use to query your supergraph:
-
-```mermaid
-flowchart LR;
-  clients(Clients);
-  subgraph "Your infrastructure";
-  router(["Router"]);
-  subgraphA[Locations<br/>subgraph];
-  subgraphB[Reviews<br/>subgraph];
-  router --- subgraphA & subgraphB;
-  end;
-  clients -.- router;
-  class clients secondary;
-```
+## 2. Clone the router project template
 
 For this quickstart, we'll use some Apollo-hosted example services as our subgraphs, and we'll set up **the Apollo Router** in front of them. The Apollo Router is a high-performance, precompiled Rust executable that acts as the router for a supergraph.
 
-Start by using the [GitHub template](https://github.com/apollographql/router-template) to create a new Router project. This comes with all the basics you need to run Router in a Docker container. Click "Use this template" to create a new repository in your GitHub account, then clone that repository to your local machine.
+First, let's create a project directory for your router:
 
-To run the Router locally, you'll need a way to build and run containers, some popular options are:
+1. Open [this GitHub template](https://github.com/apollographql/router-template). It provides out-of-the box configuration for deploying and running the Apollo Router via a Dockerfile.
+2. On the template page, click **Use this template > Create a new repository** to copy the template into a new repository in your GitHub account.
+3. Clone your new repository to your local machine.
+
+## 3. Start the router with Docker
+
+To run the Apollo Router locally, you need a way to build and run Docker containers. Here are some popular options:
 
 - [Docker Desktop](https://www.docker.com/products/personal/)
 - [Rancher](https://rancherdesktop.io)
 - [Podman](https://podman.io)
 
-For the rest of this tutorial, we'll be using the `docker` command, but commands for the alternatives should look very similar. Let's try starting the router:
+> The rest of this tutorial uses the `docker` command. Alternative commands usually look very similar.
+
+Try building and running your router container:
 
 ```bash
 docker build -t router .
@@ -220,7 +213,7 @@ Apollo Router v1.18.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.
 
       $ ./router --supergraph <file_path>
 
-  * Fetch a registered schema from Apollo Studio by setting
+  * Fetch a registered schema from GraphOS by setting
     these environment variables:
 
       $ APOLLO_KEY="..." APOLLO_GRAPH_REF="..." ./router
@@ -249,7 +242,7 @@ That's because we aren't currently providing a **supergraph schema** to the rout
 <blockquote>
 
 
-This quickstart uses two Apollo-hosted subgraphs (named Locations and Reviews) from an imaginary space tourism application called FlyBy. Here are their URLs and schemas for reference:
+This quickstart uses two Apollo-hosted subgraphs (named **Locations** and **Reviews**) from an imaginary space tourism application called FlyBy. Here are their URLs and schemas for reference:
 
 <ExpansionPanel title="Locations">
 
@@ -339,7 +332,7 @@ type SubmitReviewResponse {
 
 </ExpansionPanel>
 
-When using your own subgraphs, you will use Rover to publish their schemas from their repos, typically in your CI pipeline. If you have your own existing subgraphs that you want to use instead of these examples, feel free! Provide their names and URLs wherever you see the example subgraphs used in the steps below.
+If you have your own existing subgraphs that you want to use instead of these examples, feel free! Provide their names and URLs wherever you see the example subgraphs used in the steps below.
 
 </blockquote>
 
@@ -350,13 +343,11 @@ To compose a supergraph schema for our router, GraphOS needs the following infor
 
 Fortunately, we have all of this information! Let's send it to GraphOS.
 
-> 💡 **In most supergraphs,** each subgraph schema lives in the codebase for its associated subgraph. Because we're using remotely-hosted example subgraphs in this quickstart, we're saving these subgraph schemas in our router project for convenience.
-
 ## 4. Publish your subgraph schemas
 
-With Rover already configured, we can use the Rover CLI's `subgraph publish` command to publish our subgraph schemas to GraphOS.
+Because we've already configured the Rover CLI, we can now use its `subgraph publish` command to publish our subgraph schemas to GraphOS.
 
-In [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content), click the graph you created back in the first step. Because we haven't published a schema to it yet, the following dialog appears:
+In [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content), click the graph you created back in the first step. Because we haven't published any schemas to it yet, the following dialog appears:
 
 <img
   src="../../img/register-schema-dialog.jpg"
@@ -365,80 +356,84 @@ In [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content), cli
   width="600"
 />
 
-We're going to use a similar command to the "Introspection" option, but we don't need the `APOLLO_KEY` variable because we configured Rover earlier. If you set up a `--profile` with Rover, be sure to use it here! The first subgraph can be published like this:
+To publish our subgraph schema, we'll first use Rover to **introspect** the running subgraph, then pass the obtained schema to `subgraph publish`.
 
-```bash
-rover subgraph introspect https://flyby-locations-sub.herokuapp.com/ | \
-rover subgraph publish --name locations \
---routing-url https://flyby-locations-sub.herokuapp.com/ \
---schema - <GRAPH_REF>
-```
+1. Copy the following multi-line command into your text editor so you can modify it:
 
-<blockquote>
+    ```bash
+    rover subgraph introspect https://flyby-locations-sub.herokuapp.com/ | \
+    rover subgraph publish --name locations \
+    --routing-url https://flyby-locations-sub.herokuapp.com/ \
+    --schema - <GRAPH_REF>
+    ```
 
-Note that you need to replace `<GRAPH_REF>` above with the appropriate value for _your_ graph. In our screenshot above, this is `MyGraph-1ncyus@current` but **your value will be different**.
+2. In your editor, replace `<GRAPH_REF>` with the appropriate value for _your_ graph. In the screenshot above, this value is `MyGraph-1ncyus@current`, but **your value will be different**.
 
-<ExpansionPanel title="What's a graph ref?">
+    <ExpansionPanel title="What's a graph ref?">
 
-A **graph ref** uniquely identifies a particular **variant** of a particular graph in GraphOS. Every graph ref is a string with the following format:
+    A **graph ref** uniquely identifies a particular **variant** of a particular graph in GraphOS. Every graph ref is a string with the following format:
 
-`graph-id@variant-name`
+    `graph-id@variant-name`
 
-- The value before the `@` is your graph's unique ID in GraphOS.
-- The value after the `@` is the name of the graph variant you're interacting with.
+    - The value before the `@` is your graph's unique ID in GraphOS.
+    - The value after the `@` is the name of the graph variant you're interacting with.
 
-Each **variant** of a graph represents a different _environment_ where that graph runs (such as staging and production). For this quickstart, you can keep the default suggested variant name or change it to anything else you like (e.g., `quickstart`). Just make sure to provide the _same_ graph ref to every command in this quickstart!
+    Each **variant** of a graph represents a different _environment_ where that graph runs (such as staging and production). For this quickstart, you can keep the default suggested variant name or change it to anything else you like (e.g., `quickstart`). Just make sure to provide the _same_ graph ref to every command in this quickstart!
 
-_After_ you've published a schema to a particular variant, that variant's graph ref is always available at the top of its README page:
+    _After_ you've published a schema to a particular variant, that variant's graph ref is always available at the top of its README page:
 
-<img class="screenshot" alt="Graph ref in Studio" src="../../img/studio-graph-ref.jpg" width="300"/>
+    <img class="screenshot" alt="Graph ref in Studio" src="../../img/studio-graph-ref.jpg" width="300"/>
 
-</ExpansionPanel>
+    </ExpansionPanel>
 
-</blockquote>
+3. Paste the modified command into your terminal and run it.
 
-Paste the command into your terminal, replace `<GRAPH_REF>` with your value, and run it. If the command is successful, you'll see output like the following:
+    - **If the command is successful,** you'll see output like the following:
 
-```
-A new subgraph called 'locations' was created in 'docs-example-graph@main'
-The supergraph schema for 'docs-example-graph@main' was updated, composed from the updated 'locations' subgraph
-```
+      ```
+      A new subgraph called 'locations' was created in 'docs-example-graph@main'
+      The supergraph schema for 'docs-example-graph@main' was updated, composed from the updated 'locations' subgraph
+      ```
 
-Nice! If you open your graph's details in Studio now, you'll see types and fields from our `locations` subgraph listed on the Schema page:
+    - **If the command fails,** make sure you've [authenticated Rover with GraphOS](#authenticate-rover-with-graphos). All Rover commands that interact with GraphOS require a valid API key.
 
-<img class="screenshot" alt="Locations subgraph schema in Studio" src="../../img/qs-studio-schema.jpg" width="300"/>
+    If you open your graph's details in Studio now, you'll see types and fields from the Locations subgraph listed on the Schema page:
 
-Next, let's do the same thing for our `reviews` subgraph, **again substituting your graph ref**:
+    <img class="screenshot" alt="Locations subgraph schema in Studio" src="../../img/qs-studio-schema.jpg" width="300"/>
 
-```bash
-rover subgraph introspect https://flyby-reviews-sub.herokuapp.com/ | \
-rover subgraph publish --name reviews \
---routing-url https://flyby-reviews-sub.herokuapp.com/ \
---schema - <GRAPH_REF>
-```
+4. Do the same thing for the Reviews subgraph, **again substituting your graph ref**:
 
-> You only need to provide a subgraph's `--routing-url` the _first_ time you publish that subgraph's schema to a particular variant (unless you need to change that URL later).
+    ```bash
+    rover subgraph introspect https://flyby-reviews-sub.herokuapp.com/ | \
+    rover subgraph publish --name reviews \
+    --routing-url https://flyby-reviews-sub.herokuapp.com/ \
+    --schema - <GRAPH_REF>
+    ```
 
-If you refresh the Schema page in Studio, you'll now see types and fields from our `reviews` service as well.
+    > You only need to provide a subgraph's `--routing-url` the _first_ time you publish that subgraph's schema to a particular variant (unless you need to change that URL later).
+
+    If you refresh the Schema page in Studio, you'll now see types and fields from the Reviews subgraph as well.
 
 Every time we publish a subgraph schema, GraphOS automatically composes _all_ of our subgraph schemas into a **supergraph schema**! However, our router isn't yet _fetching_ that schema from Apollo. We'll tackle that next.
 
 ## 5. Connect the router to GraphOS
 
-It's time to enable our router to fetch its supergraph schema from GraphOS. To do that, we'll need a **graph API key** that we set as the value of an environment variable. We recommend that you create a separate API key for each system that communicates with GraphOS. This reduces the impact whenever you need to _replace_ an API key that might be compromised.
+It's time to enable our router to fetch its supergraph schema from GraphOS. To do that, we need a **graph API key** that we set as the value of an environment variable.
+
+> We recommend that you create a separate API key for each system that communicates with GraphOS. This reduces the impact whenever you need to _replace_ an API key that might be compromised.
 
 1. Obtain a graph API key for your Studio graph by <a href="../api-keys/#graph-api-keys" target="_blank">following these steps</a>. If you have an Enterprise plan, set the API key's role to **Contributor**.
 
     > Make sure to copy and paste the API key's value somewhere so you can reference it (for security, API keys are not visible in Studio after creation).
 
-2. Create a file called `.env` in your Router project and paste in the following (replacing `<API_KEY>` with your graph API key and `<GRAPH_REF>` with your graph ref):
+2. Create a file called `.env` in your Router project and paste in the following (replace `<API_KEY>` with your graph API key and `<GRAPH_REF>` with your graph ref):
 
     ```
     APOLLO_KEY=<API_KEY>
     APOLLO_GRAPH_REF=<GRAPH_REF>
     ```
 
-> ⚠️ **API keys are secret credentials.** Never share them outside your organization or commit them to version control. Delete and replace API keys that you believe are compromised. The provided template has `.env` added to `.gitignore`, if you are not using the template, make sure to add `.env` to your `.gitignore` file.
+> ⚠️ **API keys are secret credentials.** Never share them outside your organization or commit them to version control. Delete and replace API keys that you believe are compromised. Make sure always to add `.env` files to your `.gitignore` file (the router template project already does this).
 
 3. Paste this command into your terminal and run it:
 
@@ -451,7 +446,7 @@ It's time to enable our router to fetch its supergraph schema from GraphOS. To d
     <ExpansionPanel title="Click to expand">
 
     ```
-    INFO Apollo Router v1.3.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
+    INFO Apollo Router v1.18.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
     INFO Anonymous usage data is gathered to inform Apollo product development.  See https://go.apollo.dev/o/privacy for more info.
     INFO Running with *development* mode settings which facilitate development experience (e.g., introspection enabled)
     INFO Apollo Studio usage reporting is enabled. See https://go.apollo.dev/o/data for details
@@ -475,7 +470,7 @@ While we're here, execute some test queries against the supergraph! We'll look a
 
 Because our router is connected to GraphOS, it automatically collects and reports metrics on incoming operations. You can then visualize those metrics in Studio.
 
-Return to [Apollo Studio](https://studio.apollographql.com?referrer=docs-content) and go to your supergraph variant's Operations page, which looks like this:
+Return to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content) and go to your supergraph variant's Operations page, which looks like this:
 
 <img
   src="../../img/operations-quickstart.jpg"
@@ -492,7 +487,7 @@ Now that our router is running successfully in our development environment, we c
 The exact details for deploying the router depend on which platform you use, but these high-level steps hold true for most platforms:
 
 1. Build the Docker image in CI and push it to a container registry (some providers let you skip this step).
-2. Deploy the image to your preferred platform (there are [additional resources for Kubernetes deployments](/docs/router/containerization/kubernetes))
+2. Deploy the image to your preferred platform (there are [additional resources for Kubernetes deployments](/router/containerization/kubernetes)).
 3. Set the `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables in the router's deployment environment, as we did locally in [this step](#5-connect-the-router-to-graphos).
     - Keep in mind that `APOLLO_KEY` is a secret, so use an appropriate mechanism for storing it in your deployment environment.
 

--- a/src/content/graphos/basics/quickstart/self-hosted.mdx
+++ b/src/content/graphos/basics/quickstart/self-hosted.mdx
@@ -190,16 +190,19 @@ flowchart LR;
 
 For this quickstart, we'll use some Apollo-hosted example services as our subgraphs, and we'll set up **the Apollo Router** in front of them. The Apollo Router is a high-performance, precompiled Rust executable that acts as the router for a supergraph.
 
-On your development machine, first create a new directory for your router project. Then inside that directory, run the following to install the Apollo Router:
+Start by using the [GitHub template](https://github.com/apollographql/router-template) to create a new Router project. This comes with all the basics you need to run Router in a Docker container. Click "Use this template" to create a new repository in your GitHub account, then clone that repository to your local machine.
+
+To run the Router locally, you'll need a way to build and run containers, some popular options are:
+
+- [Docker Desktop](https://www.docker.com/products/personal/)
+- [Rancher](https://rancherdesktop.io)
+- [Podman](https://podman.io)
+
+For the rest of this tutorial, we'll be using the `docker` command, but commands for the alternatives should look very similar. Let's try starting the router:
 
 ```bash
-curl -sSL https://router.apollo.dev/download/nix/latest | sh
-```
-
-This installs the `router` executable in your project directory. Try running it with the following command:
-
-```bash
-./router
+docker build -t router .
+docker run -it -p4000:4000 router
 ```
 
 When you do, you'll get a startup error message like the following:
@@ -207,7 +210,7 @@ When you do, you'll get a startup error message like the following:
 <ExpansionPanel title="Click to expand">
 
 ```
-Apollo Router v1.2.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
+Apollo Router v1.18.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
 
 ⚠️  The Apollo Router requires a composed supergraph schema at startup. ⚠️
 
@@ -336,8 +339,7 @@ type SubmitReviewResponse {
 
 </ExpansionPanel>
 
-
-If you have your own existing subgraphs that you want to use instead of these examples, feel free! Provide their names and URLs wherever you see the example subgraphs used in the steps below.
+When using your own subgraphs, you will use Rover to publish their schemas from their repos, typically in your CI pipeline. If you have your own existing subgraphs that you want to use instead of these examples, feel free! Provide their names and URLs wherever you see the example subgraphs used in the steps below.
 
 </blockquote>
 
@@ -346,103 +348,13 @@ To compose a supergraph schema for our router, GraphOS needs the following infor
 * The subgraph's schema
 * The URL of the subgraph's GraphQL endpoint (which must be accessible by the router)
 
-Fortunately, we have all of this information! Let's collect it in our project.
-
-Do the following in your router project's root directory:
-
-1. Create a new file called `locations.graphql` and paste the following schema into it:
-
-    <ExpansionPanel title="Locations">
-
-    ```graphql title="locations.graphql"
-    extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.0",
-            import: ["@key"])
-
-    type Query {
-      "The full list of locations presented by the Interplanetary Space Tourism department"
-      locations: [Location!]!
-      "The details of a specific location"
-      location(id: ID!): Location
-    }
-
-    type Location @key(fields: "id"){
-      id: ID!
-      "The name of the location"
-      name: String!
-      "A short description about the location"
-      description: String!
-      "The location's main photo as a URL"
-      photo: String!
-    }
-    ```
-
-    </ExpansionPanel>
-
-2. Create a new file called `reviews.graphql` and paste the following schema into it:
-
-    <ExpansionPanel title="Reviews">
-
-    ```graphql title="reviews.graphql"
-    extend schema
-      @link(url: "https://specs.apollo.dev/federation/v2.0",
-            import: ["@key"])
-
-    type Query {
-      "The three latest reviews submitted for FlyBy's locations"
-      latestReviews: [Review!]!
-    }
-
-    type Mutation {
-      submitReview(locationReview: LocationReviewInput): SubmitReviewResponse
-    }
-
-    type Location @key(fields: "id") {
-      id: ID!
-      "The calculated overall rating based on all reviews"
-      overallRating: Float
-      "All submitted reviews about this location"
-      reviewsForLocation: [Review]!
-    }
-
-    type Review {
-      id: ID!
-      "Written text"
-      comment: String
-      "A number from 1 - 5 with 1 being lowest and 5 being highest"
-      rating: Int
-      "The location the review is about"
-      location: Location
-    }
-
-    input LocationReviewInput {
-      "Written text"
-      comment: String!
-      "A number from 1 - 5 with 1 being lowest and 5 being highest"
-      rating: Int!
-      "Location Id"
-      locationId: String!
-    }
-
-    type SubmitReviewResponse {
-      "Similar to HTTP status code, represents the status of the mutation"
-      code: Int!
-      "Indicates whether the mutation was successful"
-      success: Boolean!
-      "Human-readable message for the UI"
-      message: String!
-      "Newly created review"
-      locationReview: Review
-    }
-    ```
-
-    </ExpansionPanel>
+Fortunately, we have all of this information! Let's send it to GraphOS.
 
 > 💡 **In most supergraphs,** each subgraph schema lives in the codebase for its associated subgraph. Because we're using remotely-hosted example subgraphs in this quickstart, we're saving these subgraph schemas in our router project for convenience.
 
 ## 4. Publish your subgraph schemas
 
-With our subgraph schemas ready, we now can use the Rover CLI's `subgraph publish` command to publish those schemas to GraphOS.
+With Rover already configured, we can use the Rover CLI's `subgraph publish` command to publish our subgraph schemas to GraphOS.
 
 In [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content), click the graph you created back in the first step. Because we haven't published a schema to it yet, the following dialog appears:
 
@@ -453,34 +365,18 @@ In [Apollo Studio](https://studio.apollographql.com/?referrer=docs-content), cli
   width="600"
 />
 
-This dialog shows an example Rover command for publishing a subgraph schema. Copy that command and paste it into your text editor so we can modify it.
+We're going to use a similar command to the "Introspection" option, but we don't need the `APOLLO_KEY` variable because we configured Rover earlier. If you set up a `--profile` with Rover, be sure to use it here! The first subgraph can be published like this:
 
-Edit the command like so:
-
-1. Change the value of the `--name` option to `locations`
-    - This will be our first subgraph's name.
-2. Change the value of the `--schema` option to `./locations.graphql`
-    - This is the path to the schema for our Locations subgraph.
-3. Change the value of the `--routing-url` option to:
-    - `https://flyby-locations-sub.herokuapp.com/` 
-    - This is the URL that our router will use to communicate with the Locations subgraph.
-
-When you're done, the command resembles the following:
-
-```shell {1-2}
-APOLLO_KEY=<API_KEY> \
-rover subgraph publish <GRAPH_REF> \
-  --name locations \
-  --schema ./locations.graphql \
-  --routing-url https://flyby-locations-sub.herokuapp.com/  
+```bash
+rover subgraph introspect https://flyby-locations-sub.herokuapp.com/ | \
+rover subgraph publish --name locations \
+--routing-url https://flyby-locations-sub.herokuapp.com/ \
+--schema - <GRAPH_REF>
 ```
 
 <blockquote>
 
-Note that this command includes two custom values: an **API key** and a **graph ref**.
-
-- Rover uses the **API key** to authenticate with GraphOS. The key's permissions are scoped to this particular graph, which means Rover can't use it to perform operations on any _other_ graph.
-  - If you [authenticated Rover with GraphOS](#authenticate-rover-with-graphos) earlier, you don't actually _need_ to provide an API key to this command via `APOLLO_KEY` (although it's fine to do so).
+Note that you need to replace `<GRAPH_REF>` above with the appropriate value for _your_ graph. In our screenshot above, this is `MyGraph-1ncyus@current` but **your value will be different**.
 
 <ExpansionPanel title="What's a graph ref?">
 
@@ -501,9 +397,7 @@ _After_ you've published a schema to a particular variant, that variant's graph 
 
 </blockquote>
 
-When you're finished modifying the command, paste it into your terminal and run it from your router project's root directory.
-
-If the command is successful, you'll see output like the following:
+Paste the command into your terminal, replace `<GRAPH_REF>` with your value, and run it. If the command is successful, you'll see output like the following:
 
 ```
 A new subgraph called 'locations' was created in 'docs-example-graph@main'
@@ -516,12 +410,11 @@ Nice! If you open your graph's details in Studio now, you'll see types and field
 
 Next, let's do the same thing for our `reviews` subgraph, **again substituting your graph ref**:
 
-```shell {1-2}
-APOLLO_KEY=<API_KEY> \
-rover subgraph publish <GRAPH_REF> \
-  --routing-url https://flyby-reviews-sub.herokuapp.com/ \
-  --schema ./reviews.graphql \
-  --name reviews
+```bash
+rover subgraph introspect https://flyby-reviews-sub.herokuapp.com/ | \
+rover subgraph publish --name reviews \
+--routing-url https://flyby-reviews-sub.herokuapp.com/ \
+--schema - <GRAPH_REF>
 ```
 
 > You only need to provide a subgraph's `--routing-url` the _first_ time you publish that subgraph's schema to a particular variant (unless you need to change that URL later).
@@ -532,31 +425,26 @@ Every time we publish a subgraph schema, GraphOS automatically composes _all_ of
 
 ## 5. Connect the router to GraphOS
 
-It's time to enable our router to fetch its supergraph schema from GraphOS. To do that, we'll need a **graph API key** that we set as the value of an environment variable.
-
-In theory, we _could_ use the same API key that we just provided to the `rover subgraph publish` command. However, it's recommended practice to create a separate API key for each system that communicates with GraphOS. This reduces the impact whenever you need to _replace_ an API key that might be compromised.
-
-> ⚠️ **API keys are secret credentials.** Never share them outside your organization or commit them to version control. Delete and replace API keys that you believe are compromised.
+It's time to enable our router to fetch its supergraph schema from GraphOS. To do that, we'll need a **graph API key** that we set as the value of an environment variable. We recommend that you create a separate API key for each system that communicates with GraphOS. This reduces the impact whenever you need to _replace_ an API key that might be compromised.
 
 1. Obtain a graph API key for your Studio graph by <a href="../api-keys/#graph-api-keys" target="_blank">following these steps</a>. If you have an Enterprise plan, set the API key's role to **Contributor**.
 
     > Make sure to copy and paste the API key's value somewhere so you can reference it (for security, API keys are not visible in Studio after creation).
 
-2. Paste the following terminal command into your text editor so you can make changes to it:
+2. Create a file called `.env` in your Router project and paste in the following (replacing `<API_KEY>` with your graph API key and `<GRAPH_REF>` with your graph ref):
 
-    ```bash
-    APOLLO_KEY=your-api-key \
-    APOLLO_GRAPH_REF=your-graph-id@your-variant \
-    ./router --dev
+    ```
+    APOLLO_KEY=<API_KEY>
+    APOLLO_GRAPH_REF=<GRAPH_REF>
     ```
 
-    Then, make the following changes:
+> ⚠️ **API keys are secret credentials.** Never share them outside your organization or commit them to version control. Delete and replace API keys that you believe are compromised. The provided template has `.env` added to `.gitignore`, if you are not using the template, make sure to add `.env` to your `.gitignore` file.
 
-    * Replace `your-api-key` with your graph API key.
-    * Replace `your-graph-id@your-variant` with your variant's **graph ref**.
-        * _For a refresher on graph refs, see [Step 4](#4-publish-your-subgraph-schemas)._
+3. Paste this command into your terminal and run it:
 
-3. Paste the edited command into your terminal and run it.
+    ```bash
+    docker run -it --env-file .env -p4000:4000 router
+    ```
 
     This time there's no error, and you'll see output similar to the following (timestamps omitted for brevity):
 
@@ -576,10 +464,6 @@ In theory, we _could_ use the same API key that we just provided to the `rover s
     </ExpansionPanel>
 
     > By providing an API key to the router, you also automatically enable **operation metrics reporting** to GraphOS, enabling you visualize your graph's performance. [Learn more about metrics.](../metrics/)
-
-4. **Optionally,** to help you keep track of your router's environment variables, consider setting up a tool like [direnv](https://direnv.net/) so you don't need to set the variables every time you run `./router`.
-
-    (Most cloud deployment environments provide a helpful way to set environment variables, so this issue is mostly limited to local development.)
 
 Now that our router is running, we can quickly open our browser to `localhost:4000` to explore our composed schema in Apollo Sandbox:
 
@@ -607,30 +491,19 @@ Now that our router is running successfully in our development environment, we c
 
 The exact details for deploying the router depend on which platform you use, but these high-level steps hold true for most platforms:
 
-1. Set the `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables in the router's deployment environment, as we did locally in [this step](#5-connect-the-router-to-graphos).
-    - Most deployment platforms provide a mechanism for setting environment variables for a given application or container.
+1. Build the Docker image in CI and push it to a container registry (some providers let you skip this step).
+2. Deploy the image to your preferred platform (there are [additional resources for Kubernetes deployments](/docs/router/containerization/kubernetes))
+3. Set the `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables in the router's deployment environment, as we did locally in [this step](#5-connect-the-router-to-graphos).
+    - Keep in mind that `APOLLO_KEY` is a secret, so use an appropriate mechanism for storing it in your deployment environment.
 
-2. Make sure the Apollo Router executable is available to the application _before_ it runs `router` to start up.
-    - The application can include the router download command as a pre-launch task:
+4. If your platform expects the router to listen on a particular port, set this port in the [`router.yaml`](https://github.com/dbanty/enterprise-router-test/blob/main/router.yaml) file included with the template:
 
-      ```bash
-      curl -sSL https://router.apollo.dev/download/nix/latest | sh
-      ```
-
-3. If your platform expects the router to listen on a particular port, set this port in a YAML configuration file you include in the application's deployment bundle:
-
-    ```yaml title="router-config.yaml"
+    ```yaml title="router.yaml"
     supergraph:
       # The socket address and port to listen on
       listen: 127.0.0.1:4000
       # OR if the port is specified via environment variable
       listen: 127.0.0.1:${env.PORT}
-    ```
-
-    You provide this config file to the router executable like so:
-
-    ```bash
-    router --config router-config.yaml
     ```
 
     > Learn more about [router configuration options](/router/configuration/overview).


### PR DESCRIPTION
Overview of changes:

1. Switches to recommending Docker via [this template](https://github.com/dbanty/enterprise-router-test/tree/main) instead of a binary.
2. Uses introspection for sample subgraphs instead of downloading them, which reduces the number of steps by a few

Questions to be answered:

- [ ] Do we want more content describing the _right_ way to do subgraph publishes in CI? I think we cover this in later steps.
- [ ] How do we feel about listing Docker, Rancher, and Podman as options for container runtimes? I think those are the most popular, but _I haven't tested Podman to see if it needs changes_ (I used Rancher which is largely Docker-compatible). My main concern is that most enterprise users will not be able to use Docker Desktop without licensing it, and I don't want to push them down that road as a pre-requisite.
- [ ] Is it worth updating the screenshot to show the introspection screen now? And maybe having a nicer graph ref example?