### PR TITLE
Upgrade to latest gatsby-remark-mermaid version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "polished": "^4.1.4",
         "prismjs": "^1.27.0",
         "prop-types": "^15.7.2",
-        "puppeteer": "^10.4.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-helmet-async": "^1.2.1",
@@ -7781,14 +7780,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.9.2",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/yoga-layout": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
@@ -9668,13 +9659,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -12729,10 +12713,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.901419",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/diff": {
       "version": "4.0.2",
       "dev": true,
@@ -15070,24 +15050,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -15171,13 +15133,6 @@
     "node_modules/fd": {
       "version": "0.0.3",
       "license": "MIT"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fenceparser": {
       "version": "1.1.1",
@@ -43557,10 +43512,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "license": "MIT"
-    },
     "node_modules/physical-cpu-count": {
       "version": "2.0.0",
       "license": "ISC"
@@ -44418,10 +44369,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "license": "ISC"
@@ -44454,77 +44401,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "10.4.0",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.3.1",
-        "devtools-protocol": "0.0.901419",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.1",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.0.0",
-        "unbzip2-stream": "1.3.3",
-        "ws": "7.4.6"
-      },
-      "engines": {
-        "node": ">=10.18.1"
-      }
-    },
-    "node_modules/puppeteer/node_modules/debug": {
-      "version": "4.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer/node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/puppeteer/node_modules/progress": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/puppeteer/node_modules/ws": {
-      "version": "7.4.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/q": {
@@ -49774,14 +49650,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "license": "MIT",
@@ -51271,14 +51139,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yeast": {
@@ -56575,13 +56435,6 @@
       "version": "20.2.1",
       "dev": true
     },
-    "@types/yauzl": {
-      "version": "2.9.2",
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/yoga-layout": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
@@ -57832,9 +57685,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-crc32": {
-      "version": "0.2.13"
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1"
@@ -60046,9 +59896,6 @@
         }
       }
     },
-    "devtools-protocol": {
-      "version": "0.0.901419"
-    },
     "diff": {
       "version": "4.0.2",
       "dev": true,
@@ -61594,15 +61441,6 @@
         }
       }
     },
-    "extract-zip": {
-      "version": "2.0.1",
-      "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.3"
     },
@@ -61673,12 +61511,6 @@
     },
     "fd": {
       "version": "0.0.3"
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "requires": {
-        "pend": "~1.2.0"
-      }
     },
     "fenceparser": {
       "version": "1.1.1"
@@ -81897,9 +81729,6 @@
     "peek-readable": {
       "version": "4.0.1"
     },
-    "pend": {
-      "version": "1.2.0"
-    },
     "physical-cpu-count": {
       "version": "2.0.0"
     },
@@ -82387,9 +82216,6 @@
         "ipaddr.js": "1.9.1"
       }
     },
-    "proxy-from-env": {
-      "version": "1.1.0"
-    },
     "pseudomap": {
       "version": "1.0.2"
     },
@@ -82411,43 +82237,6 @@
       "version": "2.1.1",
       "requires": {
         "escape-goat": "^2.0.0"
-      }
-    },
-    "puppeteer": {
-      "version": "10.4.0",
-      "requires": {
-        "debug": "4.3.1",
-        "devtools-protocol": "0.0.901419",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.1",
-        "pkg-dir": "4.2.0",
-        "progress": "2.0.1",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.0.0",
-        "unbzip2-stream": "1.3.3",
-        "ws": "7.4.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        },
-        "progress": {
-          "version": "2.0.1"
-        },
-        "ws": {
-          "version": "7.4.6",
-          "requires": {}
-        }
       }
     },
     "q": {
@@ -85807,13 +85596,6 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
-    "unbzip2-stream": {
-      "version": "1.3.3",
-      "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
     "unc-path-regex": {
       "version": "0.1.2"
     },
@@ -86773,13 +86555,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "yeast": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "gatsby-plugin-webfonts": "^2.2.1",
         "gatsby-remark-autolink-headers": "^5.4.0",
         "gatsby-remark-copy-linked-files": "^5.4.0",
-        "gatsby-remark-mermaid": "^2.1.0",
+        "gatsby-remark-mermaid": "^4.0.0",
         "gatsby-source-filesystem": "^4.4.0",
         "gatsby-source-remote-file": "^0.5.2",
         "gatsby-transformer-json": "^4.4.0",
@@ -2287,8 +2287,9 @@
       "license": "MIT"
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "3.1.0",
-      "license": "MIT"
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
     },
     "node_modules/@builder.io/partytown": {
       "version": "0.5.4",
@@ -3422,6 +3423,15 @@
     "node_modules/@fec/remark-a11y-emoji/node_modules/emoji-regex": {
       "version": "9.2.2",
       "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "1.9.0",
@@ -7468,6 +7478,24 @@
       "version": "2.8.12",
       "license": "MIT"
     },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw=="
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
     "node_modules/@types/debug": {
       "version": "0.0.30",
       "license": "MIT"
@@ -10841,6 +10869,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "6.0.0",
       "license": "MIT",
@@ -11785,6 +11821,53 @@
       "version": "3.0.9",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.27.0.tgz",
+      "integrity": "sha512-pPZJilfX9BxESwujODz5pydeGi+FBrXq1rcaB1mfhFXXFJ9GjE6CNndAk+8jPzoXGD+16LtSS4xlYEIUiW4Abg==",
+      "dependencies": {
+        "heap": "^0.2.6",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "license": "ISC",
@@ -11794,15 +11877,16 @@
       }
     },
     "node_modules/d3": {
-      "version": "7.1.1",
-      "license": "ISC",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -11833,8 +11917,9 @@
       }
     },
     "node_modules/d3-array": {
-      "version": "3.1.1",
-      "license": "ISC",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -11844,14 +11929,16 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -11865,7 +11952,8 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
       "dependencies": {
         "d3-path": "1 - 3"
       },
@@ -11873,30 +11961,29 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-color": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-contour": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
       "dependencies": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "license": "ISC",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "dependencies": {
         "delaunator": "5"
       },
@@ -11906,14 +11993,16 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -11924,7 +12013,8 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "dependencies": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -11947,7 +12037,8 @@
     },
     "node_modules/d3-dsv/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -11957,14 +12048,16 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
       "dependencies": {
         "d3-dsv": "1 - 3"
       },
@@ -11974,7 +12067,8 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -11985,15 +12079,17 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-geo": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -12002,15 +12098,17 @@
       }
     },
     "node_modules/d3-hierarchy": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -12019,36 +12117,76 @@
       }
     },
     "node_modules/d3-path": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -12062,7 +12200,8 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -12073,24 +12212,27 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-shape": {
