### PR TITLE
Use staging index in preview search links

### DIFF
--- a/src/components/GlossaryPage/Results.js
+++ b/src/components/GlossaryPage/Results.js
@@ -73,6 +73,13 @@ ClickableHeading.propTypes = {
 export const makeGlossaryTermId = term =>
   term.replace(/\s+/g, '-').replace(/@/g, '').replace(/\//g, '').toLowerCase();
 
+const updateHost = (url) => {
+  if (process.env.CONTEXT !== 'production' && typeof window !== 'undefined'){
+    return url.replace("https://www.apollographql.com/docs", window.location.origin)
+  }
+  return url;
+}
+
 const Results = () => {
   const {hits} = useHits();
   const {user} = useUser();
@@ -212,7 +219,7 @@ const Results = () => {
               <PrimaryLink
                 my="4"
                 as="a"
-                href={hit.learnMore}
+                href={updateHost(hit.learnMore)}
                 style={{display: 'flex', alignItems: 'center'}}
               >
                 {hit.learnMoreText

--- a/src/components/Search/GlossaryResult.js
+++ b/src/components/Search/GlossaryResult.js
@@ -57,6 +57,9 @@ function stripCodeExample(definition) {
 }
 
 export default function GlossaryResult({item}) {
+  const host = process.env.CONTEXT !== 'production' && typeof window !== 'undefined' ?
+    window.location.origin : "https://www.apollographql.com/docs";
+
   return (
     <Box key="Apollopedia" borderBottomWidth="1px" pb="16px">
       <Flex align="center" p="2" pr="0">
@@ -83,7 +86,7 @@ export default function GlossaryResult({item}) {
           <PrimaryLink
             aria-label="Go to the glossary"
             as="a"
-            href={`https://www.apollographql.com/docs/resources/glossary#${makeGlossaryTermId(
+            href={`${host}/resources/glossary#${makeGlossaryTermId(
               item.term
             )}`}
             mt="12px"

--- a/src/components/Search/Panel.js
+++ b/src/components/Search/Panel.js
@@ -14,7 +14,7 @@ import {
   useBreakpointValue
 } from '@chakra-ui/react';
 
-export const DOCS_INDEX = 'docs';
+export const DOCS_INDEX = process.env.CONTEXT === 'production' ? 'docs' : 'staging_docs';
 export const QUERY_SUGGESTIONS_INDEX = 'docs_query_suggestions';
 export const APOLLOPEDIA_INDEX = 'apollopedia';
 

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -18,7 +18,7 @@ export default function Result({item, ...props}) {
   const {text, title, description} = item._highlightResult;
   const {'aria-selected': isSelected} = props;
 
-  const url = item.__autocomplete_indexName == "docs" && typeof window !== 'undefined' ? window.location.origin + item.slug : item.url;
+  const url = item.__autocomplete_indexName == "staging_docs" && typeof window !== 'undefined' ? window.location.origin + item.slug : item.url;
 
   return (
     <chakra.li bg={isSelected && activeBg} {...props}>

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -18,9 +18,11 @@ export default function Result({item, ...props}) {
   const {text, title, description} = item._highlightResult;
   const {'aria-selected': isSelected} = props;
 
+  const url = item.__autocomplete_indexName == "docs" && typeof window !== 'undefined' ? window.location.origin + item.slug : item.url;
+
   return (
     <chakra.li bg={isSelected && activeBg} {...props}>
-      <Flex as="a" href={item.url} p="2">
+      <Flex as="a" href={url} p="2">
         <Box mr="3" fontSize="xl" color="primary" flexShrink="0">
           <ResultIcon result={item} />
         </Box>


### PR DESCRIPTION
This PR uses the `staging_docs` Algolia index which is rebuilt for every Netlify deploy (including previews) and uses window's current host, whether that's `localhost` or a Netlify deploy preview URL—for links in documentation and glossary search results.