### PR TITLE
Add new schema linter rules + custom rules

### DIFF
--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -619,6 +619,6 @@ You can create custom prefix and suffix rules beyond the built-in ones. These ru
 
 This rule would include a list of strings to forbid as prefixes in interface names.
 
-A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid all of the strings.
+A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid _all_ the strings you include.
 
-Refer to the schema linter page for [custom rule configuration instructions](./schema-linter#creating-custom-rules).
+Refer to the schema linter page for [custom rule configuration instructions](./schema-linter#configure-custom-rules).

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -62,7 +62,7 @@ type User {
 
 ## Fields
 
-These rules apply to _all_ fields, except for [`FIELDS_HAVE_DESCRIPTIONS_QUERY_MUTATION`](#fields_have_descriptions_query_mutation) which only applies to fields in queries and mutations.
+These rules apply to the fields in your schema. Certain rules apply only to fields of particular types.
 
 #### `FIELD_NAMES_SHOULD_BE_CAMEL_CASE`
 
@@ -120,7 +120,7 @@ type Query {
 
 #### `FIELDS_HAVE_DESCRIPTIONS_QUERY_MUTATION`
 
-All query and mutation fields have descriptions.
+All fields of the `Query` and `Mutation` types should have descriptions.
 
 <p style="margin-bottom: 0">❌</p>
 
@@ -222,15 +222,19 @@ type Book { # highlight-line
 
 #### `DEFINED_TYPES_ARE_USED`
 
-All defined types are used at least once in the schema.
+Every type defined in a schema should be used at least once.
 
-Types that are defined but then not used are most likely due to a mistake such as incomplete refactoring. Unused types take up space and can confuse readers.
+Unused types commonly appear after you refactor other parts of your schema. You should remove unused types to prevent confusion.
 
 <p style="margin-bottom: 0">❌</p>
 
 ```graphql title="schema.graphql"
-type someUnusedType { # Also fails the TYPE_SUFFIX rule!
+type SomeUnusedType { # Also fails the TYPE_SUFFIX rule!
   name: String!
+}
+
+type Query {
+  hello: String!
 }
 ```
 
@@ -606,7 +610,7 @@ The `@tag` directive should always use an approved value for its `name` argument
 
 ## Custom rules
 
-You can create custom rules to forbid or require certain terms as prefixes or suffixes in a specific schema element. You can create rules for the following elements:
+You can create custom linter rules to forbid or require certain strings as the prefix or suffix for different schema elements. You can create rules for the following elements:
 
 - Fields
 - Types
@@ -616,9 +620,9 @@ You can create custom rules to forbid or require certain terms as prefixes or su
 - Enums
 - Unions
 
-A rule can include multiple strings to forbid or require, but each rule can _either_ only forbid _or_ require the terms and can only apply to one schema element.
+A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings.
 
-### Custom rule configuration
+### Creating a custom rule
 
 To create a new rule, click the **+** button above your list of linter rules.
 
@@ -632,13 +636,12 @@ To create a new rule, click the **+** button above your list of linter rules.
 In the modal that opens, select the following:
 
 - Which **Schema element** you want to apply the rule to
-- Whether you want to **Forbid** or **Require** certain terms
-- Whether the terms should be considered **Prefixes** or **Suffixes**
-- The **Strings** the rule should check for; the allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
+- Whether you want to **Forbid** or **Require** certain strings
+- Whether the strings are **Prefixes** or **Suffixes**
+- The list of **Strings** to check for. Allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
+    - Note that strings are case-sensitive.
 
-> **Note:** Rules are case-sensitive.
-
-Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the rule name would be `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
+GraphOS dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the resulting rule name is `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
 
 <img
   className="screenshot"
@@ -647,8 +650,10 @@ Apollo dynamically generates the rule name based on your selections. For example
   width="300"
 />
 
-You can add as many rules as you like by clicking **Add another rule**. Once you've finished, don't forget to click **Create**.
+You can add as many rules as you want by clicking **Add another rule**. When you're done, click **Create**.
 
-Your custom rules appear in the list of rules with the **Custom** tag. Once created, you can edit them by clicking the pencil icon on the right of the rule's name.
+Your custom rules appear with a **CUSTOM** tag in the rule list. You can edit a custom rule by clicking the pencil icon to the right of its name:
 
-As with other linter rules, you can [configure their severity](./schema-linter/#setting-severity-levels), including setting their severity to **Ignore**, if you want to disable them. To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.
+[screenshot]
+
+As with built-in linter rules, you can set a custom rule's [severity level](./schema-linter/#setting-severity-levels). To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -117,7 +117,6 @@ type Query {
 
 All query and mutation fields have descriptions.
 
-
 <p style="margin-bottom: 0">❌</p>
 
 ```graphql title="schema.graphql"
@@ -137,8 +136,6 @@ type Mutation {
   ): Post
 }
 ```
-
-
 
 ## All types
 

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -3,7 +3,7 @@ title: GraphOS schema linter rules
 description: Reference
 ---
 
-This reference lists the built-in rules that you can enforce with [GraphOS schema linting](./schema-linter/). You can also create [custom rules](#custom-rules) to forbid or require prefixes or suffixes you define on specific schema elements.
+This reference lists the default rules that you can enforce with [GraphOS schema linting](./schema-linter/). You can also create [custom rules](#custom-rules) to forbid or require prefixes or suffixes you define on specific schema elements.
 
 Rules are categorized by the part(s) of your schema that they correspond to.
 
@@ -638,7 +638,7 @@ In the modal that opens, select the following:
 
 > **Note:** Rules are case-sensitive.
 
-Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for Interfaces, the rule name would be `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
+Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the rule name would be `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
 
 <img
   className="screenshot"

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -29,8 +29,8 @@ type Query {
 }
 
 #highlight-start
+# Don't define operations in a schema document
 query GetUsers {
-  # Don't define operations in a schema document
   users {
     id
   }

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -53,9 +53,9 @@ type User {
 <p style="margin-bottom: 0">✅</p>
 
 ```graphql title="schema.graphql"
-# Represents a user
+"Represents a user"
 type User {
-  # The username of the user
+  "The user's username"
   username: String!
 }
 ```
@@ -134,9 +134,9 @@ type Mutation {
 
 ```graphql title="schema.graphql"
 type Mutation {
-  # Create a new blog post
+  "Create a new blog post"
   createBlogPost(
-    # The content of the blog post to be created
+    "The content of the blog post to be created"
     blogPostContent: BlogPostContent!
   ): Post
 }
@@ -233,8 +233,13 @@ type SomeUnusedType { # Also fails the TYPE_SUFFIX rule!
   name: String!
 }
 
+type AnActuallyUsedType {
+  name: String!
+}
+
 type Query {
   hello: String!
+  title: AnActuallyUsedType
 }
 ```
 
@@ -639,7 +644,7 @@ In the modal that opens, select the following:
 - Whether you want to **Forbid** or **Require** certain strings
 - Whether the strings are **Prefixes** or **Suffixes**
 - The list of **Strings** to check for. Allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
-    - Note that strings are case-sensitive.
+  - Note that strings are case-sensitive.
 
 GraphOS dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the resulting rule name is `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
 

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -35,6 +35,31 @@ query GetUsers { # Don't define operations in a schema document
 #highlight-end
 ```
 
+#### `ALL_ELEMENTS_REQUIRE_DESCRIPTION`
+
+Each element in the schema must include a description.
+
+<p style="margin-bottom: 0">❌</p>
+
+```graphql title="schema.graphql"
+type User {
+     username: String!
+     password: String!
+}
+```
+
+<p style="margin-bottom: 0">✅</p>
+
+```graphql title="schema.graphql"
+# A type that describes the user
+type User {
+     # The user's username, should be typed in the login field.
+     username: String!
+     # The user's password.
+     password: String!
+}
+```
+
 ## All fields
 
 #### `FIELD_NAMES_SHOULD_BE_CAMEL_CASE`

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -613,52 +613,12 @@ type Product {
 
 The `@tag` directive should always use an approved value for its `name` argument. You specify approved values in [GraphOS Studio](./schema-linter/#configuring-the-linter).
 
-## Custom rules
+### Custom rules
 
-You can create custom linter rules to forbid or require certain strings as the prefix or suffix for different schema elements. You can create rules for the following elements:
+You can create custom prefix and suffix rules beyond the built-in ones. These rules have the following naming convention: `{ELEMENT_NAME}_{FORBID|REQUIRE}_USER_DEFINED_{PREFIX|SUFFIX}`, for example, `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
 
-- Fields
-- Types
-- Objects
-- Interfaces
-- Inputs
-- Enums
-- Unions
+This rule would include a list of strings to forbid as prefixes in interface names.
 
-A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings.
+A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid all of the strings.
 
-### Creating a custom rule
-
-To create a new rule, click the **+** button above your list of linter rules.
-
-<img
-  className="screenshot"
-  src="../img/schema-rules/create-new-rule.jpg"
-  alt="To-do: How to create a new rule"
-  width="300"
-/>
-
-In the modal that opens, select the following:
-
-- Which **Schema element** you want to apply the rule to
-- Whether you want to **Forbid** or **Require** certain strings
-- Whether the strings are **Prefixes** or **Suffixes**
-- The list of **Strings** to check for. Allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
-  - Note that strings are case-sensitive.
-
-GraphOS dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the resulting rule name is `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
-
-<img
-  className="screenshot"
-  src="../img/schema-rules/new-rule-modal.jpg"
-  alt="To-do: New rule modal"
-  width="300"
-/>
-
-You can add as many rules as you want by clicking **Add another rule**. When you're done, click **Create**.
-
-Your custom rules appear with a **CUSTOM** tag in the rule list. You can edit a custom rule by clicking the pencil icon to the right of its name:
-
-[screenshot]
-
-As with built-in linter rules, you can set a custom rule's [severity level](./schema-linter/#setting-severity-levels). To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.
+Refer to the schema linter page for [custom rule configuration instructions](./schema-linter#creating-custom-rules).

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -5,7 +5,7 @@ description: Reference
 
 This reference lists the rules that you can enforce with [GraphOS schema linting](./schema-linter/), along with the code that GraphOS returns for each rule violation.
 
-Rules are categorized by the part(s) of your schema that they correspond to.
+Rules are categorized by the part(s) of your schema that they correspond to. You can also create [custom rules](#custom-rules) to forbid or require prefixes or suffixes you define on specific schema elements.
 
 ## Schema
 
@@ -598,3 +598,38 @@ type Product {
 #### `TAG_DIRECTIVE_USES_UNKNOWN_NAME`
 
 The `@tag` directive should always use an approved value for its `name` argument. You specify approved values in [GraphOS Studio](./schema-linter/#configuring-the-linter).
+
+## Custom rules
+
+You can create custom rules to forbid or require certain terms as prefixes or suffixes in a specific schema element. You can include multiple strings to forbid or require, but each rule can either only forbid or require the terms and can only apply to one schema element.
+
+### Custom rule configuration
+
+To create a new rule, click the **+** button above your list of Linter Rules.
+
+<img
+  className="screenshot"
+  src="../img/schema-rules/create-new-rule.jpg"
+  alt="To-do: How to create a new rule"
+  width="300"
+/>
+
+In the modal that opens, select the following:
+- Whether you want to **Forbid** or **Require** certain terms
+- Which **Schema element** you want to apply the rule to
+- Whether the terms should be considered **Prefixes** or **Suffixes**
+- The **Strings** the rule should check for; the allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]` and rules are case-sensitive
+
+<img
+  className="screenshot"
+  src="../img/schema-rules/new-rule-modal.jpg"
+  alt="To-do: New rule modal"
+  width="300"
+/>
+
+Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for Interfaces, the rule name would be `FORBID_USER_DEFINED_INTERFACE_PREFIX`.
+
+You can add as many rules as you like by clicking **Add another rule**. Once you've finished, don't forget to click **Create**.
+
+Your custom rules appear in the list of rules with the **Custom** tag. Once created, you can edit them by clicking the pencil icon on the right of the rule's name.
+As with other linter rules, you can [configure their severity](./schema-linter/#setting-severity-levels), including setting their severity to **Ignore**, if you want to disable them. To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -191,6 +191,32 @@ type Book { # highlight-line
 }
 ```
 
+#### `DEFINED_TYPES_ARE_USED`
+
+All defined types are used at least once in the schema.
+
+Types that are defined but then not used are most likely due to a mistake such as incomplete refactoring. Unused types take up space and can confuse readers.
+
+<p style="margin-bottom: 0">❌</p>
+
+```graphql title="schema.graphql"
+type someUnusedType { # Also fails the TYPE_SUFFIX rule!
+  name: String!
+}
+```
+
+<p style="margin-bottom: 0">✅</p>
+
+```graphql title="schema.graphql"
+type Book { 
+  title: String!
+}
+
+type Query {
+  books: [Book!]!
+}
+```
+
 ## Objects
 
 #### `OBJECT_PREFIX`

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -62,7 +62,7 @@ type User {
 
 ## Fields
 
-These rules apply to the fields in your schema. Certain rules apply only to fields of particular types.
+These rules apply to the fields in your schema.
 
 #### `FIELD_NAMES_SHOULD_BE_CAMEL_CASE`
 
@@ -115,30 +115,6 @@ type Query {
 ```graphql title="schema.graphql"
 type Query {
   users: [User!]! # highlight-line
-}
-```
-
-#### `FIELDS_HAVE_DESCRIPTIONS_QUERY_MUTATION`
-
-All fields of the `Query` and `Mutation` types should have descriptions.
-
-<p style="margin-bottom: 0">❌</p>
-
-```graphql title="schema.graphql"
-type Mutation {
-  createBlogPost(blogPostContent: BlogPostContent!): Post
-}
-```
-
-<p style="margin-bottom: 0">✅</p>
-
-```graphql title="schema.graphql"
-type Mutation {
-  "Create a new blog post"
-  createBlogPost(
-    "The content of the blog post to be created"
-    blogPostContent: BlogPostContent!
-  ): Post
 }
 ```
 

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -3,17 +3,19 @@ title: GraphOS schema linter rules
 description: Reference
 ---
 
-This reference lists the rules that you can enforce with [GraphOS schema linting](./schema-linter/), along with the code that GraphOS returns for each rule violation.
+This reference lists the built-in rules that you can enforce with [GraphOS schema linting](./schema-linter/). You can also create [custom rules](#custom-rules) to forbid or require prefixes or suffixes you define on specific schema elements.
 
-Rules are categorized by the part(s) of your schema that they correspond to. You can also create [custom rules](#custom-rules) to forbid or require prefixes or suffixes you define on specific schema elements.
+Rules are categorized by the part(s) of your schema that they correspond to.
 
 ## Schema
+
+These rules apply to the entire schema.
 
 #### `DOES_NOT_PARSE`
 
 The schema linter raises this violation if it attempts to read a malformed GraphQL schema. Check your schema for any syntax errors.
 
-<hr/>
+<hr />
 
 #### `QUERY_DOCUMENT_DECLARATION`
 
@@ -27,7 +29,8 @@ type Query {
 }
 
 #highlight-start
-query GetUsers { # Don't define operations in a schema document
+query GetUsers {
+  # Don't define operations in a schema document
   users {
     id
   }
@@ -43,7 +46,7 @@ Each element in the schema must include a description.
 
 ```graphql title="schema.graphql"
 type User {
-     username: String!
+  username: String!
 }
 ```
 
@@ -52,12 +55,14 @@ type User {
 ```graphql title="schema.graphql"
 # Represents a user
 type User {
-     # The username of the user
-     username: String!
+  # The username of the user
+  username: String!
 }
 ```
 
-## All fields
+## Fields
+
+These rules apply to _all_ fields, except for [`FIELDS_HAVE_DESCRIPTIONS_QUERY_MUTATION`](#fields_have_descriptions_query_mutation) which only applies to fields in queries and mutations.
 
 #### `FIELD_NAMES_SHOULD_BE_CAMEL_CASE`
 
@@ -83,7 +88,7 @@ type User {
 }
 ```
 
-<hr/>
+<hr />
 
 #### `RESTY_FIELD_NAMES`
 
@@ -113,7 +118,7 @@ type Query {
 }
 ```
 
-#### `FIELDS-HAVE-DESCRIPTIONS-QUERY-MUTATION`
+#### `FIELDS_HAVE_DESCRIPTIONS_QUERY_MUTATION`
 
 All query and mutation fields have descriptions.
 
@@ -137,7 +142,7 @@ type Mutation {
 }
 ```
 
-## All types
+## Types
 
 These rules apply to _all_ types that appear in a GraphQL schema, including:
 
@@ -156,7 +161,7 @@ All type names should use `PascalCase`.
 ```graphql title="schema.graphql"
 # highlight-start
 type streamingService { # camelCase
-# highlight-end
+  # highlight-end
   id: ID!
 }
 ```
@@ -166,12 +171,12 @@ type streamingService { # camelCase
 ```graphql title="schema.graphql"
 # highlight-start
 type StreamingService { # PascalCase
-# highlight-end
+  # highlight-end
   id: ID!
 }
 ```
 
-<hr/>
+<hr />
 
 #### `TYPE_PREFIX`
 
@@ -193,7 +198,7 @@ type Book { # highlight-line
 }
 ```
 
-<hr/>
+<hr />
 
 #### `TYPE_SUFFIX`
 
@@ -232,7 +237,7 @@ type someUnusedType { # Also fails the TYPE_SUFFIX rule!
 <p style="margin-bottom: 0">✅</p>
 
 ```graphql title="schema.graphql"
-type Book { 
+type Book {
   title: String!
 }
 
@@ -263,7 +268,7 @@ type Book { # highlight-line
 }
 ```
 
-<hr/>
+<hr />
 
 #### `OBJECT_SUFFIX`
 
@@ -309,7 +314,7 @@ interface Book { # highlight-line
 }
 ```
 
-<hr/>
+<hr />
 
 #### `INTERFACE_SUFFIX`
 
@@ -359,7 +364,7 @@ type Mutation {
 }
 ```
 
-<hr/>
+<hr />
 
 #### `INPUT_TYPE_SUFFIX`
 
@@ -409,7 +414,7 @@ enum Amenity {
 }
 ```
 
-<hr/>
+<hr />
 
 #### `ENUM_PREFIX`
 
@@ -435,7 +440,7 @@ enum Residence { # highlight-line
 }
 ```
 
-<hr/>
+<hr />
 
 #### `ENUM_SUFFIX`
 
@@ -461,7 +466,7 @@ enum Residence { # highlight-line
 }
 ```
 
-<hr/>
+<hr />
 
 #### `ENUM_USED_AS_INPUT_WITHOUT_SUFFIX`
 
@@ -493,7 +498,7 @@ type Query {
 }
 ```
 
-<hr/>
+<hr />
 
 #### `ENUM_USED_AS_OUTPUT_DESPITE_SUFFIX`
 
@@ -543,12 +548,11 @@ directive @SpecialField on FIELD_DEFINITION # PascalCase
 directive @specialField on FIELD_DEFINITION # camelCase
 ```
 
-<hr/>
+<hr />
 
 #### `CONTACT_DIRECTIVE_MISSING`
 
 A subgraph schema should always provide owner contact details via the `@contact` directive. [Learn more.](../graphs/federated-graphs#contact-info-for-subgraphs)
-
 
 <p style="margin-bottom: 0">✅</p>
 
@@ -562,14 +566,15 @@ directive @contact(
   description: String
 ) on SCHEMA
 
-extend schema @contact(
-  name: "Products Team",
-  url: "https://myteam.slack.com/archives/teams-chat-room-url",
-  description: "Send urgent issues to [#oncall](https://yourteam.slack.com/archives/oncall)."
-)
+extend schema
+  @contact(
+    name: "Products Team"
+    url: "https://myteam.slack.com/archives/teams-chat-room-url"
+    description: "Send urgent issues to [#oncall](https://yourteam.slack.com/archives/oncall)."
+  )
 ```
 
-<hr/>
+<hr />
 
 #### `DEPRECATED_DIRECTIVE_MISSING_REASON`
 
@@ -593,7 +598,7 @@ type Product {
 }
 ```
 
-<hr/>
+<hr />
 
 #### `TAG_DIRECTIVE_USES_UNKNOWN_NAME`
 
@@ -601,11 +606,21 @@ The `@tag` directive should always use an approved value for its `name` argument
 
 ## Custom rules
 
-You can create custom rules to forbid or require certain terms as prefixes or suffixes in a specific schema element. You can include multiple strings to forbid or require, but each rule can either only forbid or require the terms and can only apply to one schema element.
+You can create custom rules to forbid or require certain terms as prefixes or suffixes in a specific schema element. You can create rules for the following elements:
+
+- Fields
+- Types
+- Objects
+- Interfaces
+- Inputs
+- Enums
+- Unions
+
+A rule can include multiple strings to forbid or require, but each rule can _either_ only forbid _or_ require the terms and can only apply to one schema element.
 
 ### Custom rule configuration
 
-To create a new rule, click the **+** button above your list of Linter Rules.
+To create a new rule, click the **+** button above your list of linter rules.
 
 <img
   className="screenshot"
@@ -615,10 +630,15 @@ To create a new rule, click the **+** button above your list of Linter Rules.
 />
 
 In the modal that opens, select the following:
-- Whether you want to **Forbid** or **Require** certain terms
+
 - Which **Schema element** you want to apply the rule to
+- Whether you want to **Forbid** or **Require** certain terms
 - Whether the terms should be considered **Prefixes** or **Suffixes**
-- The **Strings** the rule should check for; the allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]` and rules are case-sensitive
+- The **Strings** the rule should check for; the allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
+
+> **Note:** Rules are case-sensitive.
+
+Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for Interfaces, the rule name would be `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
 
 <img
   className="screenshot"
@@ -627,9 +647,8 @@ In the modal that opens, select the following:
   width="300"
 />
 
-Apollo dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for Interfaces, the rule name would be `FORBID_USER_DEFINED_INTERFACE_PREFIX`.
-
 You can add as many rules as you like by clicking **Add another rule**. Once you've finished, don't forget to click **Create**.
 
 Your custom rules appear in the list of rules with the **Custom** tag. Once created, you can edit them by clicking the pencil icon on the right of the rule's name.
+
 As with other linter rules, you can [configure their severity](./schema-linter/#setting-severity-levels), including setting their severity to **Ignore**, if you want to disable them. To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -113,6 +113,33 @@ type Query {
 }
 ```
 
+#### `FIELDS-HAVE-DESCRIPTIONS-QUERY-MUTATION`
+
+All query and mutation fields have descriptions.
+
+
+<p style="margin-bottom: 0">❌</p>
+
+```graphql title="schema.graphql"
+type Mutation {
+  createBlogPost(blogPostContent: BlogPostContent!): Post
+}
+```
+
+<p style="margin-bottom: 0">✅</p>
+
+```graphql title="schema.graphql"
+type Mutation {
+  # Create a new blog post
+  createBlogPost(
+    # The content of the blog post to be created
+    blogPostContent: BlogPostContent!
+  ): Post
+}
+```
+
+
+
 ## All types
 
 These rules apply to _all_ types that appear in a GraphQL schema, including:

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -44,19 +44,16 @@ Each element in the schema must include a description.
 ```graphql title="schema.graphql"
 type User {
      username: String!
-     password: String!
 }
 ```
 
 <p style="margin-bottom: 0">✅</p>
 
 ```graphql title="schema.graphql"
-# A type that describes the user
+# Represents a user
 type User {
-     # The user's username, should be typed in the login field.
+     # The username of the user
      username: String!
-     # The user's password.
-     password: String!
 }
 ```
 

--- a/src/content/graphos/delivery/schema-linter.mdx
+++ b/src/content/graphos/delivery/schema-linter.mdx
@@ -73,7 +73,58 @@ Click a rule's severity to set it to any of the following:
 
 ### Creating custom rules
 
-You can create custom prefix and suffix rules beyond the default ones provided. Refer to the [linter rules page](./linter-rules) for a reference list of all default rules and [custom rule configuration instructions](./linter-rules#custom-rules).
+You can create custom linter rules to forbid or require certain strings as the prefix or suffix for different schema elements. You can create rules for the following elements:
+
+- Fields
+- Types
+- Objects
+- Interfaces
+- Inputs
+- Enums
+- Unions
+
+A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid all of the strings.
+
+#### Custom rule configuration
+
+To create a new rule, click the **+** button above your list of linter rules.
+
+<img
+  className="screenshot"
+  src="../img/schema-rules/create-new-rule.jpg"
+  alt="To-do: How to create a new rule"
+  width="300"
+/>
+
+In the modal that opens, select the following:
+
+- Which **Schema element** you want to apply the rule to
+- Whether you want to **Forbid** or **Require** certain strings
+- Whether the strings are **Prefixes** or **Suffixes**
+- The list of **Strings** to check for. Allowed characters are `[A-Z]`, `[a-z]`, `[0-9]`, and `[_]`
+  - Note that strings are case-sensitive.
+
+GraphOS dynamically generates the rule name based on your selections. For example, if you create a rule forbidding certain prefixes for interfaces, the resulting rule name is `INTERFACE_FORBID_USER_DEFINED_PREFIX`.
+
+<img
+  className="screenshot"
+  src="../img/schema-rules/new-rule-modal.jpg"
+  alt="To-do: New rule modal"
+  width="300"
+/>
+
+You can add as many rules as you want by clicking **Add another rule**. When you're done, click **Create**.
+
+Your custom rules appear with a **CUSTOM** tag in the rule list. You can edit a custom rule by clicking the pencil icon to the right of its name:
+
+<img
+  className="screenshot"
+  src="../img/schema-rules/edit-rule.jpg"
+  alt="To-do: Edit rule"
+  width="300"
+/>
+
+As with built-in linter rules, you can set a custom rule's [severity level](./schema-linter/#setting-severity-levels). To delete a rule, click the pencil icon and then click the trash can icon next to it in the custom rule modal.
 
 ## Running the linter
 

--- a/src/content/graphos/delivery/schema-linter.mdx
+++ b/src/content/graphos/delivery/schema-linter.mdx
@@ -73,7 +73,7 @@ Click a rule's severity to set it to any of the following:
 
 ### Creating custom rules
 
-You can create custom prefix and suffix rules beyond the default ones provided. Refer to the linter rules page for a reference list of all default rules and [custom rule configuration instructions](./linter-rules#custom-rules).
+You can create custom prefix and suffix rules beyond the default ones provided. Refer to the [linter rules page](./linter-rules) for a reference list of all default rules and [custom rule configuration instructions](./linter-rules#custom-rules).
 
 ## Running the linter
 

--- a/src/content/graphos/delivery/schema-linter.mdx
+++ b/src/content/graphos/delivery/schema-linter.mdx
@@ -71,6 +71,10 @@ Click a rule's severity to set it to any of the following:
 - **Warn.** Violations of this rule are flagged in checks reports, but they _don't_ cause the associated linter check to fail.
 - **Ignore.** Violations of this rule are ignored entirely.
 
+### Creating custom rules
+
+You can create custom prefix and suffix rules beyond the default ones provided. Refer to the linter rules page for a reference list of all default rules and [custom rule configuration instructions](./linter-rules#custom-rules).
+
 ## Running the linter
 
 Schema linting runs automatically as part of your graph's [schema checks](#linting-via-schema-checks). You can also perform [one-off linting](#one-off-linting) of local schema changes via the Rover CLI.

--- a/src/content/graphos/delivery/schema-linter.mdx
+++ b/src/content/graphos/delivery/schema-linter.mdx
@@ -83,9 +83,9 @@ You can create custom linter rules to forbid or require certain strings as the p
 - Enums
 - Unions
 
-A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid all of the strings.
+A single rule can specify multiple strings to forbid _or_ require (not both) for a particular schema element. If you create a "require" rule and specify multiple strings, each schema element can use _any one_ of the specified strings. Rules forbidding strings forbid _all_ the strings you include.
 
-#### Custom rule configuration
+#### Configure custom rules
 
 To create a new rule, click the **+** button above your list of linter rules.
 

--- a/src/content/graphos/delivery/schema-linter.mdx
+++ b/src/content/graphos/delivery/schema-linter.mdx
@@ -80,6 +80,7 @@ You can create custom linter rules to forbid or require certain strings as the p
 - Objects
 - Interfaces
 - Inputs
+- Arguments
 - Enums
 - Unions
 


### PR DESCRIPTION
This PR adds three new default schema linter rules and describes how you can create custom rules.

Context
- https://github.com/mdg-private/planning/issues/2217
- https://www.figma.com/file/W0HXJ10i6SC3rktt9uVUOF/Schema-Linter?type=design&node-id=1520-79202&mode=design&t=P9jN4FRTVBjPXiGG-0