-      "version": "3.0.1",
-      "license": "ISC",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dependencies": {
-        "d3-path": "1 - 3"
+        "d3-path": "^3.1.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-time": {
-      "version": "3.0.0",
-      "license": "ISC",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": {
         "d3-array": "2 - 3"
       },
@@ -12099,8 +12241,9 @@
       }
     },
     "node_modules/d3-time-format": {
-      "version": "4.0.0",
-      "license": "ISC",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dependencies": {
         "d3-time": "1 - 3"
       },
@@ -12110,14 +12253,16 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -12132,13 +12277,10 @@
         "d3-selection": "2 - 3"
       }
     },
-    "node_modules/d3-voronoi": {
-      "version": "1.1.4",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "dependencies": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -12150,261 +12292,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "license": "MIT",
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.10.tgz",
+      "integrity": "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==",
       "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/dagre-d3": {
-      "version": "0.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "d3": "^5.14",
-        "dagre": "^0.8.5",
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT"
-    },
-    "node_modules/dagre-d3/node_modules/d3": {
-      "version": "5.16.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-axis": "1",
-        "d3-brush": "1",
-        "d3-chord": "1",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-contour": "1",
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-dsv": "1",
-        "d3-ease": "1",
-        "d3-fetch": "1",
-        "d3-force": "1",
-        "d3-format": "1",
-        "d3-geo": "1",
-        "d3-hierarchy": "1",
-        "d3-interpolate": "1",
-        "d3-path": "1",
-        "d3-polygon": "1",
-        "d3-quadtree": "1",
-        "d3-random": "1",
-        "d3-scale": "2",
-        "d3-scale-chromatic": "1",
-        "d3-selection": "1",
-        "d3-shape": "1",
-        "d3-time": "1",
-        "d3-time-format": "2",
-        "d3-timer": "1",
-        "d3-transition": "1",
-        "d3-voronoi": "1",
-        "d3-zoom": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-array": {
-      "version": "1.2.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-axis": {
-      "version": "1.0.12",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-brush": {
-      "version": "1.1.6",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-chord": {
-      "version": "1.0.6",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1",
-        "d3-path": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-color": {
-      "version": "1.4.1",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-contour": {
-      "version": "1.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.1.1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-drag": {
-      "version": "1.2.5",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-dsv": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-ease": {
-      "version": "1.0.7",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-fetch": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dsv": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-force": {
-      "version": "1.2.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-format": {
-      "version": "1.4.5",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-geo": {
-      "version": "1.12.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-hierarchy": {
-      "version": "1.1.9",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-path": {
-      "version": "1.0.9",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-polygon": {
-      "version": "1.0.6",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-quadtree": {
-      "version": "1.0.7",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-random": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-scale": {
-      "version": "2.2.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-scale-chromatic": {
-      "version": "1.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-selection": {
-      "version": "1.4.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-time": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-time": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-timer": {
-      "version": "1.0.10",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/dagre-d3/node_modules/d3-transition": {
-      "version": "1.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/dagre-d3/node_modules/d3-zoom": {
-      "version": "1.8.3",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
+        "d3": "^7.8.2",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -12435,6 +12329,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -12643,7 +12542,8 @@
     },
     "node_modules/delaunator": {
       "version": "5.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
       "dependencies": {
         "robust-predicates": "^3.0.0"
       }
@@ -12927,8 +12827,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.3.5",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -13031,6 +12932,11 @@
       "version": "1.4.277",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.277.tgz",
       "integrity": "sha512-Ej4VyUfGdVY5D2J5WHAVNqrEFBKgeNcX7p/bBQU4x/VKwvnyEvGd62NEkIK3lykLEe9Cg4MCcoWAa+u97o0u/A=="
+    },
+    "node_modules/elkjs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -17131,32 +17037,55 @@
       "license": "0BSD"
     },
     "node_modules/gatsby-remark-mermaid": {
-      "version": "2.1.0",
-      "license": "ISC",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-mermaid/-/gatsby-remark-mermaid-4.0.0.tgz",
+      "integrity": "sha512-G4f4vJFnGzRrkYMpVKu8sV/0hNWec8UHW6bl6aB6pRJDQalzYD2YgGvReScRdFL7CWtFgcHdYzzl7pOHg8FCZQ==",
       "dependencies": {
-        "mermaid": "^8.7.0",
-        "unist-util-visit": "^1.4.0"
+        "remark-mermaidjs": "^5.0.0",
+        "vfile": "^5.0.0"
       },
-      "peerDependencies": {
-        "puppeteer": "*"
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
       }
     },
-    "node_modules/gatsby-remark-mermaid/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
-    "node_modules/gatsby-remark-mermaid/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "license": "MIT",
+    "node_modules/gatsby-remark-mermaid/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
       "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/gatsby-remark-mermaid/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "license": "MIT",
+    "node_modules/gatsby-remark-mermaid/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
       "dependencies": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/gatsby-remark-mermaid/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/gatsby-script": {
@@ -18721,13 +18650,6 @@
       "version": "4.2.8",
       "license": "ISC"
     },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/graphql": {
       "version": "15.8.0",
       "license": "MIT",
@@ -19030,6 +18952,323 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-4.2.0.tgz",
+      "integrity": "sha512-t1RJW/OpJbCAJQeKi3Qrj1cAOLA0+av/iPFori112+0X7R3wng+jxLA+kXec8K4szqPRGI8vPxbbpEYvvpwaeQ==",
+      "dependencies": {
+        "hastscript": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/property-information": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-1.0.2.tgz",
+      "integrity": "sha512-LhrTA2gfCbLOGJq2u/asp4kwuG0y6NhWTXiPKP+n0qNukKy7hc10whqqCFfyvIA1Q5U5d0sp9HhNim9gglEH4A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-from-parse5": "^7.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-1.0.0.tgz",
+      "integrity": "sha512-Yu480AKeOEN/+l5LA674a+7BmIvtDj24GvOt7MtQWuhzUwlaaRWdEPXAh3Qm5vhuthpAipFb2vTetKXWOjmTvw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-from-dom": "^4.0.0",
+        "hast-util-from-html": "^1.0.0",
+        "unist-util-remove-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic/node_modules/unist-util-remove-position": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz",
+      "integrity": "sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/hast-util-from-parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
+      "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "hastscript": "^7.0.0",
+        "property-information": "^6.0.0",
+        "vfile": "^5.0.0",
+        "vfile-location": "^4.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/hast-util-parse-selector": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+      "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/hastscript": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+      "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/property-information": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile-location": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+      "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "6.0.1",
       "license": "MIT",
@@ -19193,6 +19432,11 @@
       "dependencies": {
         "lower-case": "^1.1.1"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",
@@ -19623,7 +19867,8 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "engines": {
         "node": ">=12"
       }
@@ -23873,8 +24118,9 @@
       }
     },
     "node_modules/khroma": {
-      "version": "1.4.1",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -23917,6 +24163,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -24027,6 +24278,11 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -24806,18 +25062,144 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "8.14.0",
-      "license": "MIT",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.6.1.tgz",
+      "integrity": "sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==",
       "dependencies": {
-        "@braintree/sanitize-url": "^3.1.0",
-        "d3": "^7.0.0",
-        "dagre": "^0.8.5",
-        "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.5",
-        "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
-        "moment-mini": "^2.24.0",
-        "stylis": "^4.0.10"
+        "@braintree/sanitize-url": "^6.0.1",
+        "@types/d3-scale": "^4.0.3",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.4.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.10",
+        "dayjs": "^1.11.7",
+        "dompurify": "^3.0.5",
+        "elkjs": "^0.8.2",
+        "khroma": "^2.0.0",
+        "lodash-es": "^4.17.21",
+        "mdast-util-from-markdown": "^1.3.0",
+        "non-layered-tidy-tree-layout": "^2.0.2",
+        "stylis": "^4.1.3",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^9.0.0",
+        "web-worker": "^1.2.0"
+      }
+    },
+    "node_modules/mermaid-isomorphic": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mermaid-isomorphic/-/mermaid-isomorphic-2.1.1.tgz",
+      "integrity": "sha512-iShQaYYfGYakKs6fbwVjaTAaTVYm02aIvq8QZJFZMEJ18it2YMhW7QF23jLc1SgXHfVLbeWVoQ27jar2X8KP9g==",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.0.0",
+        "mermaid": "^10.0.0",
+        "playwright-core": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/mermaid/node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/mermaid/node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid/node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -25463,10 +25845,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/moment-mini": {
-      "version": "2.24.0",
-      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -42222,6 +42600,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "license": "MIT",
@@ -43271,6 +43654,17 @@
     "node_modules/platform": {
       "version": "1.3.6",
       "license": "MIT"
+    },
+    "node_modules/playwright-core": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/polished": {
       "version": "4.1.4",
@@ -46051,6 +46445,148 @@
       "version": "7.10.4",
       "license": "MIT"
     },
+    "node_modules/remark-mermaidjs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/remark-mermaidjs/-/remark-mermaidjs-5.0.2.tgz",
+      "integrity": "sha512-w7iIKhl2rAkz6Lax/txmU+S0/2rfWXQbi3AD0ooSHtc4wSlXz0ynX2CfNozVuotvpHzooMrrAFnExHSm2Unyxg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "hast-util-from-html-isomorphic": "^1.0.0",
+        "mermaid-isomorphic": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mermaidjs/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "8.0.3",
       "license": "MIT",
@@ -46988,8 +47524,9 @@
       }
     },
     "node_modules/robust-predicates": {
-      "version": "3.0.1",
-      "license": "Unlicense"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rtl-css-js": {
       "version": "1.15.0",
@@ -47028,7 +47565,8 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
@@ -48431,8 +48969,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.0.10",
-      "license": "MIT"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/subarg": {
       "version": "1.0.0",
@@ -49035,6 +49574,14 @@
     "node_modules/true-case-path": {
       "version": "2.2.1",
       "license": "Apache-2.0"
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
+      }
     },
     "node_modules/ts-easing": {
       "version": "0.2.0",
@@ -50076,6 +50623,11 @@
     "node_modules/web-vitals": {
       "version": "1.1.2",
       "license": "Apache-2.0"
+    },
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -52222,7 +52774,9 @@
       "dev": true
     },
     "@braintree/sanitize-url": {
-      "version": "3.1.0"
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="
     },
     "@builder.io/partytown": {
       "version": "0.5.4",
@@ -53025,6 +53579,11 @@
           "version": "9.2.2"
         }
       }
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw=="
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "1.9.0",
@@ -55755,6 +56314,24 @@
     "@types/cors": {
       "version": "2.8.12"
     },
+    "@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw=="
+    },
+    "@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
     "@types/debug": {
       "version": "0.0.30"
     },
@@ -58158,6 +58735,14 @@
         "vary": "^1"
       }
     },
+    "cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "requires": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "requires": {
@@ -58807,6 +59392,46 @@
     "csstype": {
       "version": "3.0.9"
     },
+    "cytoscape": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.27.0.tgz",
+      "integrity": "sha512-pPZJilfX9BxESwujODz5pydeGi+FBrXq1rcaB1mfhFXXFJ9GjE6CNndAk+8jPzoXGD+16LtSS4xlYEIUiW4Abg==",
+      "requires": {
+        "heap": "^0.2.6",
+        "lodash": "^4.17.21"
+      }
+    },
+    "cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "requires": {
+        "cose-base": "^1.0.0"
+      }
+    },
+    "cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "requires": {
+        "cose-base": "^2.2.0"
+      },
+      "dependencies": {
+        "cose-base": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+          "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+          "requires": {
+            "layout-base": "^2.0.0"
+          }
+        },
+        "layout-base": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+          "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
+        }
+      }
+    },
     "d": {
       "version": "1.0.1",
       "requires": {
@@ -58815,14 +59440,16 @@
       }
     },
     "d3": {
-      "version": "7.1.1",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
+      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
       "requires": {
         "d3-array": "3",
         "d3-axis": "3",
         "d3-brush": "3",
         "d3-chord": "3",
         "d3-color": "3",
-        "d3-contour": "3",
+        "d3-contour": "4",
         "d3-delaunay": "6",
         "d3-dispatch": "3",
         "d3-drag": "3",
@@ -58850,16 +59477,22 @@
       }
     },
     "d3-array": {
-      "version": "3.1.1",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "requires": {
         "internmap": "1 - 2"
       }
     },
     "d3-axis": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
     },
     "d3-brush": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -58870,33 +59503,42 @@
     },
     "d3-chord": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
       "requires": {
         "d3-path": "1 - 3"
       }
     },
