### PR TITLE
Clarifying logging behavior in safelisting modes

### DIFF
--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -386,7 +386,7 @@ If safelisting is your goal, you'll need to [coordinate across client teams](#co
 
 Once your router's logs are completely clear of unexpected operations, you can configure your router to use [safelisting mode](#safelisting). Then, to reap the performance benefits, [update your client apps](#4-client-updates) to use operation IDs rather than full query strings.
 
-Once you've confirmed all client apps use IDs, you can move to the most restrictive security level: [safelisting with IDs only](#safelisting-ids-only).
+Once you've confirmed all client apps use IDs, you can move to the most restrictive security level: [safelisting with IDs only](#safelisting-with-ids-only).
 This security level _enforces_ the performance benefit of using operation IDs rather than full operation strings. If you're content with the safelisting aspect of persisted queries with only optional performance benefits, you don't need to enable it.
 
 ### Coordinate with client teams

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -50,12 +50,33 @@ If you _only_ want to improve request latency and bandwidth usage, APQ addresses
 
 The Apollo Router supports the following security levels or modes, in increasing order of restrictiveness:
 
-|Security Level|Description|
-|--|--|
-|**Allow operation IDs**| Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.|
-|**Audit mode**| Executing operations by providing a PQL-specified ID is still optional, but the router logs any unregistered operations.|
-|**Safelisting**| The router _rejects_ any incoming operations that aren't present in its PQL.|
-|**Safelisting with IDs only**| The router rejects any incoming operations that aren't present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.|
+<table>
+  <thead>
+    <tr>
+      <th style={{minWidth: 215}}>Security Level</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Allow operation IDs</strong></td>
+      <td>Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.</td>
+    </tr>
+    <tr>
+      <td><strong>Audit mode</strong></td>
+      <td>Executing operations by providing a PQL-specified ID is still optional, but the router logs any unregistered operations.</td>
+    </tr>
+    <tr>
+      <td><strong>Safelisting</strong></td>
+      <td>The router <em>rejects</em> any incoming operations that aren't present in its PQL. Clients can use either PQL-specified ID or operation string to execute operations.</td>
+    </tr>
+    <tr>
+      <td><strong>Safelisting with IDs only</strong></td>
+      <td>The router rejects any incoming operations that aren't present in its PQL, <em>and</em> clients <em>must</em> execute an operation by providing its PQL-specified ID.</td>
+    </tr>
+  </tbody>
+</table>
+
 
 > _You can find more details, including configuration instructions, in the [implementation section](#2-router-configuration)._
 

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -72,7 +72,7 @@ The Apollo Router supports the following security levels or modes, in increasing
     </tr>
     <tr>
       <td><strong>Safelisting with IDs only</strong></td>
-      <td>The router rejects any incoming operations that aren't present in its PQL, <em>and</em> clients <em>must</em> execute an operation by providing its PQL-specified ID.</td>
+      <td>Clients can _only_ execute operations by providing their PQL-specified IDs; the router rejects all freeform GraphQL requests.</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -52,9 +52,9 @@ The Apollo Router supports the following security levels or modes, in increasing
 
 |Security Level|Description|
 |--|--|
-|**Performance-only**| Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.|
+|**Allow operation IDs**| Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.|
 |**Audit mode**| Executing operations by providing a PQL-specified ID is still optional, but the router logs any unregistered operations.|
-|**Safelisting with operation strings allowed**| The router _rejects_ any incoming operations that aren't present in its PQL.|
+|**Safelisting**| The router _rejects_ any incoming operations that aren't present in its PQL.|
 |**Safelisting with IDs only**| The router rejects any incoming operations that aren't present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.|
 
 > _You can find more details, including configuration instructions, in the [implementation section](#2-router-configuration)._
@@ -317,7 +317,7 @@ To generate an operation manifest with Apollo iOS, you use the same [code genera
 
 With your [manifest published](#3-preregister-trusted-operations) and the [router configured](#2-router-configuration), you can update your clients to use trusted operations IDs. Organizations can do this one client at a time as client teams [publish client-specific PQMs](#32-publish-manifests-to-the-pql) to the PQL.
 
-> **Note:** This step provides performance benefits but isn't necessary for safelisting. You can continue to use full operation strings rather than operation IDs in [safelisting mode](#safelisting-operation-strings-allowed).
+> **Note:** This step provides performance benefits but isn't necessary for safelisting. You can continue to use full operation strings rather than operation IDs in [safelisting mode](#safelisting).
 
 To execute operations using their PQL-specified ID instead of full operations strings, clients can use the same protocol used for automatic persisted queries (APQ). 
 
@@ -363,7 +363,7 @@ Persisted queries' [tiered security levels](#security-levels) let you adopt an i
 
 If safelisting is your goal, you'll need to [coordinate across client teams](#coordinate-with-client-teams) to complete these steps for each of your client apps.
 
-Once your router's logs are completely clear of unexpected operations, you can configure your router to use [safelisting mode](#safelisting-operation-strings-allowed). Then, to reap the performance benefits, [update your client apps](#4-client-updates) to use operation IDs rather than full query strings.
+Once your router's logs are completely clear of unexpected operations, you can configure your router to use [safelisting mode](#safelisting). Then, to reap the performance benefits, [update your client apps](#4-client-updates) to use operation IDs rather than full query strings.
 
 Once you've confirmed all client apps use IDs, you can move to the most restrictive security level: [safelisting with IDs only](#safelisting-ids-only).
 This security level _enforces_ the performance benefit of using operation IDs rather than full operation strings. If you're content with the safelisting aspect of persisted queries with only optional performance benefits, you don't need to enable it.
@@ -675,7 +675,7 @@ Similarly, if your clients execute operations by providing their PQL-specified I
 
 #### Operation formatting changes
 
-While in [preview](/resources/product-launch-stages#preview), if your client sends full operation strings for registered operations, the registered operation's [`body`](#body) string must _exactly_ match the operation string, **including whitespace and field order**. In [audit mode](#audit-mode-dry-run), the router executes operations regardless of whitespace or field order differences, but logs them as unregistered operations. In [safelisting with operation strings allowed](#safelisting-operation-strings-allowed), the router rejects these operations.
+While in [preview](/resources/product-launch-stages#preview), if your client sends full operation strings for registered operations, the registered operation's [`body`](#body) string must _exactly_ match the operation string, **including whitespace and field order**. In [audit mode](#audit-mode-dry-run), the router executes operations regardless of whitespace or field order differences, but logs them as unregistered operations. In [safelisting with operation strings allowed](#safelisting), the router rejects these operations.
 
 This will change before the feature reaches [general availability](/resources/product-launch-stages/#general-availability): whitespace and other formatting differences won't disqualify operations as different from their preregistered versions.
 Specifically, the router will consider operations that differ only in whitespace, comments, and other ignored tokens to be the same. Similarly, it will consider operations that differ only in the order of their top-level operation and fragment definitions to be the same. Other differences, such as the order of fields or arguments, will still cause operations to be considered as different.

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -44,7 +44,7 @@ APQ has a few limitations compared to preregistered persisted queries.
   </tbody>
 </table>
 
-If you _only_ want to improve request latency and bandwidth usage, APQ addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister trusted operations in a PQL.
+If you _only_ want to improve request latency and bandwidth usage, APQ addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister operations in a PQL.
 
 ## Security levels
 
@@ -80,13 +80,13 @@ The Apollo Router supports the following security levels or modes, in increasing
 
 > _You can find more details, including configuration instructions, in the [implementation section](#2-router-configuration)._
 
-These levels of permissiveness allow you to [incrementally adopt](#incremental-adoption-path) persisted queries on a client-by-client basis. Specifically, the router should use audit mode until you're confident that _all_ your clients' trusted operations have been registered in the PQL. Refer to the [incremental adoption section](#incremental-adoption-path) for a step-by-step guide.
+These levels of permissiveness allow you to [incrementally adopt](#incremental-adoption-path) persisted queries on a client-by-client basis. Specifically, the router should use audit mode until you're confident that _all_ your clients' trusted operations have been preregistered in the PQL. Refer to the [incremental adoption section](#incremental-adoption-path) for a step-by-step guide.
 
 ## Implementation steps
 
 Persisted queries provide benefits to different teams:
 - Safelisting helps **platform teams** secure the graph and optimize its performance.
-- **Application developers** can use trusted operation IDs to write performant client code.
+- **Application developers** can use preregistered operation IDs to write performant client code.
 
 Implementation also requires collaboration among these parties. These are the main steps for implementing persisted queries for safelisting, along with the team that usually performs them:
 
@@ -112,7 +112,7 @@ Implementation also requires collaboration among these parties. These are the ma
       <td>Platform team</td>
     </tr>
     <tr>
-      <td> <a href="#3-preregister-trusted-operations">3. Preregister trusted operations</a> </td>
+      <td> <a href="#3-preregister-operations">3. Preregister operations</a> </td>
       <td>
       Generate and publish a persisted queries manifest (PQM) to the PQL from your client's CI/CD pipeline.
       </td>
@@ -136,7 +136,7 @@ Continue reading for each step's details, or skip to the [incremental adoption s
 ### 1. PQL creation and linking
 
 To use persisted queries, you first need a **persisted query list** (**PQL**) in GraphOS Studio.
-Platform teams create an empty PQL in GraphOS Studio so that client teams can register trusted operations to it.
+Platform teams create an empty PQL in GraphOS Studio so that client teams can preregister operations to it.
 
 Each PQL is associated or "linked" with a single graph in GraphOS. A graph, however, can have several PQLs. For example, one graph may need multiple PQLs if you want a separate PQL for each [contract variant](../delivery/contracts/). You can link a PQL to any variants of its graph. And although many variants may use the same PQL, each variant can only have one linked PQL at a time.
 
@@ -236,9 +236,9 @@ The Apollo Router is the key component that enforces safelisting.
 
 <PQSecurityLevels />
 
-### 3. Preregister trusted operations
+### 3. Preregister operations
 
-Preregistering trusted operations to a PQL has two steps:
+Preregistering operations to a PQL has two steps:
 1. Generating persisted queries manifests (PQM) using client-specific tooling
 2. Publishing PQMs to the PQL using the Rover CLI tool
 
@@ -246,7 +246,7 @@ Building both of these into your CI/CD pipeline incorporates new operations auto
 
 #### 3.1 Generate persisted queries manifests
 
-Once a PQL exists in GraphOS, client teams can start publishing operations to it. To do so, you must generate JSON **manifests** of the trusted operations to publish. You generate a separate manifest for each of your client apps.
+Once a PQL exists in GraphOS, client teams can start publishing operations to it. To do so, you must generate JSON **manifests** of the operations to publish. You generate a separate manifest for each of your client apps.
 
 <ExpansionPanel title="See an example manifest file with two operations">
 
@@ -336,7 +336,7 @@ To generate an operation manifest with Apollo iOS, you use the same [code genera
 
 ### 4. Client updates
 
-With your [manifest published](#3-preregister-trusted-operations) and the [router configured](#2-router-configuration), you can update your clients to use trusted operations IDs. Organizations can do this one client at a time as client teams [publish client-specific PQMs](#32-publish-manifests-to-the-pql) to the PQL.
+With your [manifest published](#3-preregister-operations) and the [router configured](#2-router-configuration), you can update your clients to use preregistered operations IDs. Organizations can do this one client at a time as client teams [publish client-specific PQMs](#32-publish-manifests-to-the-pql) to the PQL.
 
 > **Note:** This step provides performance benefits but isn't necessary for safelisting. You can continue to use full operation strings rather than operation IDs in [safelisting mode](#safelisting).
 
@@ -364,23 +364,23 @@ Refer to their persisted query documentation for implementation details.
 - [Apollo iOS](/ios/fetching/persisted-queries/)
 - [Apollo Kotlin](/kotlin/advanced/persisted-queries/)
 
-The Apollo Client Web requires you to use an [additional package](https://www.npmjs.com/package/@apollo/persisted-query-lists) at runtime to send persisted queries. The Apollo Client Web requires this package because certain aspects of the operation sent at runtime may not match the registered operations without it. Mobile clients have a more deterministic approach to formatting operations and, thus, don't need it.
+The Apollo Client Web requires you to use an [additional package](https://www.npmjs.com/package/@apollo/persisted-query-lists) at runtime to send persisted queries. The Apollo Client Web requires this package because certain aspects of the operation sent at runtime may not match the preregistered operations without it. Mobile clients have a more deterministic approach to formatting operations and, thus, don't need it.
 
 Refer to the Apollo Client Web's [persisted query documentation](/react/api/link/persisted-queries/) for implementation details.
 
 ## Incremental adoption path
 
-Persisted queries' [tiered security levels](#security-levels) let you adopt an incremental approach rather than simultaneously requiring all clients to send requests via trusted operations IDs. You can follow these steps for incremental adoption:
+Persisted queries' [tiered security levels](#security-levels) let you adopt an incremental approach rather than simultaneously requiring all clients to send requests via preregistered operations IDs. You can follow these steps for incremental adoption:
 
 1. Identify the first client you want to implement persisted queries with. It could be the client or team you're most comfortable with or the one most comfortable with GraphOS.
 2. Follow all [implementation steps](#implementation-steps) for your chosen client:
     - [Create and link a PQL](#1-pql-creation-and-linking) to a staging or development variant.
     - When [configuring the router](#2-router-configuration), begin with [audit mode](#audit-mode-dry-run).
     - Use the [client-specific tooling](#generation-methods) to generate an [operation manifest](#31-generate-persisted-queries-manifests) and [publish it to the PQL](#32-publish-manifests-to-the-pql) as part of your client's CI/CD pipeline.
-    - (Optional) Update your chosen client to use only trusted operations, either by full operation string or operation ID.
+    - (Optional) Update your chosen client to use only preregistered operations, either by full operation string or operation ID.
         - Teams working with Apollo Client Web need to use an [additional package](https://www.npmjs.com/package/@apollo/persisted-query-lists) at runtime to send persisted queries.
 
-3. Continue to monitor your router logs: once you consistently see that unregistered operations are being logged and registered ones aren't, you've completed the setup for this client! 🎉
+3. Continue to monitor your router logs: once you consistently see that unregistered operations are being logged and preregistered ones aren't, you've completed the setup for this client! 🎉
 
 If safelisting is your goal, you'll need to [coordinate across client teams](#coordinate-with-client-teams) to complete these steps for each of your client apps.
 
@@ -630,7 +630,7 @@ query GetBooks {
 
 </CodeColumns>
 
-Differences in whitespace or comments between a registered operation and the operation a client sends also cause the router to reject client operations. 
+Differences in whitespace or comments between a preregistered operation and the operation a client sends also cause the router to reject client operations. 
 
 <CodeColumns>
 
@@ -696,7 +696,7 @@ Similarly, if your clients execute operations by providing their PQL-specified I
 
 #### Operation formatting changes
 
-While in [preview](/resources/product-launch-stages#preview), if your client sends full operation strings for registered operations, the registered operation's [`body`](#body) string must _exactly_ match the operation string, **including whitespace and field order**. In [audit mode](#audit-mode-dry-run), the router executes operations regardless of whitespace or field order differences, but logs them as unregistered operations. In [safelisting with operation strings allowed](#safelisting), the router rejects these operations.
+While in [preview](/resources/product-launch-stages#preview), if your client sends full operation strings for preregistered operations, the preregistered operation's [`body`](#body) string must _exactly_ match the operation string, **including whitespace and field order**. In [audit mode](#audit-mode-dry-run), the router executes operations regardless of whitespace or field order differences, but logs them as unregistered operations. In [safelisting with operation strings allowed](#safelisting), the router rejects these operations.
 
 This will change before the feature reaches [general availability](/resources/product-launch-stages/#general-availability): whitespace and other formatting differences won't disqualify operations as different from their preregistered versions.
 Specifically, the router will consider operations that differ only in whitespace, comments, and other ignored tokens to be the same. Similarly, it will consider operations that differ only in the order of their top-level operation and fragment definitions to be the same. Other differences, such as the order of fields or arguments, will still cause operations to be considered as different.

--- a/src/content/shared/client-pq-differences.mdx
+++ b/src/content/shared/client-pq-differences.mdx
@@ -1,8 +1,8 @@
 The persisted queries feature requires operations to be preregistered in a **persisted query list** (**PQL**).
-This allows the PQL to act as a safelist of trusted operations made by your first-party apps. As such, persisted queries is a security feature as much as a performance one.
+This allows the PQL to act as an operation safelist made by your first-party apps. As such, persisted queries is a security feature as much as a performance one.
 
 With APQs, if the server can't find the operation ID the client provides, the server returns an error indicating that it needs the full operation string. If an Apollo client receives this error, it automatically retries the operation with the full operation string.
 
-If you _only_ want to improve request latency and bandwidth usage, APQ addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister trusted operations in a PQL.
+If you _only_ want to improve request latency and bandwidth usage, APQ addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister operations in a PQL.
 
 For more details on differences between persisted queries and APQ, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries#differences-from-automatic-persisted).

--- a/src/content/shared/pq-intro.mdx
+++ b/src/content/shared/pq-intro.mdx
@@ -1,4 +1,4 @@
-With [GraphOS Enterprise](/graphos/enterprise/), you can enhance your supergraph's security by maintaining a **persisted query list** (**PQL**) for your supergraph's self-hosted router. The [Apollo Router](/router/) checks incoming requests against the PQL, a safelist of trusted operations made by your first-party apps.
+With [GraphOS Enterprise](/graphos/enterprise/), you can enhance your supergraph's security by maintaining a **persisted query list** (**PQL**) for your supergraph's self-hosted router. The [Apollo Router](/router/) checks incoming requests against the PQL, an operation safelist made by your first-party apps.
 
 ```mermaid
 flowchart LR

--- a/src/content/shared/pq-router-configuration.mdx
+++ b/src/content/shared/pq-router-configuration.mdx
@@ -8,4 +8,4 @@ As soon as a graph has an associated PQL, you can configure router instances to 
 
 3. Deploy your updated router instances to begin using your PQL.
 
-Once your organization's PQL has registered all your clients' operations and you've ensured your client apps are only sending trusted operations, you can update your router configuration to the [safelisting security level](#safelisting).
+Once your organization's PQL has preregistered all your clients' operations and you've ensured your client apps are only sending preregistered operations, you can update your router configuration to the [safelisting security level](#safelisting).

--- a/src/content/shared/pq-router-configuration.mdx
+++ b/src/content/shared/pq-router-configuration.mdx
@@ -8,4 +8,4 @@ As soon as a graph has an associated PQL, you can configure router instances to 
 
 3. Deploy your updated router instances to begin using your PQL.
 
-Once your organization's PQL has registered all your clients' operations and you've ensured your client apps are only sending trusted operations, you can update your router configuration to the [safelisting security level](#safelisting-operation-strings-allowed).
+Once your organization's PQL has registered all your clients' operations and you've ensured your client apps are only sending trusted operations, you can update your router configuration to the [safelisting security level](#safelisting).

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -4,7 +4,7 @@ The Apollo Router supports the following security levels, in increasing order of
     - All other levels also provide this core capability.
     - This level doesn't provide safelisting.
 - **Audit mode**: Executing operations by providing a PQL-specified ID is still optional, but the router also logs any unregistered operations.
-    - The level serves as a dry run and helps you identify operations you may still need to register before turning on safelisting.
+    - The level serves as a dry run and helps you identify operations you may still need to preregister before turning on safelisting.
 - **Safelisting**: The router _rejects_ any incoming operations not present in its PQL. Requests can use either ID or operation string.
     - Before moving to this security level, ensure _all_ your client operations are present in your PQL.
 - **Safelisting with IDs only**: The router rejects any incoming operations not present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.
@@ -95,8 +95,8 @@ apq:
 
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
 
-If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive safelisting level in your router.
+If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive [safelisting mode](#safelisting) in your router.
 
-If you set `log_unknown` to true, the router [logs](/router/logging) all rejected operations. This includes operations that were rejected because they included the full operation string rather than the ID, whether or not the operation was preregistered.
+With `log_unknown` set to true, the router [logs](/router/logging) _all_ rejected operations, including operations that were preregistered to your PQL but used the full operation string rather than PQL-specified ID.
 
 > You can set `log_unknown` to `false` while enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -5,7 +5,7 @@ The Apollo Router supports the following security levels, in increasing order of
     - This level doesn't provide safelisting.
 - **Audit mode**: Executing operations by providing a PQL-specified ID is still optional, but the router also logs any unregistered operations.
     - The level serves as a dry run and helps you identify operations you may still need to register before turning on safelisting.
-- **Safelisting (with operation strings allowed)**: The router _rejects_ any incoming operations not present in its PQL. Requests can use either ID or operation string.
+- **Safelisting**: The router _rejects_ any incoming operations not present in its PQL. Requests can use either ID or operation string.
     - Before moving to this security level, ensure _all_ your client operations are present in your PQL.
 - **Safelisting with IDs only**: The router rejects any incoming operations not present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.
     - Before moving to this security level, ensure _all_ your clients execute operations by providing their PQL-specified ID.
@@ -52,7 +52,7 @@ If your router receives a trusted operation listed in the PQL then no log messag
 
 You can use these router logs to audit operations sent to your router and ask client teams to [add new ones](/graphos/operations/persisted-queries#3-preregister-trusted-operations) to your PQL if necessary.
 
-#### Safelisting (operation strings allowed)
+#### Safelisting
 
 > ⚠️ Before applying this configuration, ensure your PQL contains _all_ GraphQL operations that _all active versions_ of your clients execute. If you enable safelisting _without_ ensuring this, your router will reject any unpublished client operations.
 
@@ -95,7 +95,7 @@ apq:
 
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
 
-If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting-operation-strings-allowed). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive safelisting level in your router.
+If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive safelisting level in your router.
 
 If you set `log_unknown` to true, the router [logs](/router/logging) all rejected operations. This includes operations that were rejected because they included the full operation string rather than the ID, whether or not the operation was preregistered.
 

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -10,9 +10,9 @@ The Apollo Router supports the following security levels, in increasing order of
 - **Safelisting with IDs only**: The router rejects any incoming operations not present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.
     - Before moving to this security level, ensure _all_ your clients execute operations by providing their PQL-specified ID.
 
-When you first adopt persisted queries, you should start with a less restrictive security such as [audit mode](#audit-mode-dry-run). You can then enable increasingly restrictive levels after your teams has updated all clients.
+When adopting persisted queries, you should start with a less restrictive security such as [audit mode](#audit-mode-dry-run). You can then enable increasingly restrictive levels after your teams have updated all clients.
 
-See below for sample YAML configurations for each level.
+See below for sample YAML configurations for each level. Refer to the [router configuration options](/router/configuration/persisted-queries#configuration-options) for option details.
 
 #### Allow operation IDs
 
@@ -48,9 +48,9 @@ For example:
 2023-08-02T11:51:59.833534Z  WARN [trace_id=5006cef73e985810eb086e5900945807] unknown operation operation_body="query ExampleQuery {\n  me {\n    id\n  }\n}\n"
 ```
 
-If your router receives a trusted operation listed in the PQL then no log message will be output.
+If your router receives an operation preregistered in the PQL, no log message will be output.
 
-You can use these router logs to audit operations sent to your router and ask client teams to [add new ones](/graphos/operations/persisted-queries#3-preregister-trusted-operations) to your PQL if necessary.
+You can use these router logs to audit operations sent to your router and ask client teams to [add new ones](/graphos/operations/persisted-queries#3-preregister-operations) to your PQL if necessary.
 
 #### Safelisting
 
@@ -69,16 +69,16 @@ apq:
   enabled: false # APQ must be turned off 
 ```
 
-> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
+> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.
 
 To execute an operation, clients can provide its PQL-specified ID _or_ full operation string.
-The router rejects unregistered operations and since `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
+The router rejects unregistered operations, and since `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
 
-> You can set `log_unknown` to `false` while enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
+> You can set `log_unknown` to `false` when enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
 
 #### Safelisting with IDs only
 
-> ⚠️ **Do not start with this configuration:** It requires _all_ your clients execute operations by providing their PQL-specified ID. If any clients still provide full operation strings, the router rejects those operations, even if they're included in the safelist.
+> ⚠️ **Do not start with this configuration:** It requires _all_ your clients to execute operations by providing their PQL-specified ID. If any clients still provide full operation strings, the router rejects those operations, even if they're included in the safelist.
 
 With the following configuration, your router allows _only_ GraphQL operations that are present in its PQL, _and_ it requires clients to provide PQL-specified IDs instead of full operation strings:
 
@@ -93,10 +93,10 @@ apq:
   enabled: false # APQ must be turned off 
 ```
 
-> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
+> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.
 
-If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive [safelisting mode](#safelisting) in your router.
+If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID-only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive [safelisting mode](#safelisting) in your router.
 
-With `log_unknown` set to true, the router [logs](/router/logging) _all_ rejected operations, including operations that were preregistered to your PQL but used the full operation string rather than PQL-specified ID.
+With `log_unknown` set to true, the router [logs](/router/logging) _all_ rejected operations, including those preregistered to your PQL but that used the full operation string rather than the PQL-specified ID.
 
-> You can set `log_unknown` to `false` while enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
+> You can set `log_unknown` to `false` when enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -20,7 +20,7 @@ To use persisted queries _only_ to reduce network bandwidth and latency (_not_ f
 
 ```yaml title="router.yaml"
 preview_persisted_queries:
-  enabled: true 
+  enabled: true
 ```
 > **Note:** You can use this security level with or without [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) enabled.
 

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -72,6 +72,9 @@ apq:
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
 
 To execute an operation, clients can provide its PQL-specified ID _or_ full operation string.
+The router rejects unregistered operations and since `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
+
+> You can set `log_unknown` to `false` while enabling safelisting, but we recommend keeping logging enabled to monitor the operations your router rejects.
 
 #### Safelisting (IDs only)
 
@@ -93,3 +96,8 @@ apq:
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries), while safelisting's intent is to restrict operations to those that have been explicitly preregistered.
 
 If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting-operation-strings-allowed). ID only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive safelisting level in your router.
+
+If you set `log_unknown` to true, the router [logs](/router/logging) all rejected operations. This includes operations that were rejected because they included the full operation string rather than the ID, whether or not the operation was preregistered.
+
+> You can set `log_unknown` to `false` while enabling safelisting, but we recommend keeping logging enabled to monitor the operations your router rejects.
+

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -7,7 +7,7 @@ The Apollo Router supports the following security levels, in increasing order of
     - The level serves as a dry run and helps you identify operations you may still need to preregister before turning on safelisting.
 - **Safelisting**: The router _rejects_ any incoming operations not present in its PQL. Requests can use either ID or operation string.
     - Before moving to this security level, ensure _all_ your client operations are present in your PQL.
-- **Safelisting with IDs only**: The router rejects any incoming operations not present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.
+- **Safelisting with IDs only**: The router rejects any freeform GraphQL operations. Clients can _only_ execute operations by providing their PQL-specified IDs.
     - Before moving to this security level, ensure _all_ your clients execute operations by providing their PQL-specified ID.
 
 When adopting persisted queries, you should start with a less restrictive security such as [audit mode](#audit-mode-dry-run). You can then enable increasingly restrictive levels after your teams have updated all clients.
@@ -72,15 +72,15 @@ apq:
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.
 
 To execute an operation, clients can provide its PQL-specified ID _or_ full operation string.
-The router rejects unregistered operations, and since `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
+The router rejects unregistered operations, and if `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
 
-> You can set `log_unknown` to `false` when enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
+> So you can monitor the operations your router rejects, it's best to keep `log_unknown` as `true` while adopting safelisting. Once you're confident that all your clients are properly configured, you can turn it off to reduce noise in your logs.
 
 #### Safelisting with IDs only
 
 > ⚠️ **Do not start with this configuration:** It requires _all_ your clients to execute operations by providing their PQL-specified ID. If any clients still provide full operation strings, the router rejects those operations, even if they're included in the safelist.
 
-With the following configuration, your router allows _only_ GraphQL operations that are present in its PQL, _and_ it requires clients to provide PQL-specified IDs instead of full operation strings:
+With the following configuration, your router rejects all operation strings and only accepts preregistered operation IDs:
 
 ```yaml title="router.yaml"
 preview_persisted_queries:
@@ -95,8 +95,8 @@ apq:
 
 > **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.
 
-If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID-only safelisting mode requires modifying _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive [safelisting mode](#safelisting) in your router.
+If you want to use this security level, you should always _first_ set up [safelisting with operation strings allowed](#safelisting). ID-only safelisting requires _all_ your clients to execute operations via PQL-specified ID instead of an operation string. While making those necessary changes, you can use the less restrictive [safelisting mode](#safelisting) in your router.
 
 With `log_unknown` set to true, the router [logs](/router/logging) _all_ rejected operations, including those preregistered to your PQL but that used the full operation string rather than the PQL-specified ID.
 
-> You can set `log_unknown` to `false` when enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
+> So you can monitor the operations your router rejects, it's best to keep `log_unknown` as `true` while adopting safelisting. Once you're confident that all your clients are properly configured, you can turn it off to reduce noise in your logs.

--- a/src/content/shared/pq-security-levels.mdx
+++ b/src/content/shared/pq-security-levels.mdx
@@ -1,11 +1,11 @@
 The Apollo Router supports the following security levels, in increasing order of restrictiveness:
 
-- **Performance-only**: Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.
+- **Allow operation IDs**: Clients can optionally execute an operation on your router by providing the operation's PQL-specified ID.
     - All other levels also provide this core capability.
-    - This level provides no operation safelisting.
+    - This level doesn't provide safelisting.
 - **Audit mode**: Executing operations by providing a PQL-specified ID is still optional, but the router also logs any unregistered operations.
     - The level serves as a dry run and helps you identify operations you may still need to register before turning on safelisting.
-- **Safelisting with operation strings allowed**: The router _rejects_ any incoming operations not present in its PQL.
+- **Safelisting (with operation strings allowed)**: The router _rejects_ any incoming operations not present in its PQL. Requests can use either ID or operation string.
     - Before moving to this security level, ensure _all_ your client operations are present in your PQL.
 - **Safelisting with IDs only**: The router rejects any incoming operations not present in its PQL, _and_ clients _must_ execute an operation by providing its PQL-specified ID.
     - Before moving to this security level, ensure _all_ your clients execute operations by providing their PQL-specified ID.
@@ -14,7 +14,7 @@ When you first adopt persisted queries, you should start with a less restrictive
 
 See below for sample YAML configurations for each level.
 
-#### Performance-only
+#### Allow operation IDs
 
 To use persisted queries _only_ to reduce network bandwidth and latency (_not_ for safelisting), add the following minimal configuration:
 
@@ -22,7 +22,7 @@ To use persisted queries _only_ to reduce network bandwidth and latency (_not_ f
 preview_persisted_queries:
   enabled: true 
 ```
-> **Note:** You can use the performance-only security level with or without [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) enabled.
+> **Note:** You can use this security level with or without [automatic persisted queries](/router/configuration/in-memory-caching#caching-automatic-persisted-queries-apq) enabled.
 
 This mode lets clients execute operations by providing their PQL-specified ID instead of the full operation string.
 Your router also continues to accept full operation strings, even for operations that _don't_ appear in its PQL.
@@ -74,11 +74,11 @@ apq:
 To execute an operation, clients can provide its PQL-specified ID _or_ full operation string.
 The router rejects unregistered operations and since `log_unknown` is true, those operations appear in your [router's logs](/router/logging).
 
-> You can set `log_unknown` to `false` while enabling safelisting, but we recommend keeping logging enabled to monitor the operations your router rejects.
+> You can set `log_unknown` to `false` while enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.
 
-#### Safelisting (IDs only)
+#### Safelisting with IDs only
 
-> ⚠️ **Do not start with this configuration:** It requires _all_ your clients execute operations by providing their PQL-specified ID. If any clients still provide full operation strings, the router rejects those operations.
+> ⚠️ **Do not start with this configuration:** It requires _all_ your clients execute operations by providing their PQL-specified ID. If any clients still provide full operation strings, the router rejects those operations, even if they're included in the safelist.
 
 With the following configuration, your router allows _only_ GraphQL operations that are present in its PQL, _and_ it requires clients to provide PQL-specified IDs instead of full operation strings:
 
@@ -99,5 +99,4 @@ If you want to use this security level, you should always _first_ set up [safeli
 
 If you set `log_unknown` to true, the router [logs](/router/logging) all rejected operations. This includes operations that were rejected because they included the full operation string rather than the ID, whether or not the operation was preregistered.
 
-> You can set `log_unknown` to `false` while enabling safelisting, but we recommend keeping logging enabled to monitor the operations your router rejects.
-
+> You can set `log_unknown` to `false` while enabling safelisting, but it's best to keep logging enabled to monitor the operations your router rejects.


### PR DESCRIPTION
This PR:
- Changes the name of "Performance-only" to "Allow operation IDs" and "Safelisting with operation strings allowed" to "Safelisting".
- Clarifies that both safelisting modes allow for logging and what is logged in "Safelisting with IDs".