### PR TITLE
Handle special characters in glossary term id creation

### DIFF
--- a/src/components/GlossaryPage/Results.js
+++ b/src/components/GlossaryPage/Results.js
@@ -69,9 +69,11 @@ ClickableHeading.propTypes = {
   children: PropTypes.node.isRequired
 };
 
+export const makeGlossaryTermId = term =>
+  term.replace(/\s+/g, '-').replace(/@/g, '').replace(/\//g, '').toLowerCase();
+
 const Results = () => {
   const {hits} = useHits();
-  const makeId = term => term.replace(/\s+/g, '-').toLowerCase();
   const {user} = useUser();
   const isApollonaut = user?.name.includes('@apollographql.com');
 
@@ -84,7 +86,7 @@ const Results = () => {
               as="h2"
               fontSize="2xl"
               fontWeight="bold"
-              id={makeId(hit.term)}
+              id={makeGlossaryTermId(hit.term)}
             >
               {hit.internalOnly && <span>🔒 </span>}
               <Highlight attribute="term" hit={hit} />
@@ -125,7 +127,7 @@ const Results = () => {
                 </Text>
                 {hit.relatedTerms.map((term, index) => (
                   <React.Fragment key={`${hit.objectID}_${index}`}>
-                    <RelativeLink href={`#${makeId(term)}`}>
+                    <RelativeLink href={`#${makeGlossaryTermId(term)}`}>
                       {term}
                     </RelativeLink>
                     {index < hit.relatedTerms.length - 1 && ', '}

--- a/src/components/Search/GlossaryResult.js
+++ b/src/components/Search/GlossaryResult.js
@@ -6,6 +6,7 @@ import React from 'react';
 import {Box, Flex, Heading, Icon, Text} from '@chakra-ui/react';
 import {BsJournals} from 'react-icons/bs';
 import {PrimaryLink} from '../RelativeLink';
+import {makeGlossaryTermId} from '../GlossaryPage/Results';
 
 const DefinitionText = ({children}) => {
   return (
@@ -82,9 +83,9 @@ export default function GlossaryResult({item}) {
           <PrimaryLink
             aria-label="Go to the glossary"
             as="a"
-            href={`https://www.apollographql.com/docs/resources/glossary#${item.term
-              .replace(/\s+/g, '-')
-              .toLowerCase()}`}
+            href={`https://www.apollographql.com/docs/resources/glossary#${makeGlossaryTermId(
+              item.term
+            )}`}
             mt="12px"
             style={{display: 'flex', alignItems: 'center'}}
           >


### PR DESCRIPTION
Handles issues that navigating to URLs like https://www.apollographql.com/docs/resources/glossary/#@apollo/gateway was causing