### PR TITLE
Remove "preview" terminology from PQs

### DIFF
--- a/src/content/graphos/basics/config.json
+++ b/src/content/graphos/basics/config.json
@@ -43,8 +43,7 @@
       "Safelisting with persisted queries": [
         "/operations/persisted-queries",
         [
-          "enterprise",
-          "preview"
+          "enterprise"
         ]
       ]
     },

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -5,8 +5,6 @@ description: Secure your graph while minimizing request latency
 
 <GraphOSEnterpriseRequired />
 
-<PreviewFeature discordLink="https://discordapp.com/channels/1022972389463687228/1143901714173407342"/>
-
 GraphQL APIs are broadly open by design. They let client applications send queries with arbitrary shapes and sizes. And while this allows for expedited client development and a highly performant API platform, it necessitates securing your graph against potentially malicious requests. 
 
 <PQIntro />
@@ -424,8 +422,6 @@ Guide each client team to follow the implementation steps presented in the [incr
 ## Manifest format
 
 <blockquote>
-
-⚠️ **This manifest format is subject to change during the preview period.**
 
 You only need to read this section if you're building your own tooling to [generate persisted query manifests](#31-generate-persisted-queries-manifests).
 

--- a/src/content/graphos/enterprise/config.json
+++ b/src/content/graphos/enterprise/config.json
@@ -31,12 +31,8 @@
             "preview"
           ]
         ],
-        "Safelisting with persisted queries": [
+        "Safelisting with persisted queries":
           "https://www.apollographql.com/docs/router/configuration/persisted-queries", 
-          [
-            "preview"
-          ]
-        ],
         "Operation limits": "https://www.apollographql.com/docs/router/configuration/operation-limits",
         "External coprocessing": "https://www.apollographql.com/docs/router/customizations/coprocessor"
       }


### PR DESCRIPTION
To do: Replace `preview_persisted_queries` with GA name.

Do not merge until PQs are in GA.