### PR TITLE
Make Mermaid labels have visible overflow

### DIFF
--- a/src/utils/mermaid.js
+++ b/src/utils/mermaid.js
@@ -90,8 +90,7 @@ export function useMermaidStyles() {
       },
       [['.label text', 'span']]: {
         color: 'inherit',
-        fill: 'currentColor',
-        overflow: 'visible'
+        fill: 'currentColor'
       },
       [[
         '.edgePath .path',

--- a/src/utils/mermaid.js
+++ b/src/utils/mermaid.js
@@ -90,7 +90,8 @@ export function useMermaidStyles() {
       },
       [['.label text', 'span']]: {
         color: 'inherit',
-        fill: 'currentColor'
+        fill: 'currentColor',
+        overflow: 'visible'
       },
       [[
         '.edgePath .path',
@@ -111,6 +112,9 @@ export function useMermaidStyles() {
         tspan: {
           fill: 'currentColor'
         }
+      },
+      [['.label foreignObject', '.cluster-label foreignObject']]: {
+        overflow: 'visible'
       }
     };
     return important(styles);


### PR DESCRIPTION
Currently some labels are cut-off in some browsers, e.g. on the [Authorization page](https://www.apollographql.com/docs/router/configuration/authorization/#how-access-control-works) in Safari:

<img width="770" alt="image" src="https://github.com/apollographql/docs/assets/23219998/896f00e7-4f1d-4edc-8a30-0b0dad0b9d77">

This updates our Mermaid styles so that labels have visible overflow.

<img width="809" alt="image" src="https://github.com/apollographql/docs/assets/23219998/5a189b38-9516-4536-8d26-889221c31eb3">