-    "d3-collection": {
-      "version": "1.0.7"
-    },
     "d3-color": {
-      "version": "3.0.1"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
     },
     "d3-contour": {
-      "version": "3.0.1",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
       "requires": {
-        "d3-array": "2 - 3"
+        "d3-array": "^3.2.0"
       }
     },
     "d3-delaunay": {
-      "version": "6.0.2",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
       "requires": {
         "delaunator": "5"
       }
     },
     "d3-dispatch": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
     },
     "d3-drag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-selection": "3"
@@ -58904,6 +59546,8 @@
     },
     "d3-dsv": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
       "requires": {
         "commander": "7",
         "iconv-lite": "0.6",
@@ -58912,6 +59556,8 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -58919,16 +59565,22 @@
       }
     },
     "d3-ease": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
     },
     "d3-fetch": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
       "requires": {
         "d3-dsv": "1 - 3"
       }
     },
     "d3-force": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-quadtree": "1 - 3",
@@ -58936,37 +59588,92 @@
       }
     },
     "d3-format": {
-      "version": "3.0.1"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
     },
     "d3-geo": {
-      "version": "3.0.1",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
       "requires": {
         "d3-array": "2.5.0 - 3"
       }
     },
     "d3-hierarchy": {
-      "version": "3.0.1"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
     },
     "d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "requires": {
         "d3-color": "1 - 3"
       }
     },
     "d3-path": {
-      "version": "3.0.1"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
     },
     "d3-polygon": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
     },
     "d3-quadtree": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
     },
     "d3-random": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "requires": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        },
