### PR TITLE
Remove CS remote docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ npm start -- ../apollo-client
 For your convenience, this repo also comes with special `start` NPM scripts for each docset, assuming you have this repo checked out in the same directory as the other OSS repos.
 
 - `npm run start:client`
-- `npm run start:customer-success`
 - `npm run start:server`
 - `npm run start:ios`
 - `npm run start:kotlin`
@@ -131,7 +130,6 @@ The docs content is written and maintained in the following places. Many of them
 - [Apollo Federation](https://github.com/apollographql/federation)
 - [Rover CLI](https://github.com/apollographql/rover)
 - [Apollo Router](https://github.com/apollographql/router)
-- [Customer Success (internal)](https://github.com/apollographql/customer-success)
 
 ## Docset configuration
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "start": "./dev.sh",
     "start:local": "DOCS_MODE=local npm start",
     "start:client": "npm start -- ../apollo-client",
-    "start:customer-success": "npm start -- ../customer-success",
     "start:platform-users": "npm start -- ../platform-users-docs",
     "start:server": "npm start -- ../apollo-server",
     "start:ios": "npm start -- ../apollo-ios",

--- a/sources/remote.js
+++ b/sources/remote.js
@@ -20,10 +20,6 @@ module.exports = {
     remote: 'https://github.com/apollographql/apollo-server',
     branch: 'version-2'
   },
-  'customer-success': {
-    remote: `https://svc-apollo-docs:${process.env.GITHUB_TOKEN}@github.com/apollographql/customer-success`,
-    branch: 'main'
-  },
   ios: {
     remote: 'https://github.com/apollographql/apollo-ios',
     branch: 'main'


### PR DESCRIPTION
The CS doc have been migrated to Confluence, so this PR removes the `customer-success` remote docset from this repo.