### PR TITLE
Fix docset internal mapping

### DIFF
--- a/algolia/index.js
+++ b/algolia/index.js
@@ -26,9 +26,21 @@ async function transformer({data}) {
   // create mapping of sources to their internal status
   const isInternal = configs.nodes.reduce((acc, node) => {
     const {internal} = JSON.parse(node.fields.content);
+    let docset = node.sourceInstanceName;
+    // when the sourceInstanceName equals "__PROGRAMMATIC", we need to extract the docset name from the path
+    if (docset === '__PROGRAMMATIC__') {
+      // an example absolutePath looks like "...gatsby-source-remote-file/a9d8bf0a406c56687240f60090ff6f14/federation/v1/config.json""
+      const path = node.absolutePath.split('/config.json')[0];
+      const paths = path.split('/');
+      docset = paths[paths.length - 1];
+      // If the last part of the path has to do with a version, use the penultimate part of the path
+      if (docset.startsWith('v')) {
+        docset = paths[paths.length - 2];
+      }
+    }
     return {
       ...acc,
-      [node.sourceInstanceName]: internal === true
+      [docset]: internal === true
     };
   }, {});
 
@@ -147,6 +159,7 @@ const query = `
         fields {
           content
         }
+        absolutePath
         sourceInstanceName
       }
     }

--- a/algolia/index.js
+++ b/algolia/index.js
@@ -27,15 +27,17 @@ async function transformer({data}) {
   const isInternal = configs.nodes.reduce((acc, node) => {
     const {internal} = JSON.parse(node.fields.content);
     let docset = node.sourceInstanceName;
-    // when the sourceInstanceName equals "__PROGRAMMATIC", we need to extract the docset name from the path
+    // when the sourceInstanceName equals "__PROGRAMMATIC__", we need to extract
+    // the docset name from the path
     if (docset === '__PROGRAMMATIC__') {
-      // an example absolutePath looks like "...gatsby-source-remote-file/a9d8bf0a406c56687240f60090ff6f14/federation/v1/config.json""
-      const path = node.absolutePath.split('/config.json')[0];
-      const paths = path.split('/');
-      docset = paths[paths.length - 1];
-      // If the last part of the path has to do with a version, use the penultimate part of the path
-      if (docset.startsWith('v')) {
-        docset = paths[paths.length - 2];
+      // an example relativeDirectory looks like:
+      // .cache/caches/gatsby-source-remote-file/2740f1d9...c765648d9fe/react/v2
+      const paths = node.relativeDirectory.split('/');
+      docset = paths.pop();
+      // If the last part of the path has to do with a version, use the
+      // penultimate part of the path
+      if (/^v\d+$/.test(docset)) {
+        docset = paths.pop();
       }
     }
     return {
@@ -159,7 +161,7 @@ const query = `
         fields {
           content
         }
-        absolutePath
+        relativeDirectory
         sourceInstanceName
       }
     }


### PR DESCRIPTION
[It appears that internal docset's are being indexed to search.](https://apollograph.slack.com/archives/C03Q1NNKGBD/p1695843569087019)
Upon further inspection, this is because the [`isInternal` map](https://github.com/apollographql/docs/blob/c4e0dfad3cb65c11edbb3c9be23daf55894c94b8/algolia/index.js#L27C6-L27C6) often looks like this:
![image](https://github.com/apollographql/docs/assets/23219998/3fad8d03-2422-44af-9433-fe23ce0c4657)

I.e., for some docsets (including the internal `platform_users` one) the `sourceInstanceName` = `__PROGRAMMATIC__`

![image](https://github.com/apollographql/docs/assets/23219998/03bb8821-b025-4e9b-9356-5ca1886c6bd6)

This PR attempts to properly set the `isInternal` map, so internal docsets aren't indexed to Algolia