### PR TITLE
Lattice-troubleshooting: Remove reference to `Rescan` button

### DIFF
--- a/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
+++ b/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
@@ -50,8 +50,7 @@ The previous example renames a `host` header to `x-host`.
 
 ### Service in resource share doesn't appear in private subgraphs
 
-Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. [Adding a subgraph](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice#setup-for-existing-graphs) or a [creating a new graph](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice#setup-for-new-graphs) will automatically trigger a scan for new Lattice services. If you are still
-unable to view the latest resource shares for your graph, please <TrackableLink href="https://www.apollographql.com/contact-sales?type=dedicated&referrer=docs" eventName="content_contact_cloud">get in touch</TrackableLink> for additional support.
+Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. [Adding a subgraph](./lattice#setup-for-existing-graphs) or a [creating a new graph](./lattice#setup-for-new-graphs) automatically trigger a scan for new Lattice services. If you can't view the latest resource shares for your graph, please <TrackableLink href="https://www.apollographql.com/contact-sales?type=dedicated&referrer=docs" eventName="content_contact_cloud">get in touch</TrackableLink> for additional support.
 
 ### Providing `Authorization` headers
 

--- a/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
+++ b/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
@@ -50,7 +50,7 @@ The previous example renames a `host` header to `x-host`.
 
 ### Service in resource share doesn't appear in private subgraphs
 
-Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. [Adding a subgraph](./lattice#setup-for-existing-graphs) or a [creating a new graph](./lattice#setup-for-new-graphs) automatically trigger a scan for new Lattice services. If you can't view the latest resource shares for your graph, please <TrackableLink href="https://www.apollographql.com/contact-sales?type=dedicated&referrer=docs" eventName="content_contact_cloud">get in touch</TrackableLink> for additional support.
+Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. [Adding a subgraph](./lattice#setup-for-existing-graphs) or [creating a new graph](./lattice#setup-for-new-graphs) automatically triggers a scan for new Lattice services. If you can't view the latest resource shares for your graph, please <TrackableLink href="https://www.apollographql.com/contact-sales?type=dedicated&referrer=docs" eventName="content_contact_cloud">get in touch</TrackableLink> for additional support.
 
 ### Providing `Authorization` headers
 

--- a/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
+++ b/src/content/graphos/cloud-routing/dedicated/lattice-troubleshooting.mdx
@@ -50,7 +50,8 @@ The previous example renames a `host` header to `x-host`.
 
 ### Service in resource share doesn't appear in private subgraphs
 
-Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. If you add a service, you can manually trigger a scan by going to your Apollo Organization settings page and clicking the **Rescan subgraphs** button.
+Cloud Dedicated doesn't automatically scan your resource shares for new Lattice services. [Adding a subgraph](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice#setup-for-existing-graphs) or a [creating a new graph](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice#setup-for-new-graphs) will automatically trigger a scan for new Lattice services. If you are still
+unable to view the latest resource shares for your graph, please <TrackableLink href="https://www.apollographql.com/contact-sales?type=dedicated&referrer=docs" eventName="content_contact_cloud">get in touch</TrackableLink> for additional support.
 
 ### Providing `Authorization` headers
 


### PR DESCRIPTION
This closes https://github.com/mdg-private/cloud-router/issues/4032.

## Summary
Our Dedicated customer, Second Spectrum, generated a support ticket inquiring about Lattice troubleshooting, and we noticed a reference to a `Rescan button` in `Settings` [here in our docs](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice-troubleshooting/#service-in-resource-share-doesnt-appear-in-private-subgraphs). 

This reference to a `Rescan button` needs to be removed as this button does not currently exist.


## Link
[Amazon VPC Lattice - Troubleshooting Guide](https://www.apollographql.com/docs/graphos/cloud-routing/dedicated/lattice-troubleshooting/#http-fetch-failed-from-_subgraph_-403-forbidden:~:text=and%20clicking%20the-,Rescan%20subgraphs,-button.)
