### PR TITLE
Clarify enterprise and premium

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
         Tip: 'readonly',
         ExperimentalFeature: 'readonly',
         GraphOSEnterpriseRequired: 'readonly',
+        GraphOSRouterFeatures: 'readonly',
         InconsistentCompositionRules: 'readonly',
         ObtainGraphApiKey: 'readonly',
         ObtainPersonalApiKey: 'readonly',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
         DirectiveCompositionRules: 'readonly',
         Disclaimer: 'readonly',
         EnterpriseFeature: 'readonly',
+        PremiumFeature: 'readonly',
         Caution: 'readonly',
         Note: 'readonly',
         Tip: 'readonly',

--- a/README.md
+++ b/README.md
@@ -626,7 +626,11 @@ Custom text for plan components can be provided by nesting Markdown within the c
 
 By default, without any children, `<EnterpriseFeature />` renders this text:
 
-> **This feature is only available with a [**GraphOS Enterprise plan\*\*](http://apollographql.com/graphos/enterprise/). You can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+> **This feature is only available with a [**GraphOS Enterprise plan\*\*](http://apollographql.com/pricing/). You can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+
+By default, the link to the pricing page is `http://apollographql.com/pricing/`, if possible, direct users to the most appropriate part of the pricing page using the `linkWithAnchor` property:
+
+`<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />`
 
 If you include custom text, it completely replaces this text. Please make sure to include links to the pricing page and Enterprise trial accordingly.
 
@@ -641,6 +645,12 @@ This is some custom markdown text that still includes a link to the [pricing pag
 By default, without any children, `<PremiumFeature />` renders this text:
 
 > **This feature is only available with a GraphOS Dedicated or Enterprise plan.** To compare GraphOS feature support across all plan types, see the [pricing page](http://apollographql.com/pricing/).
+
+By default, the link to the pricing page is `http://apollographql.com/pricing/`, if possible, direct users to the most appropriate part of the pricing page using the `linkWithAnchor` property:
+
+`<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />`
+
+If you include custom text, it completely replaces this text. Please make sure to include links to the pricing page and Enterprise trial accordingly.
 
 Like `<EnterpriseFeature>`, you can provide custom text by nesting Markdown.
 

--- a/README.md
+++ b/README.md
@@ -615,25 +615,34 @@ This completely replaces the text within the component.
 
 ##### Plan components
 
-Currently, the only plan component is `<EnterpriseFeature />`.
-Like the release stage components, this component should be put at the top of the relevant page or section.
-If a feature has both a release stage component and the `<EnterpriseFeature />`, the `<EnterpriseFeature />` should come first.
+There are two plan components: `<EnterpriseFeature />` and `<PremiumFeature />`.
+The `<EnterpriseFeature />` component denotes a feature is only available with an Enterprise plan.
+The `<PremiumFeature />` component denotes a feature is available with either the Dedicated or Enterprise plan.
 
-Custom text for `<EnterpriseFeature />` can be provided by nesting Markdown within the component.
+Like the release stage components, these components should be put at the top of the relevant page or section.
+If a feature has both a release stage component and a plan component put the plan component first.
+
+Custom text for plan components can be provided by nesting Markdown within the component.
 
 By default, without any children, `<EnterpriseFeature />` renders this text:
 
-> **This feature is only available with a [**GraphOS Enterprise plan\*\*](http://apollographql.com/graphos/enterprise/). If your organization doesn't currently have an Enterprise plan, you can test this functionality by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+> **This feature is only available with a [**GraphOS Enterprise plan\*\*](http://apollographql.com/graphos/enterprise/). You can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
 
-If you include custom text, it completely replaces this text. Please make sure to include links to the Enterprise plan docs and Enterprise trial accordingly.
+If you include custom text, it completely replaces this text. Please make sure to include links to the pricing page and Enterprise trial accordingly.
 
 ```mdx
 <EnterpriseFeature>
 
-This is some custom markdown text that still includes a link to the [GraphOS Enterprise plan\*\*](http://apollographql.com/graphos/enterprise/) and [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content) docs.
+This is some custom markdown text that still includes a link to the [pricing page](http://apollographql.com/pricing/) and [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content) docs.
 
 </EnterpriseFeature>
 ```
+
+By default, without any children, `<PremiumFeature />` renders this text:
+
+> **This feature is only available with a GraphOS Dedicated or Enterprise plan.** To compare GraphOS feature support across all plan types, see the [pricing page](http://apollographql.com/pricing/).
+
+Like `<EnterpriseFeature>`, you can provide custom text by nesting Markdown.
 
 ##### Admonitions
 

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
+import {Box, Center, Flex, Text, chakra} from '@chakra-ui/react';
+import RelativeLink from './RelativeLink';
 import {EnterpriseIcon} from './Icons';
 
 export const EnterpriseFeature = ({linkWithAnchor, children}) => {
@@ -32,18 +33,18 @@ export const EnterpriseFeature = ({linkWithAnchor, children}) => {
           <Text pl="1">
             <strong>
               This feature is only available with a{' '}
-              <Link color={'tertiary'} href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}>
+              <RelativeLink color={'tertiary'} href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}>
                 GraphOS Enterprise plan
-              </Link>
+              </RelativeLink>
               .{' '}
             </strong>
             You can test it out by signing up for a free{' '}
-            <Link
+            <RelativeLink
               color={'tertiary'}
               href="https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content"
             >
               Enterprise trial
-            </Link>
+            </RelativeLink>
             .
           </Text>
         )}

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
 import {EnterpriseIcon} from './Icons';
 
-export const EnterpriseFeature = ({children}) => {
+export const EnterpriseFeature = ({linkWithAnchor, children}) => {
   return (
     <Box
       pl="2"
@@ -32,7 +32,7 @@ export const EnterpriseFeature = ({children}) => {
           <Text pl="1">
             <strong>
               This feature is only available with a{' '}
-              <Link color={'tertiary'} href="https://www.apollographql.com/pricing/">
+              <Link color={'tertiary'} href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}>
                 GraphOS Enterprise plan
               </Link>
               .{' '}
@@ -53,5 +53,6 @@ export const EnterpriseFeature = ({children}) => {
 };
 
 EnterpriseFeature.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  linkWithAnchor: PropTypes.string
 };

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -33,7 +33,9 @@ export const EnterpriseFeature = ({linkWithAnchor, children}) => {
           <Text pl="1">
             <strong>
               This feature is only available with a{' '}
-              <RelativeLink color={'tertiary'} href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}>
+              <RelativeLink
+                color={'tertiary'}
+                href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}>
                 GraphOS Enterprise plan
               </RelativeLink>
               .{' '}

--- a/src/components/EnterpriseFeature.js
+++ b/src/components/EnterpriseFeature.js
@@ -38,7 +38,7 @@ export const EnterpriseFeature = ({linkWithAnchor, children}) => {
               </RelativeLink>
               .{' '}
             </strong>
-            You can test it out by signing up for a free{' '}
+            <br/> You can test it out by signing up for a free{' '}
             <RelativeLink
               color={'tertiary'}
               href="https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content"

--- a/src/components/ExperimentalFeature.js
+++ b/src/components/ExperimentalFeature.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
+import {Box, Center, Flex, Text, chakra} from '@chakra-ui/react';
+import RelativeLink from './RelativeLink';
 import {FlaskIcon} from './Icons';
 
 import {MarkdownInAdmonitions} from './MarkdownInAdmonitions';
@@ -38,21 +39,21 @@ export const ExperimentalFeature = ({
             <>
               <b>
                 This feature is{' '}
-                <Link
+                <RelativeLink
                   color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#experimental-features"
                 >
                   experimental
-                </Link>
+                </RelativeLink>
                 .
               </b>{' '}
               Your questions and feedback are highly valued{'—'}don&apos;t
               hesitate to get in touch with your Apollo contact or on the
               official
-              <Link color={'tertiary'} href={discordLink}>
+              <RelativeLink color={'tertiary'} href={discordLink}>
                 {' '}
                 Apollo GraphQL Discord
-              </Link>
+              </RelativeLink>
               .{' '}
               {appendText.length > 0 && (
                 <MarkdownInAdmonitions>{appendText}</MarkdownInAdmonitions>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -50,6 +50,7 @@ import {
   MultiCodeBlockContext
 } from '@apollo/chakra-helpers';
 import {EnterpriseFeature} from './EnterpriseFeature';
+import { PremiumFeature } from './PremiumFeature';
 import {ExperimentalFeature} from './ExperimentalFeature';
 import {Link as GatsbyLink} from 'gatsby';
 import {Global} from '@emotion/react';
@@ -211,6 +212,7 @@ const mdxComponents = {
   MinVersionTag,
   EnterpriseFeature,
   ExperimentalFeature,
+  PremiumFeature,
   PreviewFeature,
   ApolloLogo,
   ApolloMark,

--- a/src/components/PremiumFeature.js
+++ b/src/components/PremiumFeature.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
 import {EnterpriseIcon} from './Icons';
 
-export const EnterpriseFeature = ({children}) => {
+export const PremiumFeature = ({children}) => {
   return (
     <Box
       pl="2"
@@ -30,19 +30,13 @@ export const EnterpriseFeature = ({children}) => {
           <Text pl="1">{children}</Text>
         ) : (
           <Text pl="1">
-            <strong>
-              This feature is only available with a{' '}
-              <Link color={'tertiary'} href="https://www.apollographql.com/pricing/">
-                GraphOS Enterprise plan
-              </Link>
-              .{' '}
-            </strong>
-            You can test it out by signing up for a free{' '}
+              <strong>This feature is only available with a GraphOS Dedicated or Enterprise plan.</strong>
+              <br/>To compare GraphOS feature support across all plan types, see the{' '}
             <Link
               color={'tertiary'}
-              href="https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content"
+              href="https://www.apollographql.com/pricing/"
             >
-              Enterprise trial
+              pricing page
             </Link>
             .
           </Text>
@@ -52,6 +46,6 @@ export const EnterpriseFeature = ({children}) => {
   );
 };
 
-EnterpriseFeature.propTypes = {
+PremiumFeature.propTypes = {
   children: PropTypes.node
 };

--- a/src/components/PremiumFeature.js
+++ b/src/components/PremiumFeature.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
+import {Box, Center, Flex, Text, chakra} from '@chakra-ui/react';
+import RelativeLink from './RelativeLink';
 import {EnterpriseIcon} from './Icons';
 
 export const PremiumFeature = ({children}) => {
@@ -32,12 +33,12 @@ export const PremiumFeature = ({children}) => {
           <Text pl="1">
               <strong>This feature is only available with a GraphOS Dedicated or Enterprise plan.</strong>
               <br/>To compare GraphOS feature support across all plan types, see the{' '}
-            <Link
+            <RelativeLink
               color={'tertiary'}
               href="https://www.apollographql.com/pricing/"
             >
               pricing page
-            </Link>
+            </RelativeLink>
             .
           </Text>
         )}

--- a/src/components/PremiumFeature.js
+++ b/src/components/PremiumFeature.js
@@ -4,7 +4,7 @@ import {Box, Center, Flex, Text, chakra} from '@chakra-ui/react';
 import RelativeLink from './RelativeLink';
 import {EnterpriseIcon} from './Icons';
 
-export const PremiumFeature = ({children}) => {
+export const PremiumFeature = ({linkWithAnchor, children}) => {
   return (
     <Box
       pl="2"
@@ -35,7 +35,7 @@ export const PremiumFeature = ({children}) => {
               <br/>To compare GraphOS feature support across all plan types, see the{' '}
             <RelativeLink
               color={'tertiary'}
-              href="https://www.apollographql.com/pricing/"
+              href={linkWithAnchor ? linkWithAnchor : "https://www.apollographql.com/pricing/"}
             >
               pricing page
             </RelativeLink>
@@ -48,5 +48,6 @@ export const PremiumFeature = ({children}) => {
 };
 
 PremiumFeature.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  linkWithAnchor: PropTypes.string
 };

--- a/src/components/PreviewFeature.js
+++ b/src/components/PreviewFeature.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box, Center, Flex, Link, Text, chakra} from '@chakra-ui/react';
+import {Box, Center, Flex, Text, chakra} from '@chakra-ui/react';
+import RelativeLink from './RelativeLink';
 import {PreviewIcon} from './Icons';
 
 import {MarkdownInAdmonitions} from './MarkdownInAdmonitions';
@@ -38,21 +39,21 @@ export const PreviewFeature = ({
             <>
               <b>
                 This feature is in{' '}
-                <Link
+                <RelativeLink
                   color={'tertiary'}
                   href="https://www.apollographql.com/docs/resources/product-launch-stages#preview"
                 >
                   preview
-                </Link>
+                </RelativeLink>
                 .
               </b>{' '}
               Your questions and feedback are highly valued{'—'}don&apos;t
               hesitate to get in touch with your Apollo contact or on the
               official
-              <Link color={'tertiary'} href={discordLink}>
+              <RelativeLink color={'tertiary'} href={discordLink}>
                 {' '}
                 Apollo GraphQL Discord
-              </Link>
+              </RelativeLink>
               .{' '}
               {appendText.length > 0 && (
                 <MarkdownInAdmonitions>{appendText}</MarkdownInAdmonitions>

--- a/src/components/RelativeLink.js
+++ b/src/components/RelativeLink.js
@@ -59,7 +59,6 @@ function useLinkProps(href) {
   const isExternal = isUrl(href);
   const isHash = href.startsWith('#');
   const isFile = /\.[a-z]+$/.test(href);
-  console.log(href, isExternal)
   if (isExternal || isHash || isFile) {
     return {
       href,

--- a/src/components/RelativeLink.js
+++ b/src/components/RelativeLink.js
@@ -58,6 +58,7 @@ function useLinkProps(href) {
   const isExternal = isUrl(href);
   const isHash = href.startsWith('#');
   const isFile = /\.[a-z]+$/.test(href);
+  console.log(href, isExternal)
   if (isExternal || isHash || isFile) {
     return {
       href,

--- a/src/components/RelativeLink.js
+++ b/src/components/RelativeLink.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {Button, Link} from '@chakra-ui/react';
 import {Link as GatsbyLink, graphql, useStaticQuery} from 'gatsby';
+import {OutlinkIcon} from './Icons';
 import {PathContext, isUrl} from '../utils';
 import {isAbsolute, resolve} from 'path';
 
@@ -62,7 +63,8 @@ function useLinkProps(href) {
   if (isExternal || isHash || isFile) {
     return {
       href,
-      target: isExternal || (isFile && !isHash) ? '_blank' : null
+      target: isExternal || (isFile && !isHash) ? '_blank' : null,
+      rightIcon: <OutlinkIcon />
     };
   }
 

--- a/src/content/basics/index.mdx
+++ b/src/content/basics/index.mdx
@@ -64,7 +64,7 @@ Apollo makes GraphQL work for you at any stage and any scale, whether you're [ju
 <Docset
   icon={<NodeJsIcon />}
   title="Node.js"
-  description="Build a production-ready API that handles multiple datasources with Apollo Server."
+  description="Build a production-ready API that handles multiple data sources with Apollo Server."
   path="/apollo-server"
   cta="Explore Apollo Server docs"
 />

--- a/src/content/graphos/basics/graphs/index.mdx
+++ b/src/content/graphos/basics/graphs/index.mdx
@@ -233,7 +233,7 @@ To create a cloud supergraph, see the [GraphOS quickstart](../quickstart/cloud/)
 
 To create a non-cloud graph, follow these steps:
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 1. Go to your organization's **Graphs** tab in [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content).
 

--- a/src/content/graphos/basics/index.mdx
+++ b/src/content/graphos/basics/index.mdx
@@ -95,9 +95,6 @@ An Enterprise plan also provides access to our Graph Champions community and a d
 <ButtonLink
   colorScheme="navy"
   href="/graphos/quickstart/cloud/"
-  style={{
-    marginRight: '10px'
-  }}
 >
   Get started with GraphOS!
 </ButtonLink>

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -3,7 +3,7 @@ title: Safelisting with persisted queries
 description: Secure your graph while minimizing request latency
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 GraphQL APIs are broadly open by design to provide flexibility and efficiency in client development. However, this openness also introduces the risk of potentially malicious requests and the subsequent need to secure your graph.
 

--- a/src/content/graphos/basics/operations/persisted-queries.mdx
+++ b/src/content/graphos/basics/operations/persisted-queries.mdx
@@ -731,12 +731,8 @@ Whenever a client sends an operation string to a router with safelisting enabled
 
 When comparing an incoming freeform GraphQL document to the registered operations in its PQL, the router **ignores some aspects** of the document that have no semantic impact:
 
-<!-- vale Google.Spacing = NO -->
-
-- [Ignored tokens](http://spec.graphql.org/draft/#sec-Language.Source-Text.Ignored-Tokens) such as white space, comments, and commas are ignored.
+- [Ignored tokens](http://spec.graphql.org/draft/#sec-language.source-text.ignored-tokens) such as white space, comments, and commas are ignored.
 - The order of **top-level** definitions (operation and fragment definitions) is ignored. This means that when assembling a full GraphQL document from its operation and fragments, there's no need to ensure that fragments are put in the same order at build time and at run time.
-
-<!-- vale Google.Spacing = YES -->
 
 However, **all other details of the document must match**. For example, field order, argument order, `$variable` names, alias names, string and numeric literals, and the presence of `__typename` fields must match between the incoming freeform GraphQL document and the document in the persisted query list.
 

--- a/src/content/graphos/cloud-routing/configuration.mdx
+++ b/src/content/graphos/cloud-routing/configuration.mdx
@@ -61,7 +61,7 @@ headers:
 
 ## Router configuration YAML
 
-You can configure your router's behavior in the **Router configuration YAML** section of the **Cloud Router** tab or page.
+You can configure your router's behavior in **Router configuration YAML** on the **Cloud Router** tab or page.
 
 On the [**Serverless** plan](../org/plans/), you can configure:
 
@@ -352,7 +352,7 @@ cors:
 
 #### Response `Vary` header
 
-A plugin may set a response `Vary` header. If, after all plugins are processed, there is no response `Vary` header, then the router will add one with a value of "origin".
+A plugin may set a response `Vary` header. If, after all plugins are processed, there is no response `Vary` header, then the router will add one with a value of `origin`.
 
 ### Subgraph error inclusion
 

--- a/src/content/graphos/delivery/contract-reference.mdx
+++ b/src/content/graphos/delivery/contract-reference.mdx
@@ -4,7 +4,7 @@ subtitle: Reference for valid @tag locations, names, contract errors, and more
 description: Reference for valid @tag locations, naming conventions, dependent tag relationships, and errors for Apollo GraphOS contracts.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 ## Rules for `@tag`s and contracts
 

--- a/src/content/graphos/delivery/contract-setup.mdx
+++ b/src/content/graphos/delivery/contract-setup.mdx
@@ -4,7 +4,7 @@ subtitle: Learn how to create, use, and edit contracts in GraphOS
 description: Learn how to use the @tag directive in subgraph schemas andwhot to create, edit, and validate contracts in GraphOS Studio.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 <Note>
 

--- a/src/content/graphos/delivery/contracts.mdx
+++ b/src/content/graphos/delivery/contracts.mdx
@@ -4,7 +4,7 @@ subtitle: Deliver different subsets of your supergraph to different consumers
 description: Use Apollo GraphOS contracts to tailor access to your federated GraphQL supergraph for different consumers.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 A unified supergraph provides a single source of truth for your organization's data. That data likely has different consumers with different needs and permissions. GraphOS **contracts** enable you to deliver different subsets of your supergraph to different consumers.
 

--- a/src/content/graphos/delivery/index.mdx
+++ b/src/content/graphos/delivery/index.mdx
@@ -19,7 +19,7 @@ GraphOS provides the following schema governance tools:
 
 <EnterpriseFeature>
 
-Schema proposals are only available with a [GraphOS Enterprise plan](https://www.apollographql.com/docs/graphos/enterprise/).
+Schema proposals are only available with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing#collaboration).
 
 </EnterpriseFeature>
 
@@ -35,7 +35,7 @@ To integrate other aspects of your supergraph configuration, such as your router
 
 <EnterpriseFeature>
 
-Contracts are only available with a [GraphOS Enterprise plan](https://www.apollographql.com/docs/graphos/enterprise/).
+Contracts are only available with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing#collaboration).
 
 </EnterpriseFeature>
 

--- a/src/content/graphos/delivery/schema-checks.mdx
+++ b/src/content/graphos/delivery/schema-checks.mdx
@@ -193,13 +193,13 @@ For more info on linter checks, see [Schema linting](./schema-linter/).
 
 ## Proposals checks
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#delivery-pipeline"/>
 
 For more info on proposals checks, see the [schema proposals documentation](./schema-proposals/).
 
 ## Contract checks
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#delivery-pipeline"/>
 
 For more info on contract checks, see the [contracts documentation](./contracts/).
 

--- a/src/content/graphos/delivery/schema-proposals/configuration.mdx
+++ b/src/content/graphos/delivery/schema-proposals/configuration.mdx
@@ -4,7 +4,7 @@ subtitle: Configure default reviewers, approval requirements, and more
 description: Fine-tune the GraphQL schema proposal workflow by configuring permissions, default reviewers, approval requirements, and schema checks with GraphOS.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 [Org and graph admins](../../org/members/#organization-wide-member-roles) can configure these aspects of schema proposals:
 

--- a/src/content/graphos/delivery/schema-proposals/creation.mdx
+++ b/src/content/graphos/delivery/schema-proposals/creation.mdx
@@ -4,7 +4,7 @@ subtitle: Edit schemas, lint and check changes, and request reviews in GraphOS
 description: Propose GraphQL schema changes in GraphOS Studio. Edit and lint schemas, save and check revisions, and request reviews for async collaboration.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 This article describes actions in the **Proposal creation** stage of the [schema proposal workflow](./#proposal-workflow).
 

--- a/src/content/graphos/delivery/schema-proposals/implementation.mdx
+++ b/src/content/graphos/delivery/schema-proposals/implementation.mdx
@@ -4,7 +4,7 @@ subtitle: Use Rover and schema checks to implement only approved changes
 description: Pull GraphQL schema changes from schema proposals using Rover, validate them with schema checks, and publish them to GraphOS.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 This article describes actions in the **Proposal implementation** and **publication** stages of the [schema proposal workflow](./#proposal-workflow).
 

--- a/src/content/graphos/delivery/schema-proposals/index.mdx
+++ b/src/content/graphos/delivery/schema-proposals/index.mdx
@@ -4,7 +4,7 @@ subtitle: Propose, review, and track changes to new and published schemas
 description: Use GraphOS's native GraphQL schema change management process propose, review, and track schema changes before and after publication.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 As your supergraph schema grows, managing changes becomes more difficult.
 Assessing the impact of subgraph schema changes on [composition](/federation/federated-types/composition/) and client operations becomes more complex.

--- a/src/content/graphos/delivery/schema-proposals/review.mdx
+++ b/src/content/graphos/delivery/schema-proposals/review.mdx
@@ -4,7 +4,7 @@ subtitle: Review and provide feedback on proposed schema changes in GraphOS
 description: Review and provide feedback on GraphQL schema proposals in GraphOS Studio. Explore changes, add comments, and approve proposals.
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration"/>
 
 This article describes actions in the **Proposal review** stage of the [schema proposal workflow](./#proposal-workflow).
 

--- a/src/content/graphos/enterprise/config.json
+++ b/src/content/graphos/enterprise/config.json
@@ -23,6 +23,7 @@
         "Overview": "https://www.apollographql.com/docs/router/enterprise-features",
         "GraphQL subscriptions": "https://www.apollographql.com/docs/router/executing-operations/subscription-support",
         "Distributed caching": "https://www.apollographql.com/docs/router/configuration/distributed-caching",
+        "Entity caching": "https://www.apollographql.com/docs/router/configuration/entity-caching",
         "JWT Authentication": "https://www.apollographql.com/docs/router/configuration/authn-jwt",
         "Authorization": "https://www.apollographql.com/docs/router/configuration/authorization",
         "Incremental subgraph migration": "https://www.apollographql.com/docs/federation/entities-advanced/#incremental-migration-with-progressive-override",

--- a/src/content/graphos/enterprise/config.json
+++ b/src/content/graphos/enterprise/config.json
@@ -23,7 +23,10 @@
         "Overview": "https://www.apollographql.com/docs/router/enterprise-features",
         "GraphQL subscriptions": "https://www.apollographql.com/docs/router/executing-operations/subscription-support",
         "Distributed caching": "https://www.apollographql.com/docs/router/configuration/distributed-caching",
-        "Entity caching": "https://www.apollographql.com/docs/router/configuration/entity-caching",
+        "Entity caching": [ "https://www.apollographql.com/docs/router/configuration/entity-caching",
+        [
+          "preview"
+        ]],
         "JWT Authentication": "https://www.apollographql.com/docs/router/configuration/authn-jwt",
         "Authorization": "https://www.apollographql.com/docs/router/configuration/authorization",
         "Incremental subgraph migration": "https://www.apollographql.com/docs/federation/entities-advanced/#incremental-migration-with-progressive-override",

--- a/src/content/graphos/enterprise/index.mdx
+++ b/src/content/graphos/enterprise/index.mdx
@@ -48,7 +48,7 @@ flowchart LR;
 
 These router instances connect to GraphOS to fetch their managed configuration and report fine-grained operation metrics.
 
-This architecture helps you satisfy sophisticated requirements around data compliance and performance, and it also enables you to further customize your router's behavior with Enterprise-specific functionality (described [below](#apollo-router-features)).
+This architecture helps you satisfy sophisticated requirements around data compliance and performance, and it also enables you to further customize your router's behavior with Enterprise-specific functionality described below.
 
 <Tip>
 

--- a/src/content/graphos/enterprise/index.mdx
+++ b/src/content/graphos/enterprise/index.mdx
@@ -66,7 +66,7 @@ This architecture helps you satisfy sophisticated requirements around data compl
 
 <Tip>
 
-[Learn more about GraphOSRouterFeatures features in the Apollo Router.](/router/enterprise-features/)
+[Learn more about Enterprise features in the Apollo Router.](/router/enterprise-features/)
 
 </Tip>
 

--- a/src/content/graphos/enterprise/index.mdx
+++ b/src/content/graphos/enterprise/index.mdx
@@ -7,11 +7,7 @@ description: Overview
 
 See the left navigation for a list of all Enterprise-specific articles from across the GraphOS documentation.
 
-<Tip>
-
 To compare GraphOS feature support across all plan types, see the [pricing page](https://www.apollographql.com/pricing/).
-
-</Tip>
 
 ## Enterprise trial
 
@@ -60,15 +56,11 @@ This architecture helps you satisfy sophisticated requirements around data compl
 
 </Tip>
 
-### Apollo Router features
+### Premium GraphOS Router features
 
 <GraphOSRouterFeatures />
 
-<Tip>
-
-[Learn more about Enterprise features in the Apollo Router.](/router/enterprise-features/)
-
-</Tip>
+[Learn more about premium GraphOS features.](/router/enterprise-features/)
 
 ## Schema pipeline
 
@@ -85,15 +77,9 @@ The centralized proposal process fosters collaboration and strengthens schema go
 
 This increased coordination improves design decisions and accountability, streamlining development cycles.
 
-<Tip>
-
-[Learn more about schema proposals.](../delivery/schema-proposals/)
-
-</Tip>
-
 ### Schema filtering with contracts
 
-GraphOS [**Contracts**](../delivery/contracts/) enable you to filter your supergraph schema's types and fields according to different inclusion and exclusion rules you define:
+GraphOS [Contracts](../delivery/contracts/) enable you to filter your supergraph schema's types and fields according to different inclusion and exclusion rules you define:
 
 ```mermaid
 graph LR;
@@ -129,12 +115,6 @@ graph LR;
 
 Contracts are especially useful if you want to expose a subset of your supergraph as a public API.
 
-<Tip>
-
-[Learn more about GraphOS contracts.](../delivery/contracts/)
-
-</Tip>
-
 ## Organization management
 
 You can integrate GraphOS with your organization's identity provider (IdP) to enable single sign-on (SSO) for [GraphOS Studio](https://studio.apollographql.com/?referrer=docs-content).
@@ -145,6 +125,12 @@ SSO configuration is available for the following:
 - [Azure AD](../org/sso/azure-ad-integration-guide/)
 - [Generic SAML](../org/sso/saml-integration-guide/)
 
+<Note>
+
+SSO is also available on the [Dedicated plan](https://www.apollographql.com/pricing/).
+
+</Note>
+
 Additionally, Enterprise organizations can export an [audit log](../org/audit-log/) of material actions taken by organization members.
 
 ## Metrics and reporting
@@ -153,4 +139,10 @@ GraphOS Studio offers a performant and intuitive UI to help all GraphOS users mo
 The following features are only available to GraphOS Enterprise organizations:
 
 - The [Apollo Datadog integration](../metrics/datadog-integration) lets you forward performance metrics to your Datadog account. Datadog supports an advanced function API, which enables you to create sophisticated visualizations and alerts for GraphQL metrics.
-- [Build status notifications](../metrics/notifications/) let you notify your team via webhook whenever GraphOS attempts to build a new supergraph schema for your federated graph.
+- [Build status notifications](../metrics/notifications/build-status-notification) let you notify your team via webhook whenever GraphOS attempts to build a new supergraph schema for your federated graph.
+
+  <Note>
+
+  Build status notifications are also available on the [Dedicated plan](https://www.apollographql.com/pricing/).
+
+  </Note>

--- a/src/content/graphos/enterprise/index.mdx
+++ b/src/content/graphos/enterprise/index.mdx
@@ -62,19 +62,11 @@ This architecture helps you satisfy sophisticated requirements around data compl
 
 ### Apollo Router features
 
-[The Apollo Router](/router/) supports a collection of features specific to GraphOS Enterprise organizations. These include:
-
-- **Real-time updates** via [GraphQL subscriptions](/router/executing-operations/subscription-support/)
-- **Authentication of inbound requests** via [JSON Web Token (JWT)](/router/configuration/authn-jwt/)
-- [**Authorization** of specific fields and types](/router/configuration/authorization) through the [`@requiresScopes`](/router/configuration/authorization#requiresscopes), [`@authenticated`](/router/configuration/authorization#authenticated), and [`@policy`](/router/configuration/authorization#policy) directives
-- Incremental migration between subgraphs through [the progressive `@override` directive](/federation/entities-advanced/#incremental-migration-with-progressive-override).
-- Redis-backed [**distributed caching** of query plans and persisted queries](/router/configuration/distributed-caching/)
-- **Custom request handling** in any language via [external coprocessing](/router/customizations/coprocessor/)
-- **Mitigation of potentially malicious requests** via [operation limits](/router/configuration/operation-limits) and [safelisting](../operations/persisted-queries/)
+<GraphOSRouterFeatures />
 
 <Tip>
 
-[Learn more about Enterprise features in the Apollo Router.](/router/enterprise-features/)
+[Learn more about GraphOSRouterFeatures features in the Apollo Router.](/router/enterprise-features/)
 
 </Tip>
 

--- a/src/content/graphos/enterprise/reference-architecture.mdx
+++ b/src/content/graphos/enterprise/reference-architecture.mdx
@@ -5,7 +5,7 @@ description: Reference for Enterprise Deployment of GraphOS
 
 <EnterpriseFeature>
 
-While you can run the Apollo Router regardless of your Apollo plan, connecting the router to GraphOS requires an [Enterprise plan](https://new.apollographql.com/pricing). If your organization doesn't currently have an Enterprise plan, you can test out this functionality by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
+While you can run the Apollo Router regardless of your Apollo plan, connecting the router to GraphOS requires an [Enterprise plan](https://www.apollographql.com/pricing#graphos-router). You can test it out by signing up for a free [Enterprise trial](https://studio.apollographql.com/signup?type=enterprise-trial&referrer=docs-content).
 
 </EnterpriseFeature>
 

--- a/src/content/graphos/metrics/notifications/build-status-notification.mdx
+++ b/src/content/graphos/metrics/notifications/build-status-notification.mdx
@@ -4,7 +4,7 @@ subtitle: Receive webhook alerts whenever GraphOS attempts to build a new superg
 description: Configure Apollo GraphOS to notify your team via webhook about schema build attempts in your federated graph.
 ---
 
-<EnterpriseFeature />
+<PremiumFeature />
 
 <PreviewFeature />
 

--- a/src/content/graphos/metrics/notifications/build-status-notification.mdx
+++ b/src/content/graphos/metrics/notifications/build-status-notification.mdx
@@ -4,7 +4,7 @@ subtitle: Receive webhook alerts whenever GraphOS attempts to build a new superg
 description: Configure Apollo GraphOS to notify your team via webhook about schema build attempts in your federated graph.
 ---
 
-<PremiumFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#integrations"/>
 
 <PreviewFeature />
 

--- a/src/content/graphos/metrics/notifications/notification-setup.mdx
+++ b/src/content/graphos/metrics/notifications/notification-setup.mdx
@@ -144,7 +144,7 @@ Generate an [integration key](https://support.pagerduty.com/docs/generating-api-
 
 ### Custom webhooks (enterprise only)
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#integrations" />
 
 Custom webhooks require you to set up an HTTPS endpoint that is accessible via the public internet. Webhook notifications are sent to this endpoint as `POST` requests. Notification details are provided as JSON in the request body, as described in [Webhook format](./schema-change-integration/#webhook-format).
 

--- a/src/content/graphos/org/audit-log.mdx
+++ b/src/content/graphos/org/audit-log.mdx
@@ -3,7 +3,7 @@ title: Audit log of material GraphOS events
 description: Download a log of all material events that have occured in your organization
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#security" />
 
 Organizations with a GraphOS [Enterprise plan](http://apollographql.com/pricing) can export and download an audit log of all material events that have occurred in the organization over a given timeframe.
 

--- a/src/content/graphos/org/members.mdx
+++ b/src/content/graphos/org/members.mdx
@@ -98,7 +98,7 @@ Learn more about [schema checks](../delivery/schema-checks).
 
 ### Schema proposals permissions
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration" />
 
 The table below shows default schema proposal settings. You can [configure which roles can create, edit, and approve proposals](../delivery/schema-proposals/configuration#configure-permissions-and-approvals).
 
@@ -114,7 +114,7 @@ The table below shows default schema proposal settings. You can [configure which
 
 ### Contract permissions
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#collaboration" />
 
 Learn more about [contracts](../delivery/contracts/).
 

--- a/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
+++ b/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
@@ -2,13 +2,12 @@
 title: Setting up Apollo SSO with Azure AD
 ---
 
-<EnterpriseFeature>
+<PremiumFeature>
 
-**Single sign-on (SSO) is available only for [Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
-Unlike most Enterprise features, this feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
-
-</EnterpriseFeature>
+</PremiumFeature>
 
 This guide walks through configuring Azure Active Directory (Azure AD) as your Apollo organization's identity provider (IdP) for single sign-on (SSO).
 

--- a/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
+++ b/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
@@ -2,7 +2,7 @@
 title: Setting up Apollo SSO with Azure AD
 ---
 
-<PremiumFeature>
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
 
 **Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).

--- a/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
+++ b/src/content/graphos/org/sso/azure-ad-integration-guide.mdx
@@ -2,9 +2,9 @@
 title: Setting up Apollo SSO with Azure AD
 ---
 
-<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
+<PremiumFeature>
 
-**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing#security).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
 </PremiumFeature>

--- a/src/content/graphos/org/sso/okta-integration-guide.mdx
+++ b/src/content/graphos/org/sso/okta-integration-guide.mdx
@@ -2,9 +2,9 @@
 title: Setting up Apollo SSO with Okta
 ---
 
-<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
+<PremiumFeature >
 
-**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing#security).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
 </PremiumFeature>

--- a/src/content/graphos/org/sso/okta-integration-guide.mdx
+++ b/src/content/graphos/org/sso/okta-integration-guide.mdx
@@ -2,13 +2,12 @@
 title: Setting up Apollo SSO with Okta
 ---
 
-<EnterpriseFeature>
+<PremiumFeature>
 
-**Single sign-on (SSO) is available only for [Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
-Unlike most Enterprise features, this feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
-
-</EnterpriseFeature>
+</PremiumFeature>
 
 This guide walks through configuring Okta as your Apollo organization's identity provider (IdP) for single sign-on (SSO).
 You can [use Okta's official GraphOS integration](#using-oktas-official-apollo-graphos-integration) (recommended) or create a custom SAML integration (legacy).

--- a/src/content/graphos/org/sso/okta-integration-guide.mdx
+++ b/src/content/graphos/org/sso/okta-integration-guide.mdx
@@ -2,7 +2,7 @@
 title: Setting up Apollo SSO with Okta
 ---
 
-<PremiumFeature>
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
 
 **Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).

--- a/src/content/graphos/org/sso/saml-integration-guide.mdx
+++ b/src/content/graphos/org/sso/saml-integration-guide.mdx
@@ -2,9 +2,9 @@
 title: Setting up Apollo SSO with a SAML-based IdP
 ---
 
-<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
+<PremiumFeature>
 
-**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing#security).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
 </PremiumFeature>

--- a/src/content/graphos/org/sso/saml-integration-guide.mdx
+++ b/src/content/graphos/org/sso/saml-integration-guide.mdx
@@ -2,13 +2,12 @@
 title: Setting up Apollo SSO with a SAML-based IdP
 ---
 
-<EnterpriseFeature>
+<PremiumFeature>
 
-**Single sign-on (SSO) is available only for [Enterprise plans](https://www.apollographql.com/pricing/).**
+**Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
+This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
 
-Unlike most Enterprise features, this feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).
-
-</EnterpriseFeature>
+</PremiumFeature>
 
 This guide walks through configuring a generic SAML-based identity provider (IdP) for use with Apollo single sign-on (SSO). These steps require administrative access to your IdP.
 

--- a/src/content/graphos/org/sso/saml-integration-guide.mdx
+++ b/src/content/graphos/org/sso/saml-integration-guide.mdx
@@ -2,7 +2,7 @@
 title: Setting up Apollo SSO with a SAML-based IdP
 ---
 
-<PremiumFeature>
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#security">
 
 **Single sign-on (SSO) is available only for [Dedicated and Enterprise plans](https://www.apollographql.com/pricing/).**
 This feature is not available as part of an [Enterprise trial](../plans/#enterprise-trials).

--- a/src/content/shared/graphos-router-features.mdx
+++ b/src/content/shared/graphos-router-features.mdx
@@ -1,5 +1,5 @@
 
-[The Apollo Router](https://www.apollographql.com/docs/router/) supports a collection of features specific to GraphOS. These include:
+[The Apollo Router](https://www.apollographql.com/docs/router/) supports a collection of premium features specific to GraphOS. These include:
 
 - **Real-time updates** via [GraphQL subscriptions](/router/executing-operations/subscription-support/)
 - **Authentication of inbound requests** via [JSON Web Token (JWT)](/router/configuration/authn-jwt/)

--- a/src/content/shared/graphos-router-features.mdx
+++ b/src/content/shared/graphos-router-features.mdx
@@ -1,10 +1,13 @@
 
 [The Apollo Router](https://www.apollographql.com/docs/router/) supports a collection of premium features specific to GraphOS. These include:
 
-- **Real-time updates** via [GraphQL subscriptions](/router/executing-operations/subscription-support/)
-- **Authentication of inbound requests** via [JSON Web Token (JWT)](/router/configuration/authn-jwt/)
-- [**Authorization** of specific fields and types](/router/configuration/authorization) through the [`@requiresScopes`](/router/configuration/authorization#requiresscopes), [`@authenticated`](/router/configuration/authorization#authenticated), and [`@policy`](/router/configuration/authorization#policy) directives
+- **Real-time updates** via [GraphQL subscriptions](https://www.apollographql.com/docs/router/executing-operations/subscription-support/)
+- **Authentication of inbound requests** via [JSON Web Token (JWT)](https://www.apollographql.com/docs/router/configuration/authn-jwt/)
+- [**Authorization** of specific fields and types](https://www.apollographql.com/docs/router/configuration/authorization) through the [`@requiresScopes`](https://www.apollographql.com/docs/router/configuration/authorization#requiresscopes), [`@authenticated`](https://www.apollographql.com/docs/router/configuration/authorization#authenticated), and [`@policy`](https://www.apollographql.com/docs/router/configuration/authorization#policy) directives
 - Incremental migration between subgraphs through [the progressive `@override` directive](/federation/entities-advanced/#incremental-migration-with-progressive-override).
-- Redis-backed [**distributed caching** of query plans and persisted queries](/router/configuration/distributed-caching/)
-- **Custom request handling** in any language via [external coprocessing](/router/customizations/coprocessor/)
-- **Mitigation of potentially malicious requests** via [operation limits](/router/configuration/operation-limits) and [safelisting](../operations/persisted-queries/)
+- Redis-backed [**distributed caching** of query plans and persisted queries](https://www.apollographql.com/docs/router/configuration/distributed-caching/)
+- Redis-backed [**entity caching** of subgraph responses](https://www.apollographql.com/docs/router/configuration/entity-caching/)
+- **Custom request handling** in any language via [external coprocessing](https://www.apollographql.com/docs/router/customizations/coprocessor/)
+- **Mitigation of potentially malicious requests** via [operation limits](https://www.apollographql.com/docs/router/configuration/operation-limits) and [safelisting](../operations/persisted-queries/)
+- **Custom instrumentation and telemetry**, including [custom attributes for spans](https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/spans/#attributes).
+- An [**offline Enterprise license**](https://www.apollographql.com/docs/router/enterprise-features/#offline-enterprise-license) that enables running the router with Enterprise features when disconnected from the internet.

--- a/src/content/shared/graphos-router-features.mdx
+++ b/src/content/shared/graphos-router-features.mdx
@@ -1,0 +1,10 @@
+
+[The Apollo Router](https://www.apollographql.com/docs/router/) supports a collection of features specific to GraphOS. These include:
+
+- **Real-time updates** via [GraphQL subscriptions](/router/executing-operations/subscription-support/)
+- **Authentication of inbound requests** via [JSON Web Token (JWT)](/router/configuration/authn-jwt/)
+- [**Authorization** of specific fields and types](/router/configuration/authorization) through the [`@requiresScopes`](/router/configuration/authorization#requiresscopes), [`@authenticated`](/router/configuration/authorization#authenticated), and [`@policy`](/router/configuration/authorization#policy) directives
+- Incremental migration between subgraphs through [the progressive `@override` directive](/federation/entities-advanced/#incremental-migration-with-progressive-override).
+- Redis-backed [**distributed caching** of query plans and persisted queries](/router/configuration/distributed-caching/)
+- **Custom request handling** in any language via [external coprocessing](/router/customizations/coprocessor/)
+- **Mitigation of potentially malicious requests** via [operation limits](/router/configuration/operation-limits) and [safelisting](../operations/persisted-queries/)

--- a/src/content/shared/index.js
+++ b/src/content/shared/index.js
@@ -7,6 +7,7 @@ export {default as CreateSelfHostedSupergraph} from './create-self-hosted-superg
 export {default as DedicatedPreview} from './dedicated-preview.mdx';
 export {default as DirectiveCompositionRules} from './directive-composition-rules.mdx';
 export {default as Disclaimer} from './disclaimer.mdx';
+export {default as GraphOSRouterFeatures} from './graphos-router-features.mdx'
 export {default as GraphOSEnterpriseRequired} from './graphos-enteprise-required.mdx';
 export {default as InconsistentCompositionRules} from './inconsistent-composition-rules.mdx';
 export {default as ObtainGraphApiKey} from './obtain-graph-api-key.mdx';

--- a/src/content/technotes/TN0003-opentelemetry-traces-to-prometheus.mdx
+++ b/src/content/technotes/TN0003-opentelemetry-traces-to-prometheus.mdx
@@ -9,7 +9,7 @@ tags: [server, observability]
 
 <EnterpriseFeature>
 
-Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more.
+Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing#graphos-router) to learn more.
 
 </EnterpriseFeature>
 

--- a/src/content/technotes/TN0004-router-authentication.mdx
+++ b/src/content/technotes/TN0004-router-authentication.mdx
@@ -111,12 +111,7 @@ headers:
 
 As of Apollo Router v1.13, you can use the [JWT Authentication plugin](/router/configuration/authn-jwt) to validate JWT-based authentication tokens in your supergraph.
 
-<EnterpriseFeature>
-
-This is an [Enterprise feature](/router/enterprise-features) of the Apollo Router.
-It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
-
-</EnterpriseFeature>
+<PremiumFeature />
 
 ```mermaid
 sequenceDiagram
@@ -149,12 +144,7 @@ Cons:
 
 If you have a custom authentication strategy, you can use a [coprocessor](/router/customizations/coprocessor) to implement it.
 
-<EnterpriseFeature>
-
-This is an [Enterprise feature](/router/enterprise-features) of the Apollo Router.
-It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
-
-</EnterpriseFeature>
+<PremiumFeature />
 
 ```mermaid
 sequenceDiagram

--- a/src/content/technotes/TN0004-router-authentication.mdx
+++ b/src/content/technotes/TN0004-router-authentication.mdx
@@ -9,7 +9,7 @@ tags: [server, router, auth]
 
 <EnterpriseFeature>
 
-Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more.
+Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing#graphos-router) to learn more.
 
 </EnterpriseFeature>
 
@@ -111,7 +111,7 @@ headers:
 
 As of Apollo Router v1.13, you can use the [JWT Authentication plugin](/router/configuration/authn-jwt) to validate JWT-based authentication tokens in your supergraph.
 
-<PremiumFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router"/>
 
 ```mermaid
 sequenceDiagram
@@ -144,7 +144,7 @@ Cons:
 
 If you have a custom authentication strategy, you can use a [coprocessor](/router/customizations/coprocessor) to implement it.
 
-<PremiumFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 ```mermaid
 sequenceDiagram

--- a/src/content/technotes/TN0013-monolith-to-federation.mdx
+++ b/src/content/technotes/TN0013-monolith-to-federation.mdx
@@ -36,11 +36,11 @@ Start the process by making a "federated graph of one." Your existing monolith c
    ```
 
 1. Deploy an instance of the [Apollo Router](/router/) to your environment.
-   <EnterpriseFeature
-     text={
-       "Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more."
-     }
-   />
+   <EnterpriseFeature>
+
+    Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more.
+
+   </EnterpriseFeature>
 1. Set up [header propagation](/router/configuration/header-propagation/) so that the monolith receives any necessary headers from the router.
 1. Set up internal routing rules to redirect client requests to the Apollo Router instead of your monolith.
 1. Enable usage metrics reporting to GraphOS Studio.

--- a/src/content/technotes/TN0015-router-to-apm-via-opentelemetry.mdx
+++ b/src/content/technotes/TN0015-router-to-apm-via-opentelemetry.mdx
@@ -9,7 +9,7 @@ tags: [observability, router]
 
 <EnterpriseFeature>
 
-Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more.
+Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing#graphos-router) to learn more.
 
 </EnterpriseFeature>
 

--- a/src/content/technotes/TN0016-router-resource-management.mdx
+++ b/src/content/technotes/TN0016-router-resource-management.mdx
@@ -9,7 +9,7 @@ tags: [router, kubernetes]
 
 <EnterpriseFeature>
 
-Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing/) to learn more.
+Self-hosting the Apollo Router is limited to [GraphOS Enterprise plans](/graphos/enterprise/). Other plan types use [managed cloud routing with GraphOS](/graphos/cloud-routing). Check out the [pricing page](https://www.apollographql.com/pricing#graphos-router) to learn more.
 
 </EnterpriseFeature>
 

--- a/styles/Apollo/Headings.yml
+++ b/styles/Apollo/Headings.yml
@@ -40,6 +40,7 @@ exceptions:
   - GDPR
   - GitHub
   - GraphOS
+  - Premium GraphOS Router features
   - GraphOS Studio
   - GraphQL Summit
   - Go live

--- a/styles/Apollo/Headings.yml
+++ b/styles/Apollo/Headings.yml
@@ -7,6 +7,7 @@ match: $sentence
 indicators:
   - ":"
 exceptions:
+  - About Apollo's reference
   - API
   - Apollo Client DevTools
   - Apollo Client Web
@@ -25,8 +26,10 @@ exceptions:
   - Cloud Dedicated
   - "Configur(e|ation|ing)"
   - Connect APIs
+  - Contribute to Apollo
   - CORS
   - Cosmos
+  - Create an Apollo account
   - Datadog Metrics Explorer
   - Docker
   - Emmet
@@ -55,6 +58,7 @@ exceptions:
   - Markdown
   - Marketplace
   - MongoDB
+  - Notify Apollo
   - OpenTelemetry Collector
   - PingOne
   - PRs?
@@ -67,6 +71,7 @@ exceptions:
   - Sandbox
   - SDL
   - SDUI
+  - Send SAML metadata
   - Studio
   - TypeScript
   - UI


### PR DESCRIPTION
This PR:
- Adds a `PremiumFeature` component to document GraphOS/Router features that apply for both Enterprise/Dedicated plans
- Allows both `PremiumFeature` and `EntepriseFeature` to pass in a pricing page link with an anchor to the relevant section
- Updates pages with the EnterpriseFeature component appropriately