### PR TITLE
Fix typo in function name

### DIFF
--- a/src/content/technotes/TN0032-sdui-and-graphql.mdx
+++ b/src/content/technotes/TN0032-sdui-and-graphql.mdx
@@ -89,7 +89,7 @@ const TYPE_COMPONENTS = {
 const component = TYPE_COMPONENTS[data.featuredProducts.__typename];
 if (!component) { throw new Error('Unknown Type Returned!'); }
 
-renderComponet(component, data);
+renderComponent(component, data);
 ```
 
 This means that from the API response you can dynamically choose when to render different components or start displaying different components based on any of our API inputs, including headers or user information.


### PR DESCRIPTION
Fixing a typo in SDUI docs where "component" is spelled without the second 'n'.