### PR TITLE
significantly improve render performance on nav hover

### DIFF
--- a/src/components/MobileNav.js
+++ b/src/components/MobileNav.js
@@ -1,6 +1,6 @@
 import AuthCheck from './AuthCheck';
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
 import {
   Box,
   Drawer,
@@ -21,26 +21,30 @@ function MobileNavContent({defaultActiveDocset}) {
   const [activeDocset, setActiveDocset] = useState(
     defaultActiveDocset || basePath
   );
+  const pathContextValue = useMemo(
+    () => ({
+      ...pathContext,
+      basePath: `/${activeDocset}`
+    }),
+    [activeDocset, pathContext]
+  );
+  const docsetContextValue = useMemo(
+    () => ({
+      configs,
+      activeDocset,
+      setActiveDocset,
+      sidebarOpen: true,
+      clickToSelect: true
+    }),
+    [activeDocset, configs]
+  );
   return (
     <>
       {!activeDocset && <DrawerCloseButton zIndex="1" top="3" color="white" />}
       <Box overflow="auto" pos="relative" zIndex="0">
-        <DocsetContext.Provider
-          value={{
-            configs,
-            activeDocset,
-            setActiveDocset,
-            sidebarOpen: true,
-            clickToSelect: true
-          }}
-        >
+        <DocsetContext.Provider value={docsetContextValue}>
           {activeDocset ? (
-            <PathContext.Provider
-              value={{
-                ...pathContext,
-                basePath: `/${activeDocset}`
-              }}
-            >
+            <PathContext.Provider value={pathContextValue}>
               <SidebarNav
                 key={activeDocset}
                 currentVersion={configs[activeDocset].currentVersion}
@@ -69,6 +73,13 @@ MobileNavContent.propTypes = {
 export default function MobileNav({isInternal}) {
   const {isOpen, onOpen, onClose} = useDisclosure();
   const pathContext = useContext(PathContext);
+  const pathContextValue = useMemo(
+    () => ({
+      ...pathContext,
+      basePath: '/'
+    }),
+    [pathContext]
+  );
   return (
     <>
       <IconButton
@@ -85,12 +96,7 @@ export default function MobileNav({isInternal}) {
           {isInternal ? (
             <AuthCheck
               fallback={
-                <PathContext.Provider
-                  value={{
-                    ...pathContext,
-                    basePath: '/'
-                  }}
-                >
+                <PathContext.Provider value={pathContextValue}>
                   <MobileNavContent />
                 </PathContext.Provider>
               }

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -493,15 +493,20 @@ export default function Page({file}) {
           ) : null
         }
       >
-        <MultiCodeBlockContext.Provider value={{language, setLanguage}}>
-          {childMdx ? (
-            <MDXProvider components={mdxComponents}>
-              <MDXRenderer>{childMdx.body}</MDXRenderer>
-            </MDXProvider>
-          ) : (
-            processSync(childMarkdownRemark.html).result
-          )}
-        </MultiCodeBlockContext.Provider>
+        {useMemo(
+          () => (
+            <MultiCodeBlockContext.Provider value={{language, setLanguage}}>
+              {childMdx ? (
+                <MDXProvider components={mdxComponents}>
+                  <MDXRenderer>{childMdx.body}</MDXRenderer>
+                </MDXProvider>
+              ) : (
+                processSync(childMarkdownRemark.html).result
+              )}
+            </MultiCodeBlockContext.Provider>
+          ),
+          [childMarkdownRemark?.html, childMdx, language, setLanguage]
+        )}
       </PageContent>
       <HStack
         justify="flex-end"

--- a/src/components/PageWidthContext.js
+++ b/src/components/PageWidthContext.js
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState
 } from 'react';
@@ -117,18 +118,28 @@ export const PageWidthProvider = ({children}) => {
     root.style.setProperty(DOCS_PAGE_WIDTH_VAR, pageWidthPx + 'px');
   }, [pageWidthPx]);
 
+  const pageWidthContextValue = useMemo(
+    () => ({
+      pageWidthPx,
+      pageWidth,
+      setPageWidth,
+      togglePageWidth,
+      pageRefCallback,
+      showExpandButton
+    }),
+    [
+      pageRefCallback,
+      pageWidth,
+      pageWidthPx,
+      setPageWidth,
+      showExpandButton,
+      togglePageWidth
+    ]
+  );
+
   // Create a context provider with values
   return (
-    <PageWidthContext.Provider
-      value={{
-        pageWidthPx,
-        pageWidth,
-        setPageWidth,
-        togglePageWidth,
-        pageRefCallback,
-        showExpandButton
-      }}
-    >
+    <PageWidthContext.Provider value={pageWidthContextValue}>
       {children}
     </PageWidthContext.Provider>
   );

--- a/src/components/Sidebar/DefaultSidebarNav.js
+++ b/src/components/Sidebar/DefaultSidebarNav.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
+import React, {useContext, useMemo} from 'react';
 import SidebarNav from './SidebarNav';
 import {PathContext} from '../../utils';
 import {useConfig} from '../../utils/config';
@@ -7,13 +7,15 @@ import {useConfig} from '../../utils/config';
 export const DefaultSidebarNav = ({hideSidebar, isLocked, onLockToggle}) => {
   const {docset, navItems} = useConfig('/');
   const pathContext = useContext(PathContext);
+  const pathContextValue = useMemo(
+    () => ({
+      ...pathContext,
+      basePath: '/'
+    }),
+    [pathContext]
+  );
   return (
-    <PathContext.Provider
-      value={{
-        ...pathContext,
-        basePath: '/'
-      }}
-    >
+    <PathContext.Provider value={pathContextValue}>
       <SidebarNav
         docset={docset}
         navItems={navItems}

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState
 } from 'react';
@@ -86,6 +87,31 @@ export function Sidebar({
     };
   }, [dismissSidebar]);
 
+  const pathContextValue = useMemo(
+    () => ({
+      ...pathContext,
+      basePath: `/${activeDocset}`
+    }),
+    [pathContext, activeDocset]
+  );
+
+  const docsetContextValue = useMemo(
+    () => ({
+      configs,
+      activeDocset,
+      setActiveDocset,
+      sidebarOpen,
+      openSidebar,
+      dismissSidebar,
+      onKeyboardSelect: () => {
+        setSidebarOpen(false);
+        sidebarNavRef.current?.focusFirstLink();
+      },
+      isLocked
+    }),
+    [activeDocset, configs, dismissSidebar, isLocked, openSidebar, sidebarOpen]
+  );
+
   return (
     <chakra.aside
       ref={outerSidebarRef}
@@ -110,21 +136,7 @@ export function Sidebar({
         transform: isHidden ? 'translateX(-100%)' : 'none'
       }}
     >
-      <DocsetContext.Provider
-        value={{
-          configs,
-          activeDocset,
-          setActiveDocset,
-          sidebarOpen,
-          openSidebar,
-          dismissSidebar,
-          onKeyboardSelect: () => {
-            setSidebarOpen(false);
-            sidebarNavRef.current?.focusFirstLink();
-          },
-          isLocked
-        }}
-      >
+      <DocsetContext.Provider value={docsetContextValue}>
         <LeftSidebarNav
           w={isLocked ? COLLAPSED_SIDEBAR_WIDTH : SIDEBAR_WIDTH}
           onMouseOver={openSidebar}
@@ -152,12 +164,7 @@ export function Sidebar({
           transitionTimingFunction="ease-in-out"
         >
           {activeDocset ? (
-            <PathContext.Provider
-              value={{
-                ...pathContext,
-                basePath: `/${activeDocset}`
-              }}
-            >
+            <PathContext.Provider value={pathContextValue}>
               <SidebarNav
                 key={activeDocset}
                 ref={sidebarNavRef}

--- a/src/components/Sidebar/SidebarNav.js
+++ b/src/components/Sidebar/SidebarNav.js
@@ -92,6 +92,14 @@ const SidebarNav = forwardRef(
       [navGroups, nav]
     );
 
+    const navContextValue = useMemo(
+      () => ({
+        nav,
+        setNav: setLocalNavState
+      }),
+      [nav, setLocalNavState]
+    );
+
     return (
       <Flex
         direction="column"
@@ -150,12 +158,7 @@ const SidebarNav = forwardRef(
             </Menu>
           )}
         </Flex>
-        <NavContext.Provider
-          value={{
-            nav,
-            setNav: setLocalNavState
-          }}
-        >
+        <NavContext.Provider value={navContextValue}>
           <chakra.nav px="4" pb="3" ref={navRef}>
             <NavItems items={navItems} />
           </chakra.nav>

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,4 +1,5 @@
 import {graphql, useStaticQuery} from 'gatsby';
+import {useMemo} from 'react';
 import {v5} from 'uuid';
 
 // turn a sidebar configuration object to an array of nav items
@@ -72,53 +73,57 @@ export const useConfigs = () => {
     }
   `);
 
-  return data.configs.nodes.reduce((acc, config, _, nodes) => {
-    // TODO: convert configs to YAML
-    const content = JSON.parse(config.fields.content);
-    const {
-      title,
-      link,
-      version,
-      sidebar,
-      algoliaFilters,
-      internal,
-      versionBanner
-    } = content;
+  return useMemo(
+    () =>
+      data.configs.nodes.reduce((acc, config, _, nodes) => {
+        // TODO: convert configs to YAML
+        const content = JSON.parse(config.fields.content);
+        const {
+          title,
+          link,
+          version,
+          sidebar,
+          algoliaFilters,
+          internal,
+          versionBanner
+        } = content;
 
-    const slug = configToSlug(config);
-    const parent = getParentDocset(slug);
+        const slug = configToSlug(config);
+        const parent = getParentDocset(slug);
 
-    const versions = [];
+        const versions = [];
 
-    for (const node of nodes) {
-      const nodeSlug = configToSlug(node);
-      if (getParentDocset(nodeSlug) === parent) {
-        const {version} = JSON.parse(node.fields.content);
-        if (version) {
-          versions.push({
-            label: version,
-            slug: nodeSlug
-          });
+        for (const node of nodes) {
+          const nodeSlug = configToSlug(node);
+          if (getParentDocset(nodeSlug) === parent) {
+            const {version} = JSON.parse(node.fields.content);
+            if (version) {
+              versions.push({
+                label: version,
+                slug: nodeSlug
+              });
+            }
+          }
         }
-      }
-    }
 
-    versions.sort((a, b) => b.label.localeCompare(a.label));
+        versions.sort((a, b) => b.label.localeCompare(a.label));
 
-    return {
-      ...acc,
-      [slug]: {
-        docset: title,
-        currentVersion: version,
-        navItems: getNavItems(sidebar),
-        algoliaFilters,
-        internal,
-        versions,
-        versionBanner,
-        link
-      }
-    };
-  }, {});
+        return {
+          ...acc,
+          [slug]: {
+            docset: title,
+            currentVersion: version,
+            navItems: getNavItems(sidebar),
+            algoliaFilters,
+            internal,
+            versions,
+            versionBanner,
+            link
+          }
+        };
+      }, {}),
+    [data]
+  );
 };
 
 export const useConfig = slug => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-import {createContext} from 'react';
+import {createContext, useMemo} from 'react';
 import {gql, useQuery} from '@apollo/client';
 import {join, relative} from 'path';
 import {useColorModeValue} from '@chakra-ui/react';
@@ -25,40 +25,43 @@ export const flattenNavItems = items =>
 export function useFieldTableStyles() {
   const teal = useColorModeValue('teal.600', 'teal.300');
   const requiredBg = useColorModeValue('blackAlpha.50', 'whiteAlpha.50');
-  return {
-    'tr.required': {
-      bg: requiredBg
-    },
-    td: {
-      ':first-child': {
-        [['h5', 'h6']]: {
-          mb: 1,
-          fontSize: 'md',
-          fontWeight: 'normal'
-        },
-        p: {
-          fontSize: 'sm',
+  return useMemo(
+    () => ({
+      'tr.required': {
+        bg: requiredBg
+      },
+      td: {
+        ':first-child': {
+          [['h5', 'h6']]: {
+            mb: 1,
+            fontSize: 'md',
+            fontWeight: 'normal'
+          },
+          p: {
+            fontSize: 'sm',
+            code: {
+              p: 0,
+              bg: 'none',
+              color: teal
+            }
+          },
           code: {
-            p: 0,
-            bg: 'none',
-            color: teal
+            fontSize: 'inherit'
           }
         },
-        code: {
-          fontSize: 'inherit'
-        }
-      },
-      ':not(:first-child)': {
-        lineHeight: 'base',
-        fontSize: 'md',
-        p: {
-          ':not(:last-child)': {
-            mb: 2
+        ':not(:first-child)': {
+          lineHeight: 'base',
+          fontSize: 'md',
+          p: {
+            ':not(:last-child)': {
+              mb: 2
+            }
           }
         }
       }
-    }
-  };
+    }),
+    [requiredBg, teal]
+  );
 }
 
 const GET_USER = gql`


### PR DESCRIPTION
Currently, hovering a single link in the navigation triggers three renders, one of which can take over 250ms on some documentation pages.

Scrolling the navigation on those pages can freeze the browser for seconds.

This PR brings that down to one render of less than 25ms.

The main problem here is that none of the various context values were memoized, which meant that with every rerender of a context provider all the consumers would also rerender. This cascaded from the `useConfigs` indirectly used in `PageLayout` through all other contexts.

I've gone ahead and memoized all of them - some were rather small performance gains, but it's impossible to say if that might change in the future, so better safe than sorry.