### PR TITLE
Standardize font size

### DIFF
--- a/src/components/MarkdownInAdmonitions.js
+++ b/src/components/MarkdownInAdmonitions.js
@@ -13,7 +13,6 @@ const LIST_SPACING = 1;
 const NESTED_LIST_STYLES = {
   [['ul', 'ol']]: {
     mt: 3,
-    fontSize: 'md',
     lineHeight: 'normal'
   }
 };

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -108,7 +108,6 @@ const SCROLL_MARGIN_TOP = PAGE_PADDING_TOP + TOTAL_HEADER_HEIGHT;
 const NESTED_LIST_STYLES = {
   [['ul', 'ol']]: {
     mt: 3,
-    fontSize: 'md',
     lineHeight: 'normal'
   }
 };


### PR DESCRIPTION
Currently, nested lists items have a smaller (`md`) font as compared to the rest of the docs. This makes them both `lg`.