+        "d3-path": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+          "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-shape": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+          "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+          "requires": {
+            "d3-path": "1"
+          }
+        },
+        "internmap": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+          "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+        }
+      }
     },
     "d3-scale": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "requires": {
         "d3-array": "2.10.0 - 3",
         "d3-format": "1 - 3",
@@ -58977,37 +59684,51 @@
     },
     "d3-scale-chromatic": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
       "requires": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
       }
     },
     "d3-selection": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-shape": {
-      "version": "3.0.1",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "requires": {
-        "d3-path": "1 - 3"
+        "d3-path": "^3.1.0"
       }
     },
     "d3-time": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "requires": {
         "d3-array": "2 - 3"
       }
     },
     "d3-time-format": {
-      "version": "4.0.0",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "requires": {
         "d3-time": "1 - 3"
       }
     },
     "d3-timer": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
     },
     "d3-transition": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "requires": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -59016,11 +59737,10 @@
         "d3-timer": "1 - 3"
       }
     },
-    "d3-voronoi": {
-      "version": "1.1.4"
-    },
     "d3-zoom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
       "requires": {
         "d3-dispatch": "1 - 3",
         "d3-drag": "2 - 3",
@@ -59029,219 +59749,13 @@
         "d3-transition": "2 - 3"
       }
     },
