### PR TITLE
Add individual pages to list of graphOSBasicsContent

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -229,7 +229,11 @@ export default function Page({file}) {
           'graphs',
           'operations',
           'quickstart',
-          'routing'
+          'routing',
+          'api-keys',
+          'data-privacy',
+          'platform-api',
+          'sub-processors'
         ];
 
         // Check to see if the current page is within the GraphOS Basics section


### PR DESCRIPTION
Added additional logic to correctly link to articles in the graphos -> basics folder

See https://apollograph.slack.com/archives/C0721M2F6/p1689187467980829
