### PR TITLE
Add temp as working directory for triggering new builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
           node-version: 14
 
       - name: Trigger deploy
-        run: npx netlify-cli@16.0.3 deploy --trigger --prod
+        working-directory: /tmp/ntl
+        run: npx netlify-cli@16.3.1 deploy --trigger --prod
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
When triggering the monodocs builds, running from the project directory causes new versions of the netlify CLI to request which project you want to deploy. A fix PR is open to the CLI such that `netlify deploy --trigger` does not require a workspace (as the code doesn't need it). 

This change makes the `netlify deploy --trigger` run in a temporary directory so that there is no workspace to configure.