-    "dagre": {
-      "version": "0.8.5",
+    "dagre-d3-es": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.10.tgz",
+      "integrity": "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==",
       "requires": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
-    "dagre-d3": {
-      "version": "0.6.4",
-      "requires": {
-        "d3": "^5.14",
-        "dagre": "^0.8.5",
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3"
-        },
-        "d3": {
-          "version": "5.16.0",
-          "requires": {
-            "d3-array": "1",
-            "d3-axis": "1",
-            "d3-brush": "1",
-            "d3-chord": "1",
-            "d3-collection": "1",
-            "d3-color": "1",
-            "d3-contour": "1",
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-dsv": "1",
-            "d3-ease": "1",
-            "d3-fetch": "1",
-            "d3-force": "1",
-            "d3-format": "1",
-            "d3-geo": "1",
-            "d3-hierarchy": "1",
-            "d3-interpolate": "1",
-            "d3-path": "1",
-            "d3-polygon": "1",
-            "d3-quadtree": "1",
-            "d3-random": "1",
-            "d3-scale": "2",
-            "d3-scale-chromatic": "1",
-            "d3-selection": "1",
-            "d3-shape": "1",
-            "d3-time": "1",
-            "d3-time-format": "2",
-            "d3-timer": "1",
-            "d3-transition": "1",
-            "d3-voronoi": "1",
-            "d3-zoom": "1"
-          }
-        },
-        "d3-array": {
-          "version": "1.2.4"
-        },
-        "d3-axis": {
-          "version": "1.0.12"
-        },
-        "d3-brush": {
-          "version": "1.1.6",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "1",
-            "d3-transition": "1"
-          }
-        },
-        "d3-chord": {
-          "version": "1.0.6",
-          "requires": {
-            "d3-array": "1",
-            "d3-path": "1"
-          }
-        },
-        "d3-color": {
-          "version": "1.4.1"
-        },
-        "d3-contour": {
-          "version": "1.3.2",
-          "requires": {
-            "d3-array": "^1.1.1"
-          }
-        },
-        "d3-dispatch": {
-          "version": "1.0.6"
-        },
-        "d3-drag": {
-          "version": "1.2.5",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-selection": "1"
-          }
-        },
-        "d3-dsv": {
-          "version": "1.2.0",
-          "requires": {
-            "commander": "2",
-            "iconv-lite": "0.4",
-            "rw": "1"
-          }
-        },
-        "d3-ease": {
-          "version": "1.0.7"
-        },
-        "d3-fetch": {
-          "version": "1.2.0",
-          "requires": {
-            "d3-dsv": "1"
-          }
-        },
-        "d3-force": {
-          "version": "1.2.1",
-          "requires": {
-            "d3-collection": "1",
-            "d3-dispatch": "1",
-            "d3-quadtree": "1",
-            "d3-timer": "1"
-          }
-        },
-        "d3-format": {
-          "version": "1.4.5"
-        },
-        "d3-geo": {
-          "version": "1.12.1",
-          "requires": {
-            "d3-array": "1"
-          }
-        },
-        "d3-hierarchy": {
-          "version": "1.1.9"
-        },
-        "d3-interpolate": {
-          "version": "1.4.0",
-          "requires": {
-            "d3-color": "1"
-          }
-        },
-        "d3-path": {
-          "version": "1.0.9"
-        },
-        "d3-polygon": {
-          "version": "1.0.6"
-        },
-        "d3-quadtree": {
-          "version": "1.0.7"
-        },
-        "d3-random": {
-          "version": "1.1.2"
-        },
-        "d3-scale": {
-          "version": "2.2.2",
-          "requires": {
-            "d3-array": "^1.2.0",
-            "d3-collection": "1",
-            "d3-format": "1",
-            "d3-interpolate": "1",
-            "d3-time": "1",
-            "d3-time-format": "2"
-          }
-        },
-        "d3-scale-chromatic": {
-          "version": "1.5.0",
-          "requires": {
-            "d3-color": "1",
-            "d3-interpolate": "1"
-          }
-        },
-        "d3-selection": {
-          "version": "1.4.2"
-        },
-        "d3-shape": {
-          "version": "1.3.7",
-          "requires": {
-            "d3-path": "1"
-          }
-        },
-        "d3-time": {
-          "version": "1.1.0"
-        },
-        "d3-time-format": {
-          "version": "2.3.0",
-          "requires": {
-            "d3-time": "1"
-          }
-        },
-        "d3-timer": {
-          "version": "1.0.10"
-        },
-        "d3-transition": {
-          "version": "1.3.2",
-          "requires": {
-            "d3-color": "1",
-            "d3-dispatch": "1",
-            "d3-ease": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "^1.1.0",
-            "d3-timer": "1"
-          }
-        },
-        "d3-zoom": {
-          "version": "1.8.3",
-          "requires": {
-            "d3-dispatch": "1",
-            "d3-drag": "1",
-            "d3-interpolate": "1",
-            "d3-selection": "1",
-            "d3-transition": "1"
-          }
-        }
+        "d3": "^7.8.2",
+        "lodash-es": "^4.17.21"
       }
     },
     "damerau-levenshtein": {
@@ -59260,6 +59774,11 @@
     },
     "date-fns": {
       "version": "2.25.0"
+    },
+    "dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "debug": {
       "version": "4.3.4",
