### PR TITLE
Create PreviewFeature component

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -57,6 +57,7 @@ import {
   PageContent,
   PageSeo
 } from './PageLayout';
+import {PreviewFeature} from './PreviewFeature';
 import {SiDiscord} from 'react-icons/si';
 import {TOTAL_HEADER_HEIGHT} from './Header';
 import {YouTube} from './YouTube';
@@ -186,7 +187,8 @@ const mdxComponents = {
   TypescriptApiBox: TypeScriptApiBox,
   EmbeddableExplorer,
   ButtonLink,
-  MinVersion
+  MinVersion,
+  PreviewFeature
 };
 
 const {processSync} = rehype()

--- a/src/components/PreviewFeature.js
+++ b/src/components/PreviewFeature.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Box, Link} from '@chakra-ui/react';
+
+export const PreviewFeature = ({discordLink}) => {
+  return (
+    <Box
+      pl="4"
+      py="1"
+      borderLeftWidth="2px"
+      borderColor="primary"
+      fontSize="md"
+      sx={{
+        '>': {
+          ':not(:last-child)': {
+            mb: 2
+          }
+        }
+      }}
+    >
+      This feature is currently in{' '}
+      <Link
+        color={'primary'}
+        href="https://www.apollographql.com/docs/resources/product-launch-stages#preview"
+      >
+        preview
+      </Link>
+      . Your questions and feedback are highly valued{'—'}don&apos;t hesitate to
+      get in touch with your Apollo contact or on the official
+      <Link color={'primary'} href={discordLink}>
+        {' '}
+        Apollo GraphQL Discord
+      </Link>
+      .
+    </Box>
+  );
+};
+
+PreviewFeature.propTypes = {
+  discordLink: PropTypes.node.isRequired
+};

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -5,7 +5,7 @@ description: Secure your graph while minimizing request latency
 
 <GraphOSEnterpriseRequired />
 
-<FeatureInPreview />
+<PreviewFeature discordLink="https://discordapp.com/channels/1022972389463687228/1143901714173407342"/>
 
 GraphQL APIs are broadly open by design. They let client applications send queries with arbitrary shapes and sizes. And while this allows for expedited client development and a highly performant API platform, it necessitates securing your graph against potentially malicious requests. 
 


### PR DESCRIPTION
This component will replace the shared content "Feature in Preview" component. As opposed to that one, this one lets you pass in a link to the particular Discord thread for discussion.

Once I've replaced other usage of the `FeatureinPreview` component, I'll remove it from the shared content.