### PR TITLE
Rename term to work around glossary issue

### DIFF
--- a/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
+++ b/src/content/graphos/basics/routing/cloud-dedicated/lattice.mdx
@@ -564,7 +564,7 @@ To update a Lattice service's authorization policy with additional restrictions,
 
   <Note>
 
-  The Apollo account ID you specify in your authorization policy is _not_ the Apollo organization ID you can find in Apollo GraphOS Studio.
+  The Apollo account ID you specify in your authorization policy is _not_ the Apollo organization ID you can find in GraphOS Studio.
 
   </Note>
 


### PR DESCRIPTION
Changed the one instance of `Apollo GraphOS Studio` to `GraphOS Studio` because the Apollopedia glossary is unexpectedly removing the entire term (see Note in screenshot that ends with "... you can find in ."):

<img width="818" alt="Screenshot 2024-01-18 at 4 35 30 PM" src="https://github.com/apollographql/docs/assets/18322228/6e92a3c6-c83b-4185-8889-1ed60fe36349">

Will follow up with issue to fix glossary.