### PR TITLE
expose `useApiDocContext` and `PrimaryLink` available using `MDX` context

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -10,7 +10,7 @@ import Pagination from './Pagination';
 import Prism from 'prismjs';
 import PropTypes from 'prop-types';
 import React, {Fragment, createElement, useMemo} from 'react';
-import RelativeLink, {ButtonLink} from './RelativeLink';
+import RelativeLink, {ButtonLink, PrimaryLink} from './RelativeLink';
 import TableOfContents from './TableOfContents';
 import TrackableButton from './TrackableButton';
 import TrackableLink from './TrackableLink';
@@ -41,7 +41,7 @@ import {
 } from '@chakra-ui/react';
 import {Caution} from './Caution';
 import {CustomHeading} from './CustomHeading';
-import {DocBlock, DocPiece, FunctionDetails, InterfaceDetails} from './ApiDoc';
+import {DocBlock, DocPiece, FunctionDetails, InterfaceDetails, useApiDocContext} from './ApiDoc';
 import {
   EmbeddableExplorer,
   MarkdownCodeBlock,
@@ -212,7 +212,9 @@ const mdxComponents = {
   DocBlock,
   DocPiece,
   TrackableButton,
-  TrackableLink
+  TrackableLink,
+  useApiDocContext,
+  PrimaryLink
 };
 
 const {processSync} = rehype()


### PR DESCRIPTION
As it causes quite a bit of noise to open a PR here for every change while we still figure out how to use the `ApiDocs` components and regularly change them, I want to copy them over into the Apollo Client repo and iterate on them over there, while we do docs PRs. 

To make that possible, a few more things need to be exposed so we can access them using the `useMDXComponents` hook.