### PR TITLE
Add links to client docs

### DIFF
--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -303,7 +303,7 @@ The manifest will be generated in `build/generated/manifest/apollo/myapi/persist
 
 #### Apollo iOS
 
-> Manifest generation requires Apollo iOS `1.3.1` or later.
+> Manifest generation requires Apollo iOS `1.4.0` or later.
 
 To generate an operation manifest with Apollo iOS, you use the same [code generation engine](/ios/code-generation/introduction) that you use to generate Swift code for each of your operations. Specifically, you modify the engine's file output configuration to include the output of an `operationManifest`.
 

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -281,6 +281,8 @@ See the instructions for your client library:
     - **If the command succeeds,** your manifest is written to `persisted-query-manifest.json`.
     - **If the command fails** (or if your manifest doesn't include all the operations you expect it to), you can configure the command's behavior using the options described in the [package README](https://www.npmjs.com/package/@apollo/generate-persisted-query-manifest).
 
+[See the full Apollo Client persisted queries guide for detailed instructions](/react/api/link/persisted-queries/).
+
 #### Apollo Kotlin
 
 > Manifest generation requires Apollo Kotlin `3.8.2` or later.
@@ -297,12 +299,15 @@ apollo {
 ```
 The manifest will be generated in `build/generated/manifest/apollo/myapi/persistedQueryManifest.json`
 
+[See the full Apollo Kotlin persisted queries guide for detailed instructions](/kotlin/advanced/persisted-queries/).
+
 #### Apollo iOS
 
 > Manifest generation requires Apollo iOS `1.3.1` or later.
 
 To generate an operation manifest with Apollo iOS, you use the same [code generation engine](/ios/code-generation/introduction) that you use to generate Swift code for each of your operations. Specifically, you modify the engine's file output configuration to include the output of an `operationManifest`.
 
+[See the full Apollo iOS persisted queries guide for detailed instructions](/ios/fetching/persisted-queries/).
 
 #### 3.2 Publish manifests to the PQL
 
@@ -335,7 +340,7 @@ Here's the JSON body of a request to execute an operation by its ID:
 Apollo's mobile clients let you use the same mechanism for executing persisted queries operations as APQs.
 Refer to their persisted query documentation for implementation details.
 
-- [Apollo iOS](/ios/fetching/apqs/)
+- [Apollo iOS](/ios/fetching/persisted-queries/)
 - [Apollo Kotlin](/kotlin/advanced/persisted-queries/)
 
 The Apollo Client Web requires you to use an [additional package](https://www.npmjs.com/package/@apollo/persisted-query-lists) at runtime to send persisted queries. The Apollo Client Web requires this package because certain aspects of the operation sent at runtime may not match the registered operations without it. Mobile clients have a more deterministic approach to formatting operations and, thus, don't need it.

--- a/src/content/shared/client-pq-implementation.mdx
+++ b/src/content/shared/client-pq-implementation.mdx
@@ -2,8 +2,8 @@ We recommend you follow this order while implementing:
 
 | Implementation Step | Required for PQs? | Required for APQs? |
 | -----| ------------------ | ----------------- |
-| 1. Generate operation manifest| ✅ | -- |
-| 2. Publish operation manifest to a PQL |✅ | -- |
+| 1. Generate the operation manifest| ✅ | -- |
+| 2. Publish the operation manifest to a PQL |✅ | -- |
 | 3. Enable persisted queries on the client when it makes requests | ✅ | ✅ |
 
 The rest of this article details these steps.

--- a/src/content/shared/client-pq-implementation.mdx
+++ b/src/content/shared/client-pq-implementation.mdx
@@ -8,4 +8,4 @@ We recommend you follow this order while implementing:
 
 The rest of this article details these steps.
 
-Persisted queries also requires you to create and link a PQL, and to configure your router. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
+Persisted queries also require you to create and link a PQL, and to configure your router to receive persisted query requests. This document only describes the steps that need to be taken by the client to create a manifest of the client's operations and send persisted query requests. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).


### PR DESCRIPTION
This PR adds back links to (newly updated) client docs, improved wording on a shared content stub, and bumps ios version needed.