### PR TITLE
Update link color in Enterprise/Experimental/Preview feature callouts

### DIFF
--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -32,7 +32,7 @@ export const EnterpriseFeature = ({children}) => {
           <Text pl="1">
             <strong>
               This feature is only available with a{' '}
-              <Link color={'primary'} href="/graphos/enterprise/">
+              <Link color={'tertiary'} href="/graphos/enterprise/">
                 GraphOS Enterprise plan
               </Link>
               .{' '}
@@ -40,7 +40,7 @@ export const EnterpriseFeature = ({children}) => {
             If your organization doesn&apos;t currently have an Enterprise plan,
             you can test this functionality by signing up for a free{' '}
             <Link
-              color={'primary'}
+              color={'tertiary'}
               href="https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content"
             >
               Enterprise trial

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -37,8 +37,8 @@ export const EnterpriseFeature = ({children}) => {
               </Link>
               .{' '}
             </strong>
-            If your organization doesn&apos;t currently have an Enterprise plan,
-            you can test this functionality by signing up for a free{' '}
+            If your organization doesn&apos;t have an Enterprise plan, you can
+            test this functionality by signing up for a free{' '}
             <Link
               color={'tertiary'}
               href="https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content"

--- a/src/components/ExperimentalFeature.js
+++ b/src/components/ExperimentalFeature.js
@@ -37,7 +37,7 @@ export const ExperimentalFeature = ({
           ) : (
             <>
               <b>
-                This feature is currently{' '}
+                This feature is{' '}
                 <Link
                   color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#experimental-features"

--- a/src/components/ExperimentalFeature.js
+++ b/src/components/ExperimentalFeature.js
@@ -39,7 +39,7 @@ export const ExperimentalFeature = ({
               <b>
                 This feature is currently{' '}
                 <Link
-                  color={'primary'}
+                  color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#experimental-features"
                 >
                   experimental
@@ -49,7 +49,7 @@ export const ExperimentalFeature = ({
               Your questions and feedback are highly valued{'—'}don&apos;t
               hesitate to get in touch with your Apollo contact or on the
               official
-              <Link color={'primary'} href={discordLink}>
+              <Link color={'tertiary'} href={discordLink}>
                 {' '}
                 Apollo GraphQL Discord
               </Link>

--- a/src/components/PreviewFeature.js
+++ b/src/components/PreviewFeature.js
@@ -37,7 +37,7 @@ export const PreviewFeature = ({
           ) : (
             <>
               <b>
-                This feature is currently in{' '}
+                This feature is in{' '}
                 <Link
                   color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#preview"

--- a/src/components/PreviewFeature.js
+++ b/src/components/PreviewFeature.js
@@ -39,7 +39,7 @@ export const PreviewFeature = ({
               <b>
                 This feature is currently in{' '}
                 <Link
-                  color={'primary'}
+                  color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#preview"
                 >
                   preview
@@ -49,7 +49,7 @@ export const PreviewFeature = ({
               Your questions and feedback are highly valued{'—'}don&apos;t
               hesitate to get in touch with your Apollo contact or on the
               official
-              <Link color={'primary'} href={discordLink}>
+              <Link color={'tertiary'} href={discordLink}>
                 {' '}
                 Apollo GraphQL Discord
               </Link>

--- a/src/content/shared/graphos-enteprise-required.mdx
+++ b/src/content/shared/graphos-enteprise-required.mdx
@@ -33,8 +33,8 @@ import {TbComponents} from 'react-icons/tb';
       </Link>
       .
     </b>{' '}
-    If your organization doesn't currently have an Enterprise plan, you can test
-    this functionality by signing up for a free{' '}
+    If your organization doesn't have an Enterprise plan, you can test this
+    functionality by signing up for a free{' '}
     <Link
       color={'tertiary'}
       href="https://www.apollographql.com/docs/graphos/org/plans/#enterprise-trials"

--- a/src/content/shared/graphos-enteprise-required.mdx
+++ b/src/content/shared/graphos-enteprise-required.mdx
@@ -26,7 +26,7 @@ import {TbComponents} from 'react-icons/tb';
     <b>
       This feature is only available with a{' '}
       <Link
-        color={'primary'}
+        color={'tertiary'}
         href="https://www.apollographql.com/docs/graphos/enterprise/"
       >
         GraphOS Enterprise plan
@@ -36,7 +36,7 @@ import {TbComponents} from 'react-icons/tb';
     If your organization doesn't currently have an Enterprise plan, you can test
     this functionality by signing up for a free{' '}
     <Link
-      color={'primary'}
+      color={'tertiary'}
       href="https://www.apollographql.com/docs/graphos/org/plans/#enterprise-trials"
     >
       Enterprise trial


### PR DESCRIPTION
Previously, Enterprise/Experimental/Preview features did not highlight links in different colors.
It also removes the word "currently" from these callouts' text.

Before:
![image](https://github.com/apollographql/docs/assets/23219998/817b6907-cd16-4f15-8570-dbb644d0801d)


After:
![image](https://github.com/apollographql/docs/assets/23219998/86ec6a54-e54a-4fc7-a6bd-58b374e9d269)
