### PR TITLE
Switch to apollo-ios-dev for latest iOS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The docs content is written and maintained in the following places. Many of them
 
 - [Apollo Client (React)](https://github.com/apollographql/apollo-client)
 - [Apollo Server](https://github.com/apollographql/apollo-server)
-- [Apollo iOS](https://github.com/apollographql/apollo-ios)
+- [Apollo iOS](https://github.com/apollographql/apollo-ios-dev)
 - [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin)
 - [Apollo Federation](https://github.com/apollographql/federation)
 - [Rover CLI](https://github.com/apollographql/rover)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:client": "npm start -- ../apollo-client",
     "start:platform-users": "npm start -- ../platform-users-docs",
     "start:server": "npm start -- ../apollo-server",
-    "start:ios": "npm start -- ../apollo-ios",
+    "start:ios": "npm start -- ../apollo-ios-dev",
     "start:kotlin": "npm start -- ../apollo-kotlin",
     "start:federation": "npm start -- ../federation",
     "start:rover": "npm start -- ../rover",

--- a/sources/remote.js
+++ b/sources/remote.js
@@ -21,7 +21,7 @@ module.exports = {
     branch: 'version-2'
   },
   ios: {
-    remote: 'https://github.com/apollographql/apollo-ios',
+    remote: 'https://github.com/apollographql/apollo-ios-dev',
     branch: 'main'
   },
   'ios/v0-legacy': {


### PR DESCRIPTION
Switch repo of latest iOS docs to `apollo-ios-dev` 

~**Don't merge until transition from `apollo-ios` to `apollo-ios-dev` repo is confirmed to be completed**~ received go-ahead to merge