@@ -59391,6 +59910,8 @@
     },
     "delaunator": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
       "requires": {
         "robust-predicates": "^3.0.0"
       }
@@ -59587,7 +60108,9 @@
       }
     },
     "dompurify": {
-      "version": "2.3.5"
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -59668,6 +60191,11 @@
       "version": "1.4.277",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.277.tgz",
       "integrity": "sha512-Ej4VyUfGdVY5D2J5WHAVNqrEFBKgeNcX7p/bBQU4x/VKwvnyEvGd62NEkIK3lykLEe9Cg4MCcoWAa+u97o0u/A=="
+    },
+    "elkjs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
+      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -62686,25 +63214,40 @@
       }
     },
     "gatsby-remark-mermaid": {
-      "version": "2.1.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-mermaid/-/gatsby-remark-mermaid-4.0.0.tgz",
+      "integrity": "sha512-G4f4vJFnGzRrkYMpVKu8sV/0hNWec8UHW6bl6aB6pRJDQalzYD2YgGvReScRdFL7CWtFgcHdYzzl7pOHg8FCZQ==",
       "requires": {
-        "mermaid": "^8.7.0",
-        "unist-util-visit": "^1.4.0"
+        "remark-mermaidjs": "^5.0.0",
+        "vfile": "^5.0.0"
       },
       "dependencies": {
-        "unist-util-is": {
-          "version": "3.0.0"
-        },
-        "unist-util-visit": {
-          "version": "1.4.1",
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
           "requires": {
-            "unist-util-visit-parents": "^2.0.0"
+            "@types/unist": "^2.0.0"
           }
         },
-        "unist-util-visit-parents": {
-          "version": "2.1.2",
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
           "requires": {
-            "unist-util-is": "^3.0.0"
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
           }
         }
       }
@@ -63538,12 +64081,6 @@
     "graceful-fs": {
       "version": "4.2.8"
     },
-    "graphlib": {
-      "version": "2.1.8",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "graphql": {
       "version": "15.8.0"
     },
@@ -63743,6 +64280,224 @@
         "web-namespaces": "^1.0.0"
       }
     },
