### PR TITLE
Update check-configurations.mdx

### DIFF
--- a/src/content/graphos/delivery/check-configurations.mdx
+++ b/src/content/graphos/delivery/check-configurations.mdx
@@ -45,7 +45,7 @@ This command checks schema changes against the past two weeks of operations:
 rover subgraph check docs-example-graph@current --name products --schema ./schema.graphql --validation-period="2 weeks"
 ```
 
-Valid durations are represented as any combination of `years`, `months`, `weeks`, `days`, `min`, and `sec`:
+Valid durations are represented as any combination of `months`, `weeks`, `days`, `min`, and `sec`:
 
 - `1 month 2 weeks`
 - `525600 min`


### PR DESCRIPTION
Removed the mention of "years" in acceptable validation period entries. We may hold data further back than the obligatory 90days for enterprise customers, but we can't guarantee it. As we only promise up to 90 days, we don't need to mention years here and prompt questions from customers about a longer retention period.