### PR TITLE
Add Property and PropertyList components 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,8 @@ module.exports = {
         ExpansionPanel: 'readonly',
         MultiCodeBlock: 'readonly',
         YouTube: 'readonly',
+        PropertyList: 'readonly',
+        Property: 'readonly',
         Tabs: 'readonly',
         Tab: 'readonly',
         EmbeddableExplorer: 'readonly',

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -66,6 +66,8 @@ import {
   PageSeo
 } from './PageLayout';
 import {PreviewFeature} from './PreviewFeature';
+import {Property} from './Property';
+import {PropertyList} from './PropertyList';
 import {TOTAL_HEADER_HEIGHT} from './Header';
 import {Tab} from './Tab';
 import {Tabs} from './Tabs';
@@ -197,6 +199,8 @@ const mdxComponents = {
   MultiCodeBlock,
   Note,
   YouTube,
+  Property,
+  PropertyList,
   Tab,
   Tabs,
   WistiaEmbed,

--- a/src/components/Property.js
+++ b/src/components/Property.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types';
+import React, {useContext} from 'react';
+import {CustomHeading} from './CustomHeading';
+import {Link, Td, Tr} from '@chakra-ui/react';
+import {MarkdownInAdmonitions} from './MarkdownInAdmonitions';
+import {PropertyListContext} from './PropertyList';
+
+export function Property({name, short, long, type, children}) {
+  const kind = useContext(PropertyListContext);
+
+  if (kind === 'fieldTable') {
+    return (
+      <Tr>
+        <Td>
+          <span>
+            <CustomHeading as="h5" size="sm" id={name}>
+              <Link href={`#${name}`}>
+                <code>{name}</code>
+              </Link>
+            </CustomHeading>
+            {type && (
+              <p>
+                <code>{type}</code>
+              </p>
+            )}
+          </span>
+        </Td>
+        <Td>
+          {short && (
+            <span>
+              <strong>{short}</strong>
+              <br />
+              <br />
+            </span>
+          )}
+          {long && (
+            <span>
+              <MarkdownInAdmonitions>{long}</MarkdownInAdmonitions>
+              <br />
+            </span>
+          )}
+          {children}
+        </Td>
+      </Tr>
+    );
+  }
+  if (kind === 'errCodes') {
+    return (
+      <Tr>
+        <Td>
+          <span>
+            <CustomHeading as="h5" size="sm" id={name}>
+              <Link href={`#${name}`}>
+                <code>{name}</code>
+              </Link>
+            </CustomHeading>
+            {type && (
+              <p>
+                <strong>{short}</strong>
+              </p>
+            )}
+          </span>
+        </Td>
+        <Td>
+          {short && (
+            <span>
+              <strong>{short}</strong>
+              <br />
+              <br />
+            </span>
+          )}
+          {long && (
+            <span>
+              <MarkdownInAdmonitions>{long}</MarkdownInAdmonitions>
+              <br />
+            </span>
+          )}
+          {children}
+        </Td>
+      </Tr>
+    );
+  }
+}
+
+Property.propTypes = {
+  name: PropTypes.string.isRequired,
+  short: PropTypes.string,
+  long: PropTypes.string,
+  type: PropTypes.string,
+  children: PropTypes.node
+};

--- a/src/components/PropertyList.js
+++ b/src/components/PropertyList.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import React, {createContext} from 'react';
+import {Box, Table, Tbody, Th, Thead, Tr} from '@chakra-ui/react';
+
+export const PropertyListContext = createContext();
+
+export function PropertyList({kind, children}) {
+  if (kind === 'fieldTable') {
+    return (
+      <PropertyListContext.Provider value={kind}>
+        <Box borderRadius={4} borderWidth={1} overflow="auto">
+          <Table class="field-table api-ref">
+            <Thead>
+              <Tr>
+                <Th>
+                  Name /<br />
+                  Type
+                </Th>
+                <Th>Description</Th>
+              </Tr>
+            </Thead>
+
+            <Tbody>{children}</Tbody>
+          </Table>
+        </Box>
+      </PropertyListContext.Provider>
+    );
+  }
+  if (kind === 'errCodes') {
+    return (
+      <PropertyListContext.Provider value={kind}>
+        <Box borderRadius={4} borderWidth={1} overflow="auto">
+          <Table>
+            <Thead>
+              <Tr>
+                <Th>Code</Th>
+                <Th>Description</Th>
+              </Tr>
+            </Thead>
+
+            <Tbody>{children}</Tbody>
+          </Table>
+        </Box>
+      </PropertyListContext.Provider>
+    );
+  }
+  return null;
+}
+
+PropertyList.propTypes = {
+  kind: PropTypes.string,
+  children: PropTypes.node
+};

--- a/src/content/graphos/explorer/sandbox.mdx
+++ b/src/content/graphos/explorer/sandbox.mdx
@@ -207,28 +207,8 @@ The `EmbeddedSandbox` object takes an options object with the following structur
 
 These are the optional options you can include in the object you pass to `new EmbeddedSandbox`:
 
-<table class="field-table api-ref">
-
-<thead>
-  <tr>
-    <th>
-      Name /<br />
-      Type
-    </th>
-    <th>Description</th>
-  </tr>
-</thead>
-
-<tbody>
-<tr>
-<td>
-
-##### `initialEndpoint`
-
-`string`
-
-</td>
-<td>
+<PropertyList kind="fieldTable">
+<Property name="initialEndpoint" type="string">
 
 The URL of the GraphQL endpoint that Sandbox introspects on initial load. Sandbox populates its pages using the schema obtained from this endpoint.
 
@@ -237,69 +217,29 @@ The default value is `http://localhost:4000`.
 **You should only pass non-production endpoints to Sandbox**. Sandbox is powered by schema introspection, and we recommend [disabling introspection in production](https://www.apollographql.com/blog/graphql/security/why-you-should-disable-graphql-introspection-in-production/).
 To provide a "Sandbox-like" experience for production endpoints, we recommend using either a [public variant](../graphs/studio-features/#public-variants) or the [embedded Explorer](./embed-explorer).
 
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `handleRequest`
-
-`(url, options) => Promise`
-
-</td>
-<td>
+</Property>
+<Property name="handleRequest" type="(url, options) => Promise">
 
 By default, the embedded Sandbox uses the `fetch` API to send requests from your webpage to your specified GraphQL endpoint. If you provide a custom `handleRequest` function, Sandbox uses it instead of `fetch` for all operations.
 
 You might want to do this if you need to include specific headers in every request made from your embedded Sandbox.
 
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `hideCookieToggle`
-
-`boolean`
-
-</td>
-<td>
+</Property>
+<Property name="hideCookieToggle" type="boolean">
 
 By default, the embedded Sandbox does not show the **Include cookies** toggle in its connection settings.
 
 Set `hideCookieToggle` to `false` to enable users of your embedded Sandbox instance to toggle the **Include cookies** setting.
 
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `endpointIsEditable`
-
-`boolean`
-
-</td>
-<td>
+</Property>
+<Property name="endpointIsEditable" type="boolean">
 
 By default, the embedded Sandbox has a URL input box that is editable by users.
 
 Set `endpointIsEditable` to `false` to prevent users of your embedded Sandbox instance from changing the endpoint URL.
 
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `includeCookies`
-
-`boolean`
-
-</td>
-<td>
+</Property>
+<Property name="includeCookies" type="boolean">
 
 You can set `includeCookies` to `true` if you instead want Sandbox to pass `{ credentials: 'include' }` for its requests.
 
@@ -309,28 +249,15 @@ Read more about the `fetch` API and credentials [here](https://developer.mozilla
 
 This config option is **deprecated** in favor of using the connection settings cookie toggle in Sandbox and setting the default value via `initialState.includeCookies`.
 
-</td>
-</tr>
-
-<tr>
-<td>
-
-##### `initialState`
-
-`Object`
-
-</td>
-<td>
+</Property>
+<Property name="initialState" type="Object">
 
 An object containing additional options related to the state of the embedded Sandbox on page load.
 
 For supported subfields, see [`initialState` options](#initialstate-options).
 
-</td>
-</tr>
-
-</tbody>
-</table>
+</Property>
+</PropertyList>
 
 ### `initialState` options
 


### PR DESCRIPTION
Add `<PropertyList>` and `<Property>` components for documenting reference properties. Will replace HTML field tables.