### PR TITLE
Tightened homepage intro

### DIFF
--- a/src/content/basics/index.mdx
+++ b/src/content/basics/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Documentation
-toc: true
-subtitle: ' '
+toc: false
+subtitle: 'Use Apollo to unify your data with GraphQL'
 description: Learn how Apollo GraphQL can help enterprise architects, API implementers, and client developers build, deploy, and manage a supergraph of unified microservices, data sources, and applications.
 ---
 
@@ -30,15 +30,10 @@ import {
   GradientCard
 } from '../../components/HomePage';
 
-Apollo provides the developer platform and tools to unify your data and services into a _supergraph_—a single distributed GraphQL API.
-Apollo makes GraphQL work for you at any stage and any scale, whether you're just getting started, building your first API, querying an API, or migrating your platform onto the supergraph.
-
-## For architects
-
 <GradientCard
   icon={<GraphOSIcon />}
   title="Build a supergraph"
-  description="Use Apollo GraphOS to define, build, connect, and observe all of your data services together in a supergraph."
+  description="Use Apollo GraphOS to build a supergraph—all your data services combined into a single distributed GraphQL API."
   path="/graphos"
   cta="Learn about GraphOS"
 />


### PR DESCRIPTION
Replaced docs homepage's intro paragraph with subtitle and edited CTA text. Also disabled TOC right-nav and removed "For architects" heading.

Resolves https://apollographql.atlassian.net/browse/DOC-78