+    "hast-util-from-dom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-4.2.0.tgz",
+      "integrity": "sha512-t1RJW/OpJbCAJQeKi3Qrj1cAOLA0+av/iPFori112+0X7R3wng+jxLA+kXec8K4szqPRGI8vPxbbpEYvvpwaeQ==",
+      "requires": {
+        "hastscript": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "dependencies": {
+        "comma-separated-tokens": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "hast-util-parse-selector": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+          "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+          "requires": {
+            "@types/hast": "^2.0.0"
+          }
+        },
+        "hastscript": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+          "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "comma-separated-tokens": "^2.0.0",
+            "hast-util-parse-selector": "^3.0.0",
+            "property-information": "^6.0.0",
+            "space-separated-tokens": "^2.0.0"
+          }
+        },
+        "property-information": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+          "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ=="
+        },
+        "space-separated-tokens": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
+        "web-namespaces": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+          "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
+        }
+      }
+    },
+    "hast-util-from-html": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-1.0.2.tgz",
+      "integrity": "sha512-LhrTA2gfCbLOGJq2u/asp4kwuG0y6NhWTXiPKP+n0qNukKy7hc10whqqCFfyvIA1Q5U5d0sp9HhNim9gglEH4A==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-from-parse5": "^7.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^5.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "dependencies": {
+        "comma-separated-tokens": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "hast-util-from-parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
+          "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/unist": "^2.0.0",
+            "hastscript": "^7.0.0",
+            "property-information": "^6.0.0",
+            "vfile": "^5.0.0",
+            "vfile-location": "^4.0.0",
+            "web-namespaces": "^2.0.0"
+          }
+        },
+        "hast-util-parse-selector": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
+          "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+          "requires": {
+            "@types/hast": "^2.0.0"
+          }
+        },
+        "hastscript": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
+          "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "comma-separated-tokens": "^2.0.0",
+            "hast-util-parse-selector": "^3.0.0",
+            "property-information": "^6.0.0",
+            "space-separated-tokens": "^2.0.0"
+          }
+        },
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        },
+        "property-information": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
+          "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ=="
+        },
+        "space-separated-tokens": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-location": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
+          "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        },
+        "web-namespaces": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+          "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="
+        }
+      }
+    },
+    "hast-util-from-html-isomorphic": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-1.0.0.tgz",
+      "integrity": "sha512-Yu480AKeOEN/+l5LA674a+7BmIvtDj24GvOt7MtQWuhzUwlaaRWdEPXAh3Qm5vhuthpAipFb2vTetKXWOjmTvw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-from-dom": "^4.0.0",
+        "hast-util-from-html": "^1.0.0",
+        "unist-util-remove-position": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-remove-position": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-4.0.2.tgz",
+          "integrity": "sha512-TkBb0HABNmxzAcfLf4qsIbFbaPDvMO6wa3b3j4VcEzFVaw1LBKwnW4/sRJ/atSLSzoIg41JWEdnE7N6DIhGDGQ==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-visit": "^4.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        }
+      }
+    },
     "hast-util-from-parse5": {
       "version": "6.0.1",
       "requires": {
@@ -63847,6 +64602,11 @@
           }
         }
       }
