### PR TITLE
Update Launches docs

### DIFF
--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -12,7 +12,7 @@ Updates that trigger a launch include:
 - Adding or removing entire subgraphs
 - Migrating types or fields between subgraphs
 - Modifying your [cloud router's configuration](../routing/cloud-configuration/)
-- Updating your build pipeline track
+- Updating your federation version
 - Updating the Git commit set in the Git context
 
 A launch might consist entirely of changes that don't affect your supergraph's public API (such as migrating fields between subgraphs).

--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -12,6 +12,8 @@ Updates that trigger a launch include:
 - Adding or removing entire subgraphs
 - Migrating types or fields between subgraphs
 - Modifying your [cloud router's configuration](../routing/cloud-configuration/)
+- Updating your build pipeline track
+- Updating the Git commit set in the Git context
 
 A launch might consist entirely of changes that don't affect your supergraph's public API (such as migrating fields between subgraphs).
 


### PR DESCRIPTION
There are two more cases where we trigger a new launch that are not included in the docs. This PR makes an update to the launches docs so that customers can now understand that a launch is also triggered by 
* an update to the build configuration
* an update to the git commit in the git context