### PR TITLE
fix apidoc path and add some output to build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -119,7 +119,7 @@ const plugins = [
     resolve: 'gatsby-plugin-apollo-client-api-doc',
     options: {
       file: isSingleDocset
-        ? join(__dirname, 'local/shared/client.api.json')
+        ? join(__dirname, 'local/public/client.api.json')
         : 'https://apollo-client-docs.netlify.app/client.api.json'
     }
   },

--- a/plugins/gatsby-plugin-apollo-client-api-doc/gatsby-node.js
+++ b/plugins/gatsby-plugin-apollo-client-api-doc/gatsby-node.js
@@ -12,13 +12,17 @@ exports.sourceNodes = async (api, options) => {
     let {file} = /** @type {{file:string}} */ (options);
 
     if (file.includes('://')) {
+      console.info("downloading api doc from url", file)
       const request = await fetch(file);
       const contents = await request.text();
       file = path.join(tempDir, 'api.json');
       fs.writeFileSync(file, contents);
     }
     if (fs.existsSync(file)) {
+      console.info("loading api doc from file", file)
       loadApiDoc(file, api);
+    } else {
+      console.info("api doc file not found, skipping", file)
     }
   } finally {
     fs.rmSync(tempDir, {recursive: true});


### PR DESCRIPTION
This adds a fix for local deployments/the single docset preview over in Apollo Client, as well as a log message indicating which docmodel is being used during the build.


Tested over in https://github.com/apollographql/apollo-client/pull/11381 which currently runs against this branch - these changes fix the deploy there.