### PR TITLE
Change link element from div to span

### DIFF
--- a/src/components/RelativeLink.js
+++ b/src/components/RelativeLink.js
@@ -25,11 +25,16 @@ export const PrimaryLink = props => {
       }}
       {...props}
     >
-      <Box whiteSpace="initial" wordBreak="break-word" display="inline">
+      <Box
+        whiteSpace="initial"
+        wordBreak="break-word"
+        display="inline"
+        as="span"
+      >
         {props.children}
       </Box>
       {opensNewTab && (
-        <Box marginLeft="5px" display="inline-flex">
+        <Box marginLeft="5px" display="inline-flex" as="span">
           <OutlinkSmallIcon />
         </Box>
       )}


### PR DESCRIPTION
Copying and pasting text with divs causes there to be line breaks around links.