### PR TITLE
Make body text large

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -91,7 +91,7 @@ const theme = extendTheme({
     Text: {
       baseStyle: {
         lineHeight: '1.8rem',
-        fontSize: 'md'
+        fontSize: 'lg'
       }
     },
     Table: {

--- a/src/components/Blockquote.js
+++ b/src/components/Blockquote.js
@@ -10,7 +10,7 @@ export default function Blockquote({children, ...props}) {
       py="1"
       borderLeftWidth="2px"
       borderColor="primary"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/Caution.js
+++ b/src/components/Caution.js
@@ -10,7 +10,7 @@ export const Caution = ({children, ...props}) => {
       py="1"
       borderLeftWidth="4px"
       borderColor="yellow.400"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -10,7 +10,7 @@ export const EnterpriseFeature = ({children}) => {
       py="1"
       borderLeftWidth="2px"
       borderColor="primary"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/ExperimentalFeature.js
+++ b/src/components/ExperimentalFeature.js
@@ -16,7 +16,7 @@ export const ExperimentalFeature = ({
       py="1"
       borderLeftWidth="2px"
       borderColor="primary"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/GlossaryPage/Results.js
+++ b/src/components/GlossaryPage/Results.js
@@ -149,7 +149,7 @@ const Results = () => {
                 my="4"
                 borderLeftWidth="2px"
                 borderColor="primary"
-                fontSize="md"
+                fontSize="lg"
                 sx={{
                   '>': {
                     ':not(:last-child)': {

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -32,7 +32,7 @@ export function Odyssey() {
       }}
     >
       <div>
-        <Text fontSize="md">
+        <Text fontSize="lg">
           <strong>Welcome!</strong> 👋 Our learning platform, Odyssey, provides{' '}
           <strong>interactive tutorials</strong> with videos and code challenges
           to help you launch your journey with GraphQL and Apollo.

--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -10,7 +10,7 @@ export const Note = ({children, ...props}) => {
       py="1"
       borderLeftWidth="4px"
       borderColor="gray.400"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/PreviewFeature.js
+++ b/src/components/PreviewFeature.js
@@ -16,7 +16,7 @@ export const PreviewFeature = ({
       py="1"
       borderLeftWidth="2px"
       borderColor="primary"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -10,7 +10,7 @@ export const Tip = ({children, ...props}) => {
       py="1"
       borderLeftWidth="4px"
       borderColor="green.400"
-      fontSize="md"
+      fontSize="lg"
       sx={{
         '>': {
           ':not(:last-child)': {

--- a/src/components/TypeScriptApiBox.js
+++ b/src/components/TypeScriptApiBox.js
@@ -450,7 +450,7 @@ export default function TypeScriptApiBox({name}) {
               </Thead>
               <Tbody>
                 {group.members.map((member, index) => (
-                  <Tr key={index} fontSize="md">
+                  <Tr key={index} fontSize="lg">
                     <Td sx={{code: {bg: 'none', p: 0}}}>
                       <chakra.h6 fontSize="lg" mb="1">
                         <InlineCode>{member.name}</InlineCode>


### PR DESCRIPTION
Currently standard body text in `<p>` is medium, while top level `<ol>` and `<ul>` text is large.
This standardizes the size among these elements.