### PR TITLE
Add new `@override` hint for progressive usage

### DIFF
--- a/src/content/shared/overridden-composition-rules.mdx
+++ b/src/content/shared/overridden-composition-rules.mdx
@@ -43,7 +43,7 @@ type Product @key(fields: "id") {
 <RuleExpansionPanel
   title="OVERRIDDEN_FIELD_CAN_BE_REMOVED"
   whatItDoes="Checks if a field has been overridden by another subgraph."
-  rationale="You should consider removing overriden fields to avoid confusion."
+  rationale="You should consider removing overridden fields to avoid confusion."
 >
 
 The following example violates the rule:
@@ -65,6 +65,50 @@ type Product @key(fields: "id") {
 
 <br/>
 Use instead:
+<br/>
+
+```graphql title="✅ Subgraph A" disableCopy=true showLineNumbers=false
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  inStock: Boolean!
+}
+```
+
+```graphql title="✅ Subgraph B" disableCopy=true showLineNumbers=false
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+}
+```
+
+</RuleExpansionPanel>
+
+<RuleExpansionPanel
+  title="OVERRIDE_MIGRATION_IN_PROGRESS"
+  whatItDoes="Checks if a field migration is in progress."
+  rationale="You should complete a field migration."
+>
+
+The following example violates the rule:
+
+```graphql title="❌ Subgraph A" disableCopy=true showLineNumbers=false {3}
+type Product @key(fields: "id") {
+  id: ID!
+  inStock: Boolean! @override(from: "Subgraph B", label: "percent(50)")
+}
+```
+
+```graphql title="❌ Subgraph B" disableCopy=true showLineNumbers=false {4}
+type Product @key(fields: "id") {
+  id: ID!
+  name: String!
+  inStock: Boolean!
+}
+```
+
+<br/>
+After completing the migration, use instead:
 <br/>
 
 ```graphql title="✅ Subgraph A" disableCopy=true showLineNumbers=false

--- a/src/content/technotes/TN0001-client-id-enforcement.mdx
+++ b/src/content/technotes/TN0001-client-id-enforcement.mdx
@@ -15,7 +15,7 @@ Together, these pieces of information help teams monitor their graph and make ch
 
 ## Enforcing in Apollo Router
 
-The Apollo Router supports client awareness by default if the client sets the `apollographql-client-name` and `apollographql-client-id` in their requests. These values can be overriden using the [router configuration file](/router/managed-federation/client-awareness/) directly.
+The Apollo Router supports client awareness by default if the client sets the `apollographql-client-name` and `apollographql-client-id` in their requests. These values can be overridden using the [router configuration file](/router/managed-federation/client-awareness/) directly.
 
 Client headers can also be enforced using a [Rhai script](/router/customizations/rhai) on every incoming request.
 


### PR DESCRIPTION
Add documentation for a new composition hint, specific to _progressive_ `@override` usages.

Depends on https://github.com/apollographql/federation/pull/2922