### PR TITLE
Remove the preview feature block for schema proposal webhook notifications

### DIFF
--- a/src/content/graphos/metrics/config.json
+++ b/src/content/graphos/metrics/config.json
@@ -36,6 +36,10 @@
       "Overview": "/notifications",
       "Daily reports": "/notifications/daily-reports",
       "Schema changes": "/notifications/schema-change-integration",
+      "Schema proposals": [
+        "/notifications/schema-proposal-integration",
+        ["enterprise"]
+    ],
       "Performance alerts": [
         "/notifications/performance-alerts",
         [

--- a/src/content/graphos/metrics/notifications/index.mdx
+++ b/src/content/graphos/metrics/notifications/index.mdx
@@ -47,5 +47,5 @@ GraphOS can send notifications to the indicated channels:
 
 ### Release stage
 
-- Schema proposal and build status notifications are in [preview](/resources/product-launch-stages#preview).
+- Build status notifications are in [preview](/resources/product-launch-stages#preview).
 - Performance alerts are [experimental](/resources/product-launch-stages#experimental-features).

--- a/src/content/graphos/metrics/notifications/schema-proposal-integration.mdx
+++ b/src/content/graphos/metrics/notifications/schema-proposal-integration.mdx
@@ -10,12 +10,6 @@ Schema proposals are only available with a [GraphOS Enterprise plan](https://www
 
 </EnterpriseFeature>
 
-<PreviewFeature>
-
-This feature is in invite-only [preview](/resources/product-launch-stages#preview). Please get in touch with your Apollo contact if you'd like to request access.
-
-</PreviewFeature>
-
 Configure GraphOS to send notifications to a webhook whenever schema proposals are created or revised or if their status changes.
 These webhooks are useful for automating workflows. For example, your organization may want to open a draft pull request in your codebase whenever a proposal's status changes to **Approved**.
 

--- a/src/content/graphos/metrics/notifications/schema-proposal-integration.mdx
+++ b/src/content/graphos/metrics/notifications/schema-proposal-integration.mdx
@@ -35,7 +35,7 @@ Custom webhooks require you to set up an HTTPS endpoint accessible via the publi
 2. In the **Webhook URL** input, provide the URL of your HTTP(S) endpoint.
 3. Optionally, enter a **Secret Token**.
 
-  If you enter a token, each notification HTTP request includes an `x-apollo-signature` header whose value is a [Hash Message Authentication Code (HMAC)](https://en.wikipedia.org/wiki/HMAC) generated using the token, the request body as the message, and the SHA256 hash function. The `x-apollo-signature` header has the format `sha256=hmac-value`.
+  If you enter a token, each notification HTTP request includes an `x-apollo-signature` header whose value is a [Hash Message Authentication Code (HMAC)](https://en.wikipedia.org/wiki/HMAC) generated using the token, the request body as the message, and the SHA256 hash function. The `x-apollo-signature` header has the format `sha256=<hmac-value>`.
 
   <ExpansionPanel title="See an example">
 
@@ -44,8 +44,20 @@ Custom webhooks require you to set up an HTTPS endpoint accessible via the publi
   **Secret token** (key): `your_secret_token`
 
   **Request body** (message):
-  ```
-  {"eventType":"APOLLO_PROPOSAL_STATUS_CHANGE","eventId":"00000000-0000-0000-0000-00000000","graphId":"graphId","variantId":"p-1","proposalId":"00000000-0000-0000-0000-00000000","change":{"status":"OPEN","previousStatus":"DRAFT"},"timestamp":"1970-01-01T00:00:00+0000"}
+
+  ```json
+  {
+    "eventType": "APOLLO_PROPOSAL_STATUS_CHANGE",
+    "eventId": "00000000-0000-0000-0000-00000000",
+    "graphId": "graphId",
+    "variantId": "p-1",
+    "proposalId": "00000000-0000-0000-0000-00000000",
+    "change": {
+      "status": "OPEN",
+      "previousStatus": "DRAFT"
+    },
+    "timestamp": "1970-01-01T00:00:00+0000"
+  }
   ```
 
   **Hash function**: SHA256


### PR DESCRIPTION
Preparing to launch this feature on Friday, June 21 - so removing the preview callout.