### PR TITLE
remove platform-users-docs docset

### DIFF
--- a/sources/remote.js
+++ b/sources/remote.js
@@ -55,9 +55,5 @@ module.exports = {
   router: {
     remote: 'https://github.com/apollographql/router',
     branch: 'main'
-  },
-  'platform-users': {
-    remote: `https://svc-apollo-docs:${process.env.GITHUB_TOKEN}@github.com/apollographql/platform-users-docs`,
-    branch: 'main'
   }
 };


### PR DESCRIPTION
Removing platform-users-docs as a valid docset, based on https://github.com/apollographql/platform-users-docs/pull/15 removing the rest of `docs/source` from https://github.com/apollographql/platform-users-docs