### PR TITLE
Pin Netlify CLI 15.8.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 14
 
       - name: Trigger deploy
-        run: npx netlify-cli@16.0.3 deploy --trigger --prod
+        run: netlify-cli@15.8.1 deploy --trigger --prod
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
The trigger deploy GH action has begun to fail with `We've detected multiple sites inside your repository`, e.g. in https://github.com/apollographql/federation/actions/runs/6101805110/job/16558917324#step:4:55.

This is similar to the issue reported here: https://github.com/netlify/cli/issues/5977