### PR TITLE
Add subtitle to frontmatter to differentiate page's subtitle and SEO description

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -131,12 +131,14 @@ exports.createSchemaCustomization = ({actions: {createTypes}}) => {
       headingDepth: Int
       minVersion: String
       noIndex: Boolean
+      subtitle: String
     }
 
     type MarkdownRemarkFrontmatter {
       headingDepth: Int
       minVersion: String
       noIndex: Boolean
+      subtitle: String
     }
   `;
   createTypes(typeDefs);

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -227,8 +227,10 @@ export default function Page({file}) {
     file;
 
   const {frontmatter, headings} = childMdx || childMarkdownRemark;
-  const {title, description, toc, tags, headingDepth, minVersion, noIndex} =
+  const {title, subtitle, description, toc, tags, headingDepth, minVersion, noIndex} =
     frontmatter;
+
+  const publishedSubtitle = subtitle ? subtitle : description;
 
   const {docset, versions, currentVersion, navItems, versionBanner} =
     useConfig(basePath);
@@ -411,16 +413,16 @@ export default function Page({file}) {
         title={title}
         subtitle={
           <>
-            {description && (
-              <chakra.h2
-                fontSize={{base: 'xl', md: '2xl'}}
-                lineHeight="normal"
-                mt={{base: 2, md: 3}}
-                fontWeight="normal"
-              >
-                {description}
-              </chakra.h2>
-            )}
+              {publishedSubtitle && (
+                <chakra.h2
+                  fontSize={{base: 'xl', md: '2xl'}}
+                  lineHeight="normal"
+                  mt={{base: 2, md: 3}}
+                  fontWeight="normal"
+                >
+                  {publishedSubtitle}
+                </chakra.h2>
+              )}
             {tags?.length && (
               <HStack mt={{base: 2, md: 3}}>
                 {tags.map((tag, index) => (

--- a/src/content/basics/index.mdx
+++ b/src/content/basics/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Apollo Docs
 toc: true
+subtitle: ' '
+description: Learn how Apollo GraphQL can help enterprise architects, API implementers, and client developers build, deploy, and manage a supergraph of unified microservices, data sources, and applications.
 ---
 
 import {ButtonGroup, VStack} from '@chakra-ui/react';

--- a/src/content/basics/resources/graphql-glossary.md
+++ b/src/content/basics/resources/graphql-glossary.md
@@ -1,6 +1,7 @@
 ---
 title: GraphQL Glossary
-description: Familiarize yourself with common GraphQL terms
+subtitle: Familiarize yourself with common GraphQL terms
+description: Glossary of common GraphQL terminology
 ---
 
 As you explore the GraphQL ecosystem, you might encounter some unfamiliar terms and phrases along the way. To help you on your journey, we've defined some of the most common GraphQL vocabulary here in this handy cheat sheet.

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -45,6 +45,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
+          subtitle
           description
           toc
           tags
@@ -61,6 +62,7 @@ export const pageQuery = graphql`
         }
         frontmatter {
           title
+          subtitle
           description
           headingDepth
           minVersion


### PR DESCRIPTION
Before this PR, a page's `description` (in its frontmatter) served as both the page's subtitle and SEO description.

With this PR, a page's subtitle is now set by `subtitle`, while its SEO description is set by `description`.

> ❗ Until all pages have `subtitle` and `description` updated, a page without `subtitle` will continue to use its `description` as both subtitle and SEO description. To render a page without a subtitle when it has a `description`, set `subtitle: ' '`

Deploy previews:
- [Home page with no subtitle and added description](https://deploy-preview-603--apollo-monodocs.netlify.app/)
- [Glossary with existing subtitle and added description](https://deploy-preview-603--apollo-monodocs.netlify.app/resources/graphql-glossary)