### PR TITLE
Replace space kit logos with ones from icons package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@apollo/icons": "^0.0.4",
         "@apollo/pedia": "^3.3.1",
         "@apollo/signup-tracer": "^2.0.0",
-        "@apollo/space-kit": "8.11.0",
         "@apollo/utm-grabber": "^1.3.1",
         "@chakra-ui/gatsby-plugin": "^2.0.3",
         "@chakra-ui/react": "^1.8.3",
@@ -451,6 +450,7 @@
     "node_modules/@apollo/space-kit": {
       "version": "8.11.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@react-aria/focus": "^3.1.0",
@@ -480,7 +480,8 @@
     },
     "node_modules/@apollo/space-kit/node_modules/tslib": {
       "version": "2.3.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/@apollo/utm-grabber": {
       "version": "1.3.1",
@@ -6810,6 +6811,7 @@
     "node_modules/@react-aria/focus": {
       "version": "3.5.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/interactions": "^3.6.0",
@@ -6824,6 +6826,7 @@
     "node_modules/@react-aria/interactions": {
       "version": "3.6.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/utils": "^3.9.0",
@@ -6836,6 +6839,7 @@
     "node_modules/@react-aria/ssr": {
       "version": "3.1.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2"
       },
@@ -6846,6 +6850,7 @@
     "node_modules/@react-aria/switch": {
       "version": "3.1.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/toggle": "^3.1.4",
@@ -6859,6 +6864,7 @@
     "node_modules/@react-aria/toggle": {
       "version": "3.1.4",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/focus": "^3.4.1",
@@ -6876,6 +6882,7 @@
     "node_modules/@react-aria/utils": {
       "version": "3.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/ssr": "^3.1.0",
@@ -6890,6 +6897,7 @@
     "node_modules/@react-aria/visually-hidden": {
       "version": "3.2.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/interactions": "^3.5.1",
@@ -6910,6 +6918,7 @@
     "node_modules/@react-stately/toggle": {
       "version": "3.2.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "@react-stately/utils": "^3.2.2",
@@ -6923,6 +6932,7 @@
     "node_modules/@react-stately/utils": {
       "version": "3.2.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.6.2"
       },
@@ -6933,6 +6943,7 @@
     "node_modules/@react-types/checkbox": {
       "version": "3.2.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@react-types/shared": "^3.8.0"
       },
@@ -6943,6 +6954,7 @@
     "node_modules/@react-types/shared": {
       "version": "3.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1"
       }
@@ -6950,6 +6962,7 @@
     "node_modules/@react-types/switch": {
       "version": "3.1.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@react-types/checkbox": "^3.2.3",
         "@react-types/shared": "^3.8.0"
@@ -7550,6 +7563,7 @@
     "node_modules/@tippyjs/react": {
       "version": "4.2.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tippy.js": "^6.3.1"
       },
@@ -7849,6 +7863,7 @@
     "node_modules/@types/classnames": {
       "version": "2.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "classnames": "*"
       }
@@ -8151,7 +8166,8 @@
     },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/tmp": {
       "version": "0.0.33",
@@ -10934,6 +10950,7 @@
     "node_modules/clsx": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13299,6 +13316,7 @@
     "node_modules/downshift": {
       "version": "6.1.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.14.8",
         "compute-scroll-into-view": "^1.0.17",
@@ -13312,15 +13330,18 @@
     },
     "node_modules/downshift/node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/downshift/node_modules/react-is": {
       "version": "17.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/downshift/node_modules/tslib": {
       "version": "2.3.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -50254,6 +50275,7 @@
     "node_modules/tinycolor2": {
       "version": "1.4.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -50261,6 +50283,7 @@
     "node_modules/tippy.js": {
       "version": "6.3.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
@@ -52533,6 +52556,7 @@
     },
     "@apollo/space-kit": {
       "version": "8.11.0",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@react-aria/focus": "^3.1.0",
@@ -52554,7 +52578,8 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1"
+          "version": "2.3.1",
+          "peer": true
         }
       }
     },
@@ -56762,6 +56787,7 @@
     },
     "@react-aria/focus": {
       "version": "3.5.0",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/interactions": "^3.6.0",
@@ -56772,6 +56798,7 @@
     },
     "@react-aria/interactions": {
       "version": "3.6.0",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/utils": "^3.9.0",
@@ -56780,12 +56807,14 @@
     },
     "@react-aria/ssr": {
       "version": "3.1.0",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
     },
     "@react-aria/switch": {
       "version": "3.1.3",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/toggle": "^3.1.4",
@@ -56795,6 +56824,7 @@
     },
     "@react-aria/toggle": {
       "version": "3.1.4",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/focus": "^3.4.1",
@@ -56808,6 +56838,7 @@
     },
     "@react-aria/utils": {
       "version": "3.9.0",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/ssr": "^3.1.0",
@@ -56818,6 +56849,7 @@
     },
     "@react-aria/visually-hidden": {
       "version": "3.2.3",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/interactions": "^3.5.1",
@@ -56831,6 +56863,7 @@
     },
     "@react-stately/toggle": {
       "version": "3.2.3",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-stately/utils": "^3.2.2",
@@ -56840,22 +56873,26 @@
     },
     "@react-stately/utils": {
       "version": "3.2.2",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.6.2"
       }
     },
     "@react-types/checkbox": {
       "version": "3.2.3",
+      "peer": true,
       "requires": {
         "@react-types/shared": "^3.8.0"
       }
     },
     "@react-types/shared": {
       "version": "3.9.0",
+      "peer": true,
       "requires": {}
     },
     "@react-types/switch": {
       "version": "3.1.2",
+      "peer": true,
       "requires": {
         "@react-types/checkbox": "^3.2.3",
         "@react-types/shared": "^3.8.0"
@@ -57231,6 +57268,7 @@
     },
     "@tippyjs/react": {
       "version": "4.2.5",
+      "peer": true,
       "requires": {
         "tippy.js": "^6.3.1"
       }
@@ -57407,6 +57445,7 @@
     },
     "@types/classnames": {
       "version": "2.3.1",
+      "peer": true,
       "requires": {
         "classnames": "*"
       }
@@ -57674,7 +57713,8 @@
       "dev": true
     },
     "@types/tinycolor2": {
-      "version": "1.4.3"
+      "version": "1.4.3",
+      "peer": true
     },
     "@types/tmp": {
       "version": "0.0.33"
@@ -59646,7 +59686,8 @@
       }
     },
     "clsx": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "peer": true
     },
     "co": {
       "version": "4.6.0",
@@ -61272,6 +61313,7 @@
     },
     "downshift": {
       "version": "6.1.7",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.14.8",
         "compute-scroll-into-view": "^1.0.17",
@@ -61281,13 +61323,16 @@
       },
       "dependencies": {
         "compute-scroll-into-view": {
-          "version": "1.0.17"
+          "version": "1.0.17",
+          "peer": true
         },
         "react-is": {
-          "version": "17.0.2"
+          "version": "17.0.2",
+          "peer": true
         },
         "tslib": {
-          "version": "2.3.1"
+          "version": "2.3.1",
+          "peer": true
         }
       }
     },
@@ -87108,10 +87153,12 @@
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "tinycolor2": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "peer": true
     },
     "tippy.js": {
       "version": "6.3.2",
+      "peer": true,
       "requires": {
         "@popperjs/core": "^2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@apollo/icons": "^0.0.4",
     "@apollo/pedia": "^3.3.1",
     "@apollo/signup-tracer": "^2.0.0",
-    "@apollo/space-kit": "8.11.0",
     "@apollo/utm-grabber": "^1.3.1",
     "@chakra-ui/gatsby-plugin": "^2.0.3",
     "@chakra-ui/react": "^1.8.3",

--- a/src/components/DocsetMenu/DocsetMenu.js
+++ b/src/components/DocsetMenu/DocsetMenu.js
@@ -2,7 +2,7 @@ import DocsetButton from './DocsetButton';
 import DocsetGroup from './DocsetGroup';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {ReactComponent as ApolloMark} from '@apollo/space-kit/logos/mark.svg';
+import {ReactComponent as ApolloMark} from '@apollo/icons/logos/LogoSymbol.svg';
 import {
   Box,
   Button,
@@ -18,31 +18,31 @@ import {
   Stack,
   useDisclosure
 } from '@chakra-ui/react';
-import {ReactComponent as ChevronDown} from "@apollo/icons/default/IconChevronDown.svg";
-import {ReactComponent as Connectors} from "@apollo/icons/default/IconConnectors.svg";
-import {ReactComponent as Document} from "@apollo/icons/default/IconDocument.svg";
-import {ReactComponent as Education} from "@apollo/icons/default/IconEducation.svg";
-import {ReactComponent as Enterprise} from "@apollo/icons/default/IconEnterpriseFeatures.svg";
-import {ReactComponent as Explorer} from "@apollo/icons/default/IconExplorer.svg";
+import {ReactComponent as ChevronDown} from '@apollo/icons/default/IconChevronDown.svg';
+import {ReactComponent as Connectors} from '@apollo/icons/default/IconConnectors.svg';
+import {ReactComponent as Document} from '@apollo/icons/default/IconDocument.svg';
+import {ReactComponent as Education} from '@apollo/icons/default/IconEducation.svg';
+import {ReactComponent as Enterprise} from '@apollo/icons/default/IconEnterpriseFeatures.svg';
+import {ReactComponent as Explorer} from '@apollo/icons/default/IconExplorer.svg';
 import {FaJava, FaNodeJs} from 'react-icons/fa';
-import {ReactComponent as Federation} from "@apollo/icons/default/IconHierarchy.svg";
+import {ReactComponent as Federation} from '@apollo/icons/default/IconHierarchy.svg';
 import {Link as GatsbyLink} from 'gatsby';
-import {ReactComponent as GraphQL} from "@apollo/icons/default/IconGraphQL.svg";
-import {ReactComponent as Home} from "@apollo/icons/default/IconHome.svg";
-import {ReactComponent as Insights} from "@apollo/icons/default/IconInsights.svg";
-import {ReactComponent as Kotlin} from "@apollo/icons/default/IconKotlin.svg";
-import {ReactComponent as LayoutModule} from "@apollo/icons/default/IconLayoutModule.svg";
-import {ReactComponent as Pipeline} from "@apollo/icons/default/IconPipeline.svg";
-import {ReactComponent as ReactIcon} from "@apollo/icons/default/IconReact.svg";
-import {ReactComponent as Rocket} from "@apollo/icons/default/IconRocket.svg";
-import {ReactComponent as Router} from "@apollo/icons/default/IconRouter.svg";
-import {ReactComponent as Satellite} from "@apollo/icons/default/IconSatellite3.svg";
-import {ReactComponent as Schema} from "@apollo/icons/default/IconSchema.svg";
+import {ReactComponent as GraphQL} from '@apollo/icons/default/IconGraphQL.svg';
+import {ReactComponent as Home} from '@apollo/icons/default/IconHome.svg';
+import {ReactComponent as Insights} from '@apollo/icons/default/IconInsights.svg';
+import {ReactComponent as Kotlin} from '@apollo/icons/default/IconKotlin.svg';
+import {ReactComponent as LayoutModule} from '@apollo/icons/default/IconLayoutModule.svg';
+import {ReactComponent as Pipeline} from '@apollo/icons/default/IconPipeline.svg';
+import {ReactComponent as ReactIcon} from '@apollo/icons/default/IconReact.svg';
+import {ReactComponent as Rocket} from '@apollo/icons/default/IconRocket.svg';
+import {ReactComponent as Router} from '@apollo/icons/default/IconRouter.svg';
+import {ReactComponent as Satellite} from '@apollo/icons/default/IconSatellite3.svg';
+import {ReactComponent as Schema} from '@apollo/icons/default/IconSchema.svg';
 import {SiCsharp} from 'react-icons/si';
-import {ReactComponent as Success} from "@apollo/icons/default/IconSuccess.svg";
-import {ReactComponent as Swift} from "@apollo/icons/default/IconSwift.svg";
-import {ReactComponent as Team} from "@apollo/icons/default/IconTeam.svg";
-import {ReactComponent as Terminal} from "@apollo/icons/default/IconAppWindow.svg";
+import {ReactComponent as Success} from '@apollo/icons/default/IconSuccess.svg';
+import {ReactComponent as Swift} from '@apollo/icons/default/IconSwift.svg';
+import {ReactComponent as Team} from '@apollo/icons/default/IconTeam.svg';
+import {ReactComponent as Terminal} from '@apollo/icons/default/IconAppWindow.svg';
 
 const CustomIcon = ({icon}) => <Box fill="color" boxSize="1em" as={icon} />;
 
@@ -82,7 +82,11 @@ export function DocsetMenu({docset, versions = [], currentVersion, ...props}) {
   return (
     <>
       <ButtonGroup isAttached {...props}>
-        <Button rightIcon={<CustomIcon icon={LayoutModule} />} onClick={onOpen} colorScheme="indigo">
+        <Button
+          rightIcon={<CustomIcon icon={LayoutModule} />}
+          onClick={onOpen}
+          colorScheme="indigo"
+        >
           {docset}
         </Button>
         {versions.length > 1 && (

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import {ReactComponent as ApolloLogo} from '@apollo/space-kit/logos/logo.svg';
+import {ReactComponent as ApolloLogo} from '@apollo/icons/logos/LogoType.svg';
 import {
   Box,
   Flex,

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Search from '../Search';
 import StudioButton from './StudioButton';
-import {ReactComponent as ApolloLogo} from '@apollo/brand/logos/logotype.svg';
-import {ReactComponent as ApolloMark} from '@apollo/brand/logos/symbol.svg';
+import {ReactComponent as ApolloLogo} from '@apollo/icons/logos/LogoType.svg';
+import {ReactComponent as ApolloMark} from '@apollo/icons/logos/LogoSymbol.svg';
 import {
   Box,
   Center,
@@ -53,6 +53,11 @@ function Eyebrow({children}) {
 
 Eyebrow.propTypes = {
   children: PropTypes.node.isRequired
+};
+
+Header.propTypes = {
+  children: PropTypes.node.isRequired,
+  algoliaFilters: PropTypes.array
 };
 
 export function Header({children, algoliaFilters}) {

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -20,8 +20,8 @@ import VersionBanner from './VersionBanner';
 import autolinkHeadings from 'rehype-autolink-headings';
 import rehypeReact from 'rehype-react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import {ReactComponent as ApolloLogo} from '@apollo/space-kit/logos/logo.svg';
-import {ReactComponent as ApolloMark} from '@apollo/space-kit/logos/mark.svg';
+import {ReactComponent as ApolloLogo} from '@apollo/icons/logos/LogoType.svg';
+import {ReactComponent as ApolloMark} from '@apollo/icons/logos/LogoSymbol.svg';
 import {
   Box,
   Button,
@@ -42,13 +42,6 @@ import {
 } from '@chakra-ui/react';
 import {Caution} from './Caution';
 import {CustomHeading} from './CustomHeading';
-import {
-  DocBlock,
-  DocPiece,
-  FunctionDetails,
-  InterfaceDetails,
-  useApiDocContext
-} from './ApiDoc';
 import {
   EmbeddableExplorer,
   MarkdownCodeBlock,
@@ -82,6 +75,7 @@ import {YouTube} from './YouTube';
 import {join} from 'path';
 import {kebabCase} from 'lodash';
 import {rehype} from 'rehype';
+import {useApiDocContext} from './ApiDoc';
 import {useConfig} from '../utils/config';
 import {useFieldTableStyles} from '../utils';
 import {useMermaidStyles} from '../utils/mermaid';


### PR DESCRIPTION
With the apollo logos fully moved over, we no longer depend on space-kit!!