### PR TITLE
Fix staging search result URLs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -142,7 +142,12 @@ const plugins = [
   {
     resolve: 'gatsby-plugin-env-variables',
     options: {
-      allowList: ['ALGOLIA_APP_ID', 'ALGOLIA_SEARCH_KEY']
+      allowList: [
+        'ALGOLIA_APP_ID',
+        'ALGOLIA_SEARCH_KEY',
+        'CONTEXT',
+        'DEPLOY_URL'
+      ]
     }
   },
   {

--- a/src/components/GlossaryPage/Results.js
+++ b/src/components/GlossaryPage/Results.js
@@ -30,6 +30,10 @@ const PaddedMarkdownCodeBlock = ({children}) => {
   );
 };
 
+PaddedMarkdownCodeBlock.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
 const ClickableHeading = ({as, fontSize, fontWeight, id, children}) => {
   const handleCopyClick = () => {
     if (id) {
@@ -73,12 +77,16 @@ ClickableHeading.propTypes = {
 export const makeGlossaryTermId = term =>
   term.replace(/\s+/g, '-').replace(/@/g, '').replace(/\//g, '').toLowerCase();
 
-const updateHost = (url) => {
-  if (process.env.CONTEXT !== 'production' && typeof window !== 'undefined'){
-    return url.replace("https://www.apollographql.com/docs", window.location.origin)
+const updateHost = url => {
+  if (process.env.CONTEXT === 'production') {
+    return url;
   }
-  return url;
-}
+
+  return url.replace(
+    'https://www.apollographql.com/docs',
+    process.env.DEPLOY_URL
+  );
+};
 
 const Results = () => {
   const {hits} = useHits();

--- a/src/components/Search/GlossaryResult.js
+++ b/src/components/Search/GlossaryResult.js
@@ -22,6 +22,10 @@ const DefinitionText = ({children}) => {
   );
 };
 
+DefinitionText.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
 function stripCodeExample(definition) {
   const hasCodeBlocks = /```[\s\S]*?```/g.test(definition);
 
@@ -57,8 +61,10 @@ function stripCodeExample(definition) {
 }
 
 export default function GlossaryResult({item}) {
-  const host = process.env.CONTEXT !== 'production' && typeof window !== 'undefined' ?
-    window.location.origin : "https://www.apollographql.com/docs";
+  const host =
+    process.env.CONTEXT === 'production'
+      ? 'https://www.apollographql.com/docs'
+      : process.env.DEPLOY_URL;
 
   return (
     <Box key="Apollopedia" borderBottomWidth="1px" pb="16px">
@@ -86,9 +92,7 @@ export default function GlossaryResult({item}) {
           <PrimaryLink
             aria-label="Go to the glossary"
             as="a"
-            href={`${host}/resources/glossary#${makeGlossaryTermId(
-              item.term
-            )}`}
+            href={`${host}/resources/glossary#${makeGlossaryTermId(item.term)}`}
             mt="12px"
             style={{display: 'flex', alignItems: 'center'}}
           >

--- a/src/components/Search/Panel.js
+++ b/src/components/Search/Panel.js
@@ -14,7 +14,8 @@ import {
   useBreakpointValue
 } from '@chakra-ui/react';
 
-export const DOCS_INDEX = 'docs';
+export const DOCS_INDEX =
+  process.env.CONTEXT === 'production' ? 'docs' : 'staging_docs';
 export const QUERY_SUGGESTIONS_INDEX = 'docs_query_suggestions';
 export const APOLLOPEDIA_INDEX = 'apollopedia';
 

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -11,7 +11,6 @@ export default function Result({item, ...props}) {
   const {colorMode} = useColorMode();
   const activeBg = colorMode === 'light' ? 'silver.400' : 'indigo.400';
 
-  console.log(item.__autocomplete_indexName);
 
   const url =
     item.__autocomplete_indexName === 'staging_docs'

--- a/src/components/Search/Result.js
+++ b/src/components/Search/Result.js
@@ -10,7 +10,13 @@ export default function Result({item, ...props}) {
 
   const {colorMode} = useColorMode();
   const activeBg = colorMode === 'light' ? 'silver.400' : 'indigo.400';
-  const url = item.__autocomplete_indexName == "staging_docs" && typeof window !== 'undefined' ? window.location.origin + item.slug : item.url;
+
+  console.log(item.__autocomplete_indexName);
+
+  const url =
+    item.__autocomplete_indexName === 'staging_docs'
+      ? new URL(item.slug, process.env.DEPLOY_URL).toString()
+      : item.url;
 
   return (
     <chakra.li bg={isSelected && activeBg} {...props}>


### PR DESCRIPTION
This PR adds `CONTEXT` and `DEPLOY_URL` env vars to the allow list and tweaks search panel logic to show staging results in search locally and on deploy previews.