### PR TITLE
Normalize browser redirects

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -7,20 +7,24 @@ export {wrapPageElement} from './gatsby-ssr';
 
 const redirects = {};
 
-const prefixedRedirects = Object.fromEntries(
+const normalizeUrl = url => {
+  // Remove the trailing slash before the hash
+  return url.replace(/\/#/, '#');
+};
+
+const normalizedRedirects = Object.fromEntries(
   Object.entries(redirects).map(([from, to]) => [
-    withPrefix(from),
+    normalizeUrl(withPrefix(from)),
     withPrefix(to)
   ])
 );
 
 export const onRouteUpdate = ({location}) => {
-  // Client-side redirects for links with anchors
   if (location.hash.length > 0) {
-    const path = location.pathname + location.hash;
-    if (path in prefixedRedirects) {
+    const normalizedPath = normalizeUrl(location.pathname + location.hash);
+    if (normalizedPath in normalizedRedirects) {
       const redirectURL =
-        location.origin + prefixedRedirects[path] + location.search;
+        location.origin + normalizedRedirects[normalizedPath] + location.search;
       window.location.replace(redirectURL);
     }
   }


### PR DESCRIPTION
Allow for redirects in both of these formats:

1) From '/graphos/explorer/connecting-authenticating#scripting' to '/graphos/explorer/scripting',
2) From '/graphos/explorer/connecting-authenticating/#scripting' to '/graphos/explorer/scripting',