### PR TITLE
Dedicated: Add section for authorization policy restrictions

### DIFF
--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -553,35 +553,42 @@ Once you configure an AWS VPC Lattice service to accept traffic from the Apollo 
 You can further restrict access to your private subgraphs by configuring additional [conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) in your service's authorization policy.
 Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your graph's graph ref.
 
-<Note>
-
-If you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you must the `apollo_account_ids` and `apollo_graph_refs` variables.
-
-</Note>
 
 ### Update Lattice service authorization policy
 
-To update a Lattice service's authorization policy with additional restrictions:
+To update a Lattice service's authorization policy with additional restrictions, you first need the **Apollo account ID** and **graph ref** to which you want to restrict subgraph access.
 
-1. [Contact Apollo](mailto:cloud@apollographql.com) to request your Apollo account ID.
+#### Obtain account ID and graph ref
 
-<Note>
+- [Contact Apollo](mailto:cloud@apollographql.com) to obtain your account ID.
 
-The Apollo account ID value to use in your authorization policy is _not_ the Apollo organization ID you can find in Apollo GraphOS Studio.
-Currently, the only way to obtain your account ID is by [contacting Apollo](mailto:cloud@apollographql.com).
+  <Note>
 
-</Note>
+  The Apollo account ID you specify in your authorization policy is _not_ the Apollo organization ID you can find in Apollo GraphOS Studio.
 
-2. Find your supergraph's graph ref in your Apollo account:
+  </Note>
+
+- You can find your supergraph's graph ref in your Apollo account:
     - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
     - Click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page—click it to copy.
 