+    },
+    "heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
     },
     "hey-listen": {
       "version": "1.0.8"
@@ -64105,7 +64865,9 @@
       }
     },
     "internmap": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "interweave": {
       "version": "12.9.0",
@@ -66913,7 +67675,9 @@
       }
     },
     "khroma": {
-      "version": "1.4.1"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "kind-of": {
       "version": "6.0.3"
@@ -66938,6 +67702,11 @@
       "requires": {
         "package-json": "^6.3.0"
       }
+    },
+    "layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="
     },
     "leven": {
       "version": "3.1.0",
@@ -67019,6 +67788,11 @@
     },
     "lodash": {
       "version": "4.17.21"
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0"
@@ -67558,17 +68332,114 @@
       "version": "1.4.1"
     },
     "mermaid": {
-      "version": "8.14.0",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-10.6.1.tgz",
+      "integrity": "sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==",
       "requires": {
-        "@braintree/sanitize-url": "^3.1.0",
-        "d3": "^7.0.0",
-        "dagre": "^0.8.5",
-        "dagre-d3": "^0.6.4",
-        "dompurify": "2.3.5",
-        "graphlib": "^2.1.8",
-        "khroma": "^1.4.1",
-        "moment-mini": "^2.24.0",
-        "stylis": "^4.0.10"
+        "@braintree/sanitize-url": "^6.0.1",
+        "@types/d3-scale": "^4.0.3",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.4.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.10",
+        "dayjs": "^1.11.7",
+        "dompurify": "^3.0.5",
+        "elkjs": "^0.8.2",
+        "khroma": "^2.0.0",
+        "lodash-es": "^4.17.21",
+        "mdast-util-from-markdown": "^1.3.0",
+        "non-layered-tidy-tree-layout": "^2.0.2",
+        "stylis": "^4.1.3",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^9.0.0",
+        "web-worker": "^1.2.0"
+      },
+      "dependencies": {
+        "@types/debug": {
+          "version": "4.1.12",
+          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+          "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+          "requires": {
+            "@types/ms": "*"
+          }
+        },
+        "mdast-util-from-markdown": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+          "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "mdast-util-to-string": "^3.1.0",
+            "micromark": "^3.0.0",
+            "micromark-util-decode-numeric-character-reference": "^1.0.0",
+            "micromark-util-decode-string": "^1.0.0",
+            "micromark-util-normalize-identifier": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "uvu": "^0.5.0"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+          "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+          "requires": {
+            "@types/mdast": "^3.0.0"
+          }
+        },
+        "micromark": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+          "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+          "requires": {
+            "@types/debug": "^4.0.0",
+            "debug": "^4.0.0",
+            "decode-named-character-reference": "^1.0.0",
+            "micromark-core-commonmark": "^1.0.1",
+            "micromark-factory-space": "^1.0.0",
+            "micromark-util-character": "^1.0.0",
+            "micromark-util-chunked": "^1.0.0",
+            "micromark-util-combine-extensions": "^1.0.0",
+            "micromark-util-decode-numeric-character-reference": "^1.0.0",
+            "micromark-util-encode": "^1.0.0",
+            "micromark-util-normalize-identifier": "^1.0.0",
+            "micromark-util-resolve-all": "^1.0.0",
+            "micromark-util-sanitize-uri": "^1.0.0",
+            "micromark-util-subtokenize": "^1.0.0",
+            "micromark-util-symbol": "^1.0.0",
+            "micromark-util-types": "^1.0.1",
+            "uvu": "^0.5.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
+      }
+    },
+    "mermaid-isomorphic": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mermaid-isomorphic/-/mermaid-isomorphic-2.1.1.tgz",
+      "integrity": "sha512-iShQaYYfGYakKs6fbwVjaTAaTVYm02aIvq8QZJFZMEJ18it2YMhW7QF23jLc1SgXHfVLbeWVoQ27jar2X8KP9g==",
+      "requires": {
+        "@fortawesome/fontawesome-free": "^6.0.0",
+        "mermaid": "^10.0.0",
+        "playwright-core": "^1.0.0"
       }
     },
     "methods": {
@@ -67875,9 +68746,6 @@
     },
     "moment": {
       "version": "2.29.1"
-    },
-    "moment-mini": {
-      "version": "2.24.0"
     },
     "mri": {
       "version": "1.2.0"
@@ -80405,6 +81273,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
+    "non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="
+    },
     "normalize-path": {
       "version": "3.0.0"
     },
@@ -81090,6 +81963,11 @@
     },
     "platform": {
       "version": "1.3.6"
+    },
+    "playwright-core": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ=="
     },
     "polished": {
       "version": "4.1.4",
@@ -82863,6 +83741,105 @@
         }
       }
     },
+    "remark-mermaidjs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/remark-mermaidjs/-/remark-mermaidjs-5.0.2.tgz",
+      "integrity": "sha512-w7iIKhl2rAkz6Lax/txmU+S0/2rfWXQbi3AD0ooSHtc4wSlXz0ynX2CfNozVuotvpHzooMrrAFnExHSm2Unyxg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "hast-util-from-html-isomorphic": "^1.0.0",
+        "mermaid-isomorphic": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
+      }
+    },
     "remark-parse": {
       "version": "8.0.3",
       "requires": {
@@ -83326,7 +84303,9 @@
       }
     },
     "robust-predicates": {
-      "version": "3.0.1"
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "rtl-css-js": {
       "version": "1.15.0",
@@ -83344,7 +84323,9 @@
       }
     },
     "rw": {
-      "version": "1.3.3"
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "rxjs": {
       "version": "6.6.7",
@@ -84308,7 +85289,9 @@
       }
     },
     "stylis": {
-      "version": "4.0.10"
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "subarg": {
       "version": "1.0.0",
@@ -84693,6 +85676,11 @@
     },
     "true-case-path": {
       "version": "2.2.1"
+    },
+    "ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
     },
     "ts-easing": {
       "version": "0.2.0"
@@ -85336,6 +86324,11 @@
     },
     "web-vitals": {
       "version": "1.1.2"
+    },
+    "web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "gatsby-plugin-webfonts": "^2.2.1",
     "gatsby-remark-autolink-headers": "^5.4.0",
     "gatsby-remark-copy-linked-files": "^5.4.0",
-    "gatsby-remark-mermaid": "^2.1.0",
+    "gatsby-remark-mermaid": "^4.0.0",
     "gatsby-source-filesystem": "^4.4.0",
     "gatsby-source-remote-file": "^0.5.2",
     "gatsby-transformer-json": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "polished": "^4.1.4",
     "prismjs": "^1.27.0",
     "prop-types": "^15.7.2",
-    "puppeteer": "^10.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet-async": "^1.2.1",


### PR DESCRIPTION
Upgrades gatsby-remark-mermaid to the latest version to try and fix the deploy issues on `main`. The newer versions of this package now rely on playright instead of puppeteer. This also removes the dependency on puppeteer.