### PR TITLE
Describe manual triggered launch

### DIFF
--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -18,7 +18,7 @@ Updates that trigger a launch include:
 
 A launch might consist entirely of changes that don't affect your supergraph's public API (such as migrating fields between subgraphs).
 
-A launch can be [triggered manually by calling a platform API](#manually-trigger-launch).
+You can [trigger a launch manually by calling the GraphOS Platform API](#manually-trigger-launch).
 
 ## Launch status
 
@@ -51,10 +51,10 @@ graph TB;
   class subgraphPublished secondary;
 ```
 
-## Manually triggered launch
+## Manually trigger launch
 
 <PreviewFeature />
 
-You can manually trigger a launch by calling the [GraphOS Platform API](../basics/platform-api) to publish subgraph schema updates. This is useful for deployments that require progressive rollouts, where different environments have unique subgraph schemas. In this scenario, you can publish the subgraph schemas for an environment, wait for the completed launch (and any downstream launches), then retrieve the supergraph schema with the launch ID.  
+You can trigger a launch manually by calling the [GraphOS Platform API](../basics/platform-api) to publish subgraph schema updates. This is useful for deployments that require progressive rollouts, where different environments have unique subgraph schemas. In this scenario, you can publish the subgraph schemas for an environment, wait for the completed launch (and any downstream launches), then retrieve the supergraph schema with the launch ID.  
 
 For more details about workflows that manually trigger launches, see [Advanced deployment workflows](federation/managed-federation/deployment#advanced-deployment-workflows).

--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -55,8 +55,6 @@ graph TB;
 
 <PreviewFeature />
 
-You can manually call the [GraphOS Platform API](../basics/platform-api) to publish a batch of subgraph schema updates to trigger a launch. This is useful when you don't want the latest validated supergraph schema retrieved from Uplink, and instead you want the supergraph schemas for different sets of subgraph schemas (such as for different deployment environments).
+You can manually trigger a launch by calling the [GraphOS Platform API](../basics/platform-api) to publish subgraph schema updates. This is useful for deployments that require progressive rollouts, where different environments have unique subgraph schemas. In this scenario, you can publish the subgraph schemas for an environment, wait for the completed launch (and any downstream launches), then retrieve the supergraph schema with the launch ID.  
 
-For more details about a workflow that manually triggers launches, see [Bypass Uplink](/federation/managed-federation/uplink#bypassing-uplink).
-
-For an example scenario, see [Using variants to control rollout](/federation/managed-federation/deployment/#using-variants-to-control-rollout).  
+For more details about workflows that manually trigger launches, see [Advanced deployment workflows](federation/managed-federation/deployment#advanced-deployment-workflows).

--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -18,6 +18,8 @@ Updates that trigger a launch include:
 
 A launch might consist entirely of changes that don't affect your supergraph's public API (such as migrating fields between subgraphs).
 
+A launch can be [triggered manually by calling a platform API](#manually-trigger-launch).
+
 ## Launch status
 
 Your supergraph's Launches page in GraphOS Studio enables you to observe and monitor the schema delivery process for both in-progress and past launches:
@@ -48,3 +50,13 @@ graph TB;
   class complete tertiary;
   class subgraphPublished secondary;
 ```
+
+## Manually triggered launch
+
+<PreviewFeature />
+
+You can manually call the [GraphOS Platform API](../basics/platform-api) to publish a batch of subgraph schema updates to trigger a launch. This is useful when you don't want the latest validated supergraph schema retrieved from Uplink, and instead you want the supergraph schemas for different sets of subgraph schemas (such as for different deployment environments).
+
+For more details about a workflow that manually triggers launches, see [Bypass Uplink](/federation/managed-federation/uplink#bypassing-uplink).
+
+For an example scenario, see [Using variants to control rollout](/federation/managed-federation/deployment/#using-variants-to-control-rollout).  

--- a/src/content/graphos/delivery/launches.mdx
+++ b/src/content/graphos/delivery/launches.mdx
@@ -57,4 +57,4 @@ graph TB;
 
 You can trigger a launch manually by calling the [GraphOS Platform API](../basics/platform-api) to publish subgraph schema updates. This is useful for deployments that require progressive rollouts, where different environments have unique subgraph schemas. In this scenario, you can publish the subgraph schemas for an environment, wait for the completed launch (and any downstream launches), then retrieve the supergraph schema with the launch ID.  
 
-For more details about workflows that manually trigger launches, see [Advanced deployment workflows](federation/managed-federation/deployment#advanced-deployment-workflows).
+For an example workflow using GraphOS Platform API to manually trigger a launch, see the [Advanced deployment workflow for blue-green deployment](/federation/managed-federation/deployment/#example-blue-green-deployment).


### PR DESCRIPTION
Added new section, [Manually trigger launch](https://deploy-preview-630--apollo-monodocs.netlify.app/graphos/delivery/launches#manually-trigger-launch), to support new advanced deployment workflow for blue-green deployment