### PR TITLE
adding TrackableLink component

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import React, {Fragment, createElement, useMemo} from 'react';
 import RelativeLink, {ButtonLink} from './RelativeLink';
 import TableOfContents from './TableOfContents';
+import TrackableLink from './TrackableLink';
 import TypeScriptApiBox from './TypeScriptApiBox';
 import VersionBanner from './VersionBanner';
 import autolinkHeadings from 'rehype-autolink-headings';
@@ -39,7 +40,7 @@ import {
 } from '@chakra-ui/react';
 import {Caution} from './Caution';
 import {CustomHeading} from './CustomHeading';
-import {DocBlock, DocPiece, FunctionDetails, InterfaceDetails} from './ApiDoc'
+import {DocBlock, DocPiece, FunctionDetails, InterfaceDetails} from './ApiDoc';
 import {
   EmbeddableExplorer,
   MarkdownCodeBlock,
@@ -92,7 +93,7 @@ import 'prismjs/components/prism-swift';
 import 'prismjs/components/prism-tsx';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-yaml';
-import { ResponsiveGridStyles } from './ApiDoc/ResponsiveGrid';
+import {ResponsiveGridStyles} from './ApiDoc/ResponsiveGrid';
 
 // use JS syntax highlighting for rhai codeblocks
 Prism.languages.rhai = Prism.languages.javascript;
@@ -208,7 +209,8 @@ const mdxComponents = {
   InterfaceDetails,
   FunctionDetails,
   DocBlock,
-  DocPiece
+  DocPiece,
+  TrackableLink
 };
 
 const {processSync} = rehype()
@@ -233,8 +235,16 @@ export default function Page({file}) {
     file;
 
   const {frontmatter, headings} = childMdx || childMarkdownRemark;
-  const {title, subtitle, description, toc, tags, headingDepth, minVersion, noIndex} =
-    frontmatter;
+  const {
+    title,
+    subtitle,
+    description,
+    toc,
+    tags,
+    headingDepth,
+    minVersion,
+    noIndex
+  } = frontmatter;
 
   const publishedSubtitle = subtitle ? subtitle : description;
 
@@ -420,16 +430,16 @@ export default function Page({file}) {
         title={title}
         subtitle={
           <>
-              {publishedSubtitle && (
-                <chakra.h2
-                  fontSize={{base: 'xl', md: '2xl'}}
-                  lineHeight="normal"
-                  mt={{base: 2, md: 3}}
-                  fontWeight="normal"
-                >
-                  {publishedSubtitle}
-                </chakra.h2>
-              )}
+            {publishedSubtitle && (
+              <chakra.h2
+                fontSize={{base: 'xl', md: '2xl'}}
+                lineHeight="normal"
+                mt={{base: 2, md: 3}}
+                fontWeight="normal"
+              >
+                {publishedSubtitle}
+              </chakra.h2>
+            )}
             {tags?.length && (
               <HStack mt={{base: 2, md: 3}}>
                 {tags.map((tag, index) => (

--- a/src/components/TrackableLink.js
+++ b/src/components/TrackableLink.js
@@ -6,7 +6,7 @@ const TrackableLink = ({href, eventName, children, ...props}) => {
   return (
     <RelativeLink
       href={href}
-      onClick={() => window?.gtag?.('event', eventName)}
+      onClick={() => window?.gtag?.('event', `docs_${eventName}`)}
       {...props}
     >
       {children}

--- a/src/components/TrackableLink.js
+++ b/src/components/TrackableLink.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import RelativeLink from './RelativeLink';
+
+const TrackableLink = ({href, eventName, children, ...props}) => {
+  return (
+    <RelativeLink
+      href={href}
+      onClick={() => window?.gtag?.('event', eventName)}
+      {...props}
+    >
+      {children}
+    </RelativeLink>
+  );
+};
+
+export default TrackableLink;
+
+TrackableLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  eventName: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
+};


### PR DESCRIPTION
This PR introduces a new component that can be used to fire GA4 events on links that live within our docs content.

The `TrackableLink` component requires `href` and `eventName` props.

`eventName` will be the name of your GA4 event, and can be anything you want but it's recommended to use all lowercase, and underscores for space for consistency with our other GA4 events.

non ga4 event link:

`[reach out](https://www.apollographql.com/contact-sales/)`

ga4 event tracked link:

`<TrackableLink href="https://www.apollographql.com/contact-sales/" eventName="docs_cta_link">reach out</TrackableLink>`