### PR TITLE
show JSX-rendered headings in TOC

### DIFF
--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -12,18 +12,34 @@ export default function TableOfContents({
 }) {
   const [activeId, setActiveId] = useState(null);
   const scrollDisabled = useRef(false);
+  const [pageHeadings, setPageHeadings] = useState(headings);
+  useEffect(() => {
+    setPageHeadings(
+      [
+        ...document
+          .querySelector('main')
+          .querySelectorAll('h2[id],h3[id],h4[id],h5[id],h6[id]')
+          .values()
+      ].map(heading => ({
+        value: heading.title || heading.innerText,
+        depth: parseInt(heading.tagName[1]),
+        id: heading.id
+      }))
+    );
+  }, []);
+
   const toc = useMemo(() => {
     const slugger = new GithubSlugger();
-    return headings
+    return pageHeadings
       .filter(
         heading =>
           heading.depth >= MIN_HEADING_DEPTH && heading.depth <= headingDepth
       )
       .map(heading => ({
-        ...heading,
-        id: slugger.slug(heading.value)
+        id: slugger.slug(heading.value),
+        ...heading
       }));
-  }, [headings, headingDepth]);
+  }, [pageHeadings, headingDepth]);
 
   useEffect(() => {
     function handleScroll(event) {

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -23,7 +23,7 @@ export default function TableOfContents({
       ].map(heading => {
         const link = heading.querySelector('a');
         return {
-          value: heading.title || link.innerText || heading.innerText,
+          value: heading.title || link?.innerText || heading.innerText,
           depth: parseInt(heading.tagName[1]),
           id: heading.id
         };

--- a/src/components/TableOfContents.js
+++ b/src/components/TableOfContents.js
@@ -20,11 +20,14 @@ export default function TableOfContents({
           .querySelector('main')
           .querySelectorAll('h2[id],h3[id],h4[id],h5[id],h6[id]')
           .values()
-      ].map(heading => ({
-        value: heading.title || heading.innerText,
-        depth: parseInt(heading.tagName[1]),
-        id: heading.id
-      }))
+      ].map(heading => {
+        const link = heading.querySelector('a');
+        return {
+          value: heading.title || link.innerText || heading.innerText,
+          depth: parseInt(heading.tagName[1]),
+          id: heading.id
+        };
+      })
     );
   }, []);
 


### PR DESCRIPTION
This would show headings that are not part of the original Markdown, but rendered by JSX components, in the TOC.

This is quite important to us in the Client docs, since we're moving more and more to autogenerating sections there.

The dynamic elements will not be part of the SSRed TOC and only appear in the browser, but that's a tradeoff we'll have to accept, and probably okay. (I don't think the sidebar adds too much value in terms of SEO?)