-3. In the AWS Console for your region of choice, go to the VPC service page:
+#### Update policy
+
+Then, if you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you can set the  [`apollo_account_ids` and `apollo_graph_refs` variables](https://github.com/apollographql/terraform-graphos-aws#usage) to update your authorization policy. If you want to provide subgraph access to multiple Apollo accounts or supergraphs, you can include multiple account IDs and graph refs.
+
+```txt showLineNumbers=false disableCopy=true
+apollo_account_ids = ["my_account_id", "another_account_id"]
+apollo_graph_refs  = ["my-graph@my-variant", "my-graph@another-variant"]
+```
+
+If you aren't using the Apollo Terraform module, follow these steps:
+
+1. In the AWS Console for your region of choice, go to the VPC service page:
 
 - [US East (N. Virginia) — us-east-1](https://us-east-1.console.aws.amazon.com/ram/home?region=us-east-1)
 - [Europe (Ireland) — eu-west-1](https://eu-west-1.console.aws.amazon.com/ram/home?region=eu-west-1)
 
-4. In the menu on the left, scroll down and open **Services** in the **VPC Lattice** section.
+2. In the menu on the left, scroll down and open **Services** in the **VPC Lattice** section.
 
   <img
     className="screenshot"
@@ -590,7 +597,7 @@ Currently, the only way to obtain your account ID is by [contacting Apollo](mail
     width="175px"
   />
 
-5. Click the name of the Lattice service whose authorization policy you want to configure.
+3. Click the name of the Lattice service whose authorization policy you want to configure.
 
   <img
     className="screenshot"
@@ -598,7 +605,7 @@ Currently, the only way to obtain your account ID is by [contacting Apollo](mail
     src="../../../img/cloud-dedicated/select-lattice-service.jpg"
   />
 
-6. In the **Service access** section, update your authorization policy. You can use the following as an example&mdash;make sure to replace the account ID and graph ref depending on which conditions you are adding.
+4. In the **Service access** section, update your authorization policy. You can use the following as an example&mdash;make sure to replace the account ID and graph ref with your own.
 
   ```json {13-17} showLineNumbers=false
   {
@@ -624,17 +631,17 @@ Currently, the only way to obtain your account ID is by [contacting Apollo](mail
   }
   ```
 
-<Note>
+If there are multiple supergraphs which should have access to the subgraph, use a comma-separated string of graph refs for `aws:PrincipalTag/Apollo:graphRef`. For example:
 
-If you want to provide multiple supergraphs access to the same private subgraph, you can use a comma-separated string of multiple graph refs for `aws:PrincipalTag/Apollo:graphRef`.
-
-For example:
-
-```json showLineNumbers=false
+```json showLineNumbers=false disableCopy=true
 "aws:PrincipalTag/Apollo:graphRef": "my-graph@my-variant, my-graph@another-variant, another-graph@another-variant"
 ```
 
-</Note>
+If there are multiple Apollo accounts which should have access to the subgraph, use a comma-separated string of account IDs for `aws:PrincipalTag/Apollo:accountId`:
+
+```json showLineNumbers=false disableCopy=true
+"aws:PrincipalTag/Apollo:accountId": "my_account_id_xezf34, "my_account_id_dehs56"
+```
 
 ## Remove access to private subgraphs
 

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -560,7 +560,7 @@ To update a Lattice service's authorization policy with additional restrictions,
 
 #### Obtain account ID and graph ref
 
-- [Contact Apollo](mailto:cloud@apollographql.com) to obtain your account ID.
+- [Contact Apollo](mailto:cloud@apollographql.com) to obtain your account ID. Specify you would like the account ID needed to update your Lattice service's authorization policy.
 
   <Note>
 
@@ -572,13 +572,19 @@ To update a Lattice service's authorization policy with additional restrictions,
     - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
     - Click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page—click it to copy.
 
+<Note>
+
+If you want to provide subgraph access to multiple Apollo accounts or supergraphs, you can specify multiple account IDs and graph refs when updating your policy.
+
+</Note>
+
 #### Update policy
 
-Then, if you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you can set the  [`apollo_account_ids` and `apollo_graph_refs` variables](https://github.com/apollographql/terraform-graphos-aws#usage) to update your authorization policy. If you want to provide subgraph access to multiple Apollo accounts or supergraphs, you can include multiple account IDs and graph refs.
+If you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you can set the  [`apollo_account_ids` and `apollo_graph_refs` variables](https://github.com/apollographql/terraform-graphos-aws#usage) to update your authorization policy. Provide one or more Apollo account IDs or graph refs:
 
 ```txt showLineNumbers=false disableCopy=true
 apollo_account_ids = ["my_account_id", "another_account_id"]
-apollo_graph_refs  = ["my-graph@my-variant", "my-graph@another-variant"]
+apollo_graph_refs  = ["my-graph@my-variant", "another-graph@my-variant"]
 ```
 
 If you aren't using the Apollo Terraform module, follow these steps:

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -169,7 +169,7 @@ Congratulations! You've created an AWS VPC Lattice target group. Repeat this pro
 
 6. In the **Service access** section, select the AWS IAM authentication type and paste the following authorization policy. This policy ensures that only the AWS Organization for Cloud Dedicated can send traffic to your subgraphs.
 
-  ```json
+  ```json showLineNumbers=false
   {
     "Version": "2012-10-17",
     "Statement": [
@@ -551,23 +551,37 @@ Once you configure an AWS VPC Lattice service to accept traffic from the Apollo 
 - Cloud Routers only have permission to invoke private subgraphs listed in their graph variant configuration.
 
 You can further restrict access to your private subgraphs by configuring additional [conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) in your service's authorization policy.
-Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your supergraph's graph ref.
+Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your graph's graph ref.
 
-### Update a Lattice service's authorization policy
+<Note>
+
+If you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you must the `apollo_account_ids` and `apollo_graph_refs` variables.
+
+</Note>
+
+### Update Lattice service authorization policy
 
 To update a Lattice service's authorization policy with additional restrictions:
 
-1. Find your account ID and or graph ref in your Apollo account.
-  - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
-  - To-do: instructions on finding your account ID
-  - To find your graph ref, click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page. You can click it to copy it.
-  - If you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you must the `apollo_account_ids` and `apollo_graph_refs` variables.
-2. In the AWS Console for your region of choice, go to the VPC service page:
+1. [Contact Apollo](mailto:cloud@apollographql.com) to request your Apollo account ID.
+
+<Note>
+
+The Apollo account ID value to use in your authorization policy is _not_ the Apollo organization ID you can find in Apollo GraphOS Studio.
+Currently, the only way to obtain your account ID is by [contacting Apollo](mailto:cloud@apollographql.com).
+
+</Note>
+
+2. Find your supergraph's graph ref in your Apollo account:
+    - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
+    - Click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page—click it to copy.
+
+3. In the AWS Console for your region of choice, go to the VPC service page:
 
 - [US East (N. Virginia) — us-east-1](https://us-east-1.console.aws.amazon.com/ram/home?region=us-east-1)
 - [Europe (Ireland) — eu-west-1](https://eu-west-1.console.aws.amazon.com/ram/home?region=eu-west-1)
 
-3. In the menu on the left, scroll down and open **Services** in the **VPC Lattice** section.
+4. In the menu on the left, scroll down and open **Services** in the **VPC Lattice** section.
 
   <img
     className="screenshot"
@@ -576,7 +590,7 @@ To update a Lattice service's authorization policy with additional restrictions:
     width="175px"
   />
 
-4. Click the name of the Lattice service whose authorization policy you want to configure.
+5. Click the name of the Lattice service whose authorization policy you want to configure.
 
   <img
     className="screenshot"
@@ -584,9 +598,9 @@ To update a Lattice service's authorization policy with additional restrictions:
     src="../../../img/cloud-dedicated/select-lattice-service.jpg"
   />
 
-5. In the **Service access** section, update your authorization policy. You can use the following as an example–make sure to replace the account ID and/or graph ref depending on which conditions you are adding.
+6. In the **Service access** section, update your authorization policy. You can use the following as an example&mdash;make sure to replace the account ID and graph ref depending on which conditions you are adding.
 
-  ```json {13-17}
+  ```json {13-17} showLineNumbers=false
   {
     "Version": "2012-10-17",
     "Statement": [
@@ -610,7 +624,17 @@ To update a Lattice service's authorization policy with additional restrictions:
   }
   ```
 
-6. Update your Cloud Router.
+<Note>
+
+If you want to provide multiple supergraphs access to the same private subgraph, you can use a comma-separated string of multiple graph refs for `aws:PrincipalTag/Apollo:graphRef`.
+
+For example:
+
+```json showLineNumbers=false
+"aws:PrincipalTag/Apollo:graphRef": "my-graph@my-variant, my-graph@another-variant, another-graph@another-variant"
+```
+
+</Note>
 
 ## Remove access to private subgraphs
 

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -561,7 +561,7 @@ To update a Lattice service's authorization policy with additional restrictions:
   - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
   - To-do: instructions on finding your account ID
   - To find your graph ref, click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page. You can click it to copy it.
-  - If you are using the terraform-graphos-aws module, you must the `apollo_account_ids` and `apollo_graph_refs` variables.
+  - If you are using the [Apollo Terraform module](https://github.com/apollographql/terraform-graphos-aws), you must the `apollo_account_ids` and `apollo_graph_refs` variables.
 2. In the AWS Console for your region of choice, go to the VPC service page:
 
 - [US East (N. Virginia) — us-east-1](https://us-east-1.console.aws.amazon.com/ram/home?region=us-east-1)

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -551,7 +551,7 @@ Once you configure an AWS VPC Lattice service to accept traffic from the Apollo 
 - Cloud Routers only have permission to invoke private subgraphs listed in their graph variant configuration.
 
 You can further restrict access to your private subgraphs by configuring additional [conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) in your service's authorization policy.
-Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your subgraph's graph ref.
+Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your supergraph's graph ref.
 
 ### Update a Lattice service's authorization policy
 

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -167,7 +167,7 @@ Congratulations! You've created an AWS VPC Lattice target group. Repeat this pro
     src="../../../img/cloud-dedicated/custom-domain.jpg"
   />
 
-6. In the **Service access** section, select the AWS IAM authentication type and paste the following auth policy. This policy ensures that only the AWS Organization for Cloud Dedicated can send traffic to your subgraphs.
+6. In the **Service access** section, select the AWS IAM authentication type and paste the following authorization policy. This policy ensures that only the AWS Organization for Cloud Dedicated can send traffic to your subgraphs.
 
   ```json
   {
@@ -541,7 +541,78 @@ When your AWS resource is set to private, it isn't accessible by external servic
 
 Congratulations! You've now added a private subgraph to your GraphOS Cloud Router.
 
-## Removing access to private subgraphs
+## Further restrict access to private subgraphs
+
+Once you configure an AWS VPC Lattice service to accept traffic from the Apollo AWS Organization, it is protected by multiple security layers:
+
+- The AWS VPC Lattice service network only allows traffic with a valid signature and over HTTPS.
+- The AWS VPC Lattice service's configured authorization policy ensures that traffic only comes from Apollo's AWS accounts. (This is the authorization policy you configured in step 6 [when creating your Lattice service](#step-2-create-an-aws-vpc-lattice-service).)
+- Apollo Cloud Router Provisioning compares subgraphs in a graph variant configuration against the list of known private subgraphs in its Apollo account, and refuses to create or update Cloud Routers with unknown private subgraphs.
+- Cloud Routers are only granted permissions to invoke private subgraphs that are listed in their graph variant configuration.
+
+You can further restrict access to your private subgraphs by configuring additional [conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) in your service's authorization policy.
+Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your subgraph's graph ref.
+
+### Update a Lattice service's authorization policy
+
+To update a Lattice service's authorization policy with additional restrictions:
+
+1. Find your account ID and or graph ref in your Apollo account.
+  - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
+  - To-do: instructions on finding your account ID
+  - To find your graph ref, click on a graph variant in the **Graphs** page. The graph ref will be at the top of the page. You can click it to copy it.
+  - If you are using the terraform-graphos-aws module, you must the `apollo_account_ids` and `apollo_graph_refs` variables.
+2. In the AWS Console for your region of choice, go to the VPC service page:
+
+- [US East (N. Virginia) — us-east-1](https://us-east-1.console.aws.amazon.com/ram/home?region=us-east-1)
+- [Europe (Ireland) — eu-west-1](https://eu-west-1.console.aws.amazon.com/ram/home?region=eu-west-1)
+
+3. In the menu on the left, scroll down and open **Services** in the **VPC Lattice** section.
+
+  <img
+    className="screenshot"
+    alt="AWS VPC service page left menu"
+    src="../../../img/cloud-dedicated/vpc-lattice-menu.jpg"
+    width="175px"
+  />
+
+4. Click the name of the Lattice service you want to configure the authorization policy for.
+
+  <img
+    className="screenshot"
+    alt="AWS VPC service page"
+    src="../../../img/cloud-dedicated/select-lattice-service.jpg"
+  />
+
+5. In the **Service access** section, update your authorization policy. You can use the following as an example–make sure to replace the account ID and/or graph ref depending on which conditions you are adding.
+
+  ```json {13-17}
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": "*",
+        "Action": "vpc-lattice-svcs:Invoke",
+        "Resource": "*",
+        "Condition": {
+          "ForAnyValue:StringLike": {
+            "aws:PrincipalOrgPaths": "o-9vaxczew6u/*/ou-leyb-l9pccq2t/ou-leyb-fvqz35yo/*"
+          },
+          // Restrict traffic based on Apollo account IDs or graphRefs
+          "StringEquals": {
+            "aws:PrincipalTag/Apollo:accountId": "my_account_id_xezf34",
+            "aws:PrincipalTag/Apollo:graphRef": "my-graph@my-variant"
+          }
+        }
+      }
+    ]
+  }
+  ```
+
+6. Update your Cloud Router.
+
+## Remove access to private subgraphs
 
 To remove Cloud Dedicated access to private subgraphs, you need to remove both resource shares and service network associations. Keep in mind that any existing supergraph that sends traffic to your private subgraphs will stop working once you remove access.
 

--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -546,9 +546,9 @@ Congratulations! You've now added a private subgraph to your GraphOS Cloud Route
 Once you configure an AWS VPC Lattice service to accept traffic from the Apollo AWS Organization, it is protected by multiple security layers:
 
 - The AWS VPC Lattice service network only allows traffic with a valid signature and over HTTPS.
-- The AWS VPC Lattice service's configured authorization policy ensures that traffic only comes from Apollo's AWS accounts. (This is the authorization policy you configured in step 6 [when creating your Lattice service](#step-2-create-an-aws-vpc-lattice-service).)
-- Apollo Cloud Router Provisioning compares subgraphs in a graph variant configuration against the list of known private subgraphs in its Apollo account, and refuses to create or update Cloud Routers with unknown private subgraphs.
-- Cloud Routers are only granted permissions to invoke private subgraphs that are listed in their graph variant configuration.
+- The AWS VPC Lattice service's configured authorization policy ensures traffic only comes from Apollo's AWS accounts. (This is the authorization policy you configured in step 6 [when creating your Lattice service](#step-2-create-an-aws-vpc-lattice-service).)
+- Apollo Cloud Router Provisioning compares subgraphs in a graph variant configuration against the list of known private subgraphs in its Apollo account. It refuses to create or update Cloud Routers with unknown private subgraphs.
+- Cloud Routers only have permission to invoke private subgraphs listed in their graph variant configuration.
 
 You can further restrict access to your private subgraphs by configuring additional [conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) in your service's authorization policy.
 Specifically, you can add conditions to restrict traffic based on your organization's Apollo account ID or your subgraph's graph ref.
@@ -560,7 +560,7 @@ To update a Lattice service's authorization policy with additional restrictions:
 1. Find your account ID and or graph ref in your Apollo account.
   - Log in to [GraphOS Studio](https://studio.apollographql.com?referrer=docs-content).
   - To-do: instructions on finding your account ID
-  - To find your graph ref, click on a graph variant in the **Graphs** page. The graph ref will be at the top of the page. You can click it to copy it.
+  - To find your graph ref, click on a graph variant on the **Graphs** page. The graph ref will be at the top of the page. You can click it to copy it.
   - If you are using the terraform-graphos-aws module, you must the `apollo_account_ids` and `apollo_graph_refs` variables.
 2. In the AWS Console for your region of choice, go to the VPC service page:
 
@@ -576,7 +576,7 @@ To update a Lattice service's authorization policy with additional restrictions:
     width="175px"
   />
 
-4. Click the name of the Lattice service you want to configure the authorization policy for.
+4. Click the name of the Lattice service whose authorization policy you want to configure.
 
   <img
     className="screenshot"


### PR DESCRIPTION
Adds a section for how to restrict traffic to a Lattice service based on Apollo account ID and graph ref.