### PR TITLE
Export useApiDocContext

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -41,7 +41,13 @@ import {
 } from '@chakra-ui/react';
 import {Caution} from './Caution';
 import {CustomHeading} from './CustomHeading';
-import {DocBlock, DocPiece, FunctionDetails, InterfaceDetails} from './ApiDoc';
+import {
+  DocBlock,
+  DocPiece,
+  FunctionDetails,
+  InterfaceDetails,
+  useApiDocContext
+} from './ApiDoc';
 import {
   EmbeddableExplorer,
   MarkdownCodeBlock,
@@ -212,7 +218,8 @@ const mdxComponents = {
   DocBlock,
   DocPiece,
   TrackableButton,
-  TrackableLink
+  TrackableLink,
+  useApiDocContext
 };
 
 const {processSync} = rehype()


### PR DESCRIPTION
This should fix the failing build for Apollo Client docs from https://github.com/apollographql/apollo-client/pull/11416

This is a small slice of https://github.com/apollographql/docs/pull/646