### PR TITLE
Updating TN0010: Designing response types

### DIFF
--- a/src/content/technotes/TN0010-reponse-type-pattern.mdx
+++ b/src/content/technotes/TN0010-reponse-type-pattern.mdx
@@ -4,69 +4,11 @@ id: TN0010
 tags: [schema-design]
 ---
 
-Let's say we have a basic GraphQL API that defines the following `Query` type:
-
-```graphql
-type Query {
-  users: [User!]!
-}
-```
-
-This `Query.users` field makes intuitive sense: if you query it, you get back a list of `User` objects. _However_, this return type doesn't provide any insight into the result:
-
-* If the list is empty, is that because there are zero users, or did an error occur?
-* Even if the list is populated, did the API return _all_ users or just a subset?
-
-To answer questions like these, it's helpful for top-level fields of `Query` and `Mutation` to return "wrapper" objects that can include both the operation result _and_ metadata about the operation's execution.
-
-## Example: `UsersResponse`
-
-The following example defines a `UsersResponse` type for our `Query.users` field:
-
-```graphql
-enum ResponseStatus {
-  SUCCESS
-  FAILURE
-}
-
-type User {
-  id: ID!
-  firstName: String!
-  lastName: String!
-}
-
-type UsersResponse {
-  status: ResponseStatus!
-  total: Int!
-  users: [User!]!
-}
-
-type Query {
-  users: UsersResponse!
-}
-```
-
-With this change, a client's query can now check the `status` field to determine whether an empty list might be due to an error:
-
-```graphql
-query FetchUsers {
-  users {
-    status
-    total
-    users {
-      id
-      firstName
-      lastName
-    }
-  }
-}
-```
-
 ## Response types for mutations
 
 > See also [Structuring mutation responses](/apollo-server/schema/schema#structuring-mutation-responses).
 
-This response type pattern is even more useful for mutations, because they can result in many valid failure states (such as attempting to delete an object that doesn't exist).
+This response type pattern is useful for mutations because they can result in many valid failure states (such as attempting to delete an object that doesn't exist).
 
 For example, let's say we have an e-commerce graph. When executing a `checkout` mutation, it's valid for that mutation to fail if a purchased item is out of stock or the buyer has insufficient funds.
 
@@ -99,3 +41,62 @@ type Mutation {
   checkout(cart: ID!): CheckoutResponse!
 }
 ```
+
+
+## Response types for queries
+
+Let's say we have a basic GraphQL API that defines the following `Query` type:
+
+```graphql
+type Query {
+  users: [User!]!
+}
+```
+
+This `Query.users` field makes intuitive sense: if you query it, you get back a list of `User` objects. _However_, this return type doesn't provide any insight into the result:
+
+* If the list is empty, is that because there are zero users, or did an error occur?
+* Even if the list is populated, did the API return _all_ users or just a subset?
+* Are there multiple pages of results?
+
+To answer questions like these, it may be helpful for top-level fields of `Query` to return "wrapper" objects that can include both the operation result _and_ metadata about the operation's execution. Some examples of where this is specifically helpful is in cases where you need to [paginate your results](/technotes/TN0027-demand-oriented-schema-design/#a-brief-sidebar-on-pagination-conventions) or implement [Relay-style connections](/technotes/TN0029-relay-style-connections/).
+
+### Example: `UsersResponse`
+
+The following example defines a `UsersResponse` type for our `Query.users` field:
+
+```graphql
+type User {
+  id: ID!
+  firstName: String!
+  lastName: String!
+}
+
+type UsersResponse {
+  offset: Int!
+  perPage: Int!
+  totalResults: Int!
+  data: [User!]!
+}
+
+type Query {
+  users(perPage: Int = 10, offset: Int = 0): UsersResponse!
+}
+```
+
+With this change, a client's query can specify how many results per page, what page to start on, and understand the total number of results that can be paginated:
+
+```graphql
+query FetchUsers {
+  users(perPage: 20, offset: 0) {
+    totalResults
+    data {
+      id
+      firstName
+      lastName
+    }
+  }
+}
+```
+
+

--- a/src/content/technotes/TN0010-reponse-type-pattern.mdx
+++ b/src/content/technotes/TN0010-reponse-type-pattern.mdx
@@ -59,7 +59,7 @@ This `Query.users` field makes intuitive sense: if you query it, you get back a 
 * Even if the list is populated, did the API return _all_ users or just a subset?
 * Are there multiple pages of results?
 
-To answer questions like these, it may be helpful for top-level fields of `Query` to return "wrapper" objects that can include both the operation result _and_ metadata about the operation's execution. Some examples of where this is specifically helpful is in cases where you need to [paginate your results](/technotes/TN0027-demand-oriented-schema-design/#a-brief-sidebar-on-pagination-conventions) or implement [Relay-style connections](/technotes/TN0029-relay-style-connections/).
+To answer questions like these, it may be helpful for top-level fields of `Query` to return "wrapper" objects that can include both the operation result _and_ metadata about the operation's execution. For example, in cases where you need to [paginate your results](/technotes/TN0027-demand-oriented-schema-design/#a-brief-sidebar-on-pagination-conventions) or implement [Relay-style connections](/technotes/TN0029-relay-style-connections/) this pattern can be helpful.
 
 ### Example: `UsersResponse`
 
@@ -74,13 +74,13 @@ type User {
 
 type UsersResponse {
   offset: Int!
-  perPage: Int!
+  limit: Int!
   totalResults: Int!
   data: [User!]!
 }
 
 type Query {
-  users(perPage: Int = 10, offset: Int = 0): UsersResponse!
+  users(limit: Int = 10, offset: Int = 0): UsersResponse!
 }
 ```
 
@@ -88,7 +88,7 @@ With this change, a client's query can specify how many results per page, what p
 
 ```graphql
 query FetchUsers {
-  users(perPage: 20, offset: 0) {
+  users(limit: 20, offset: 0) {
     totalResults
     data {
       id


### PR DESCRIPTION
- Moved mutation to the top since it is always recommended
- Soften language on query to describe it as a possible pattern and provide examples of pagination and relay-style connections
- Update example to be a pagination example and change so we do "users.data" instead of "users.users"