### PR TITLE
add wistia component

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -77,6 +77,7 @@ import {PreviewFeature} from './PreviewFeature';
 import {SiDiscord} from 'react-icons/si';
 import {TOTAL_HEADER_HEIGHT} from './Header';
 import {Tip} from './Tip';
+import {WistiaEmbed} from './WistiaEmbed';
 import {YouTube} from './YouTube';
 import {join} from 'path';
 import {kebabCase} from 'lodash';
@@ -202,6 +203,7 @@ const mdxComponents = {
   MultiCodeBlock,
   Note,
   YouTube,
+  WistiaEmbed,
   CodeColumns,
   TypeScriptApiBox,
   TypescriptApiBox: TypeScriptApiBox,

--- a/src/components/WistiaEmbed.js
+++ b/src/components/WistiaEmbed.js
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {AspectRatio} from '@chakra-ui/react';
+import {Script} from 'gatsby';
+
+export const WistiaEmbed = ({videoId}) => (
+  <div>
+    <Script src="https://fast.wistia.net/assets/external/E-v1.js" />
+    <AspectRatio ratio={16 / 9}>
+      <iframe
+        title={videoId}
+        src={`//fast.wistia.net/embed/iframe/${videoId}?seo=true`}
+        allowFullScreen
+        className="wistia_embed"
+        name="wistia_embed"
+        width="100%"
+        height="100%"
+      />
+    </AspectRatio>
+  </div>
+);
+
+WistiaEmbed.propTypes = {
+  videoId: PropTypes.string.isRequired
+};


### PR DESCRIPTION
Adding wistia embed support, simply provide the wisita video id.

`<WistiaEmbed videoId="hwz4d1sf7u" />`

<img width="921" alt="Screenshot 2024-01-10 at 12 31 32" src="https://github.com/apollographql/docs/assets/1368445/d99d7064-fa02-44e3-93ff-c71d626975f6">

<img width="807" alt="Screenshot 2024-01-10 at 12 31 20" src="https://github.com/apollographql/docs/assets/1368445/64ae9c38-a318-407d-aa4e-fe3db9d2c150">