### PR TITLE
Update linter-rules.mdx

### DIFF
--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -591,7 +591,7 @@ type User {
 
 <RuleExpansionPanel
   title="DEFINED_TYPES_ARE_USED"
-  whatItDoes="Checks that every type defined in a schema is be used at least once."
+  whatItDoes="Checks that every type defined in a schema is used at least once."
   rationale="Unused types waste resources and should be immediately removed once they've been refactored out of a schema."
 >
 

--- a/src/content/graphos/delivery/linter-rules.mdx
+++ b/src/content/graphos/delivery/linter-rules.mdx
@@ -590,7 +590,7 @@ type User {
 </RuleExpansionPanel>
 
 <RuleExpansionPanel
-  title="DEFINED_TYPES_ARE_USED"
+  title="DEFINED_TYPES_ARE_UNUSED"
   whatItDoes="Checks that every type defined in a schema is used at least once."
   rationale="Unused types waste resources and should be immediately removed once they've been refactored out of a schema."
 >


### PR DESCRIPTION
Small correction to DEFINED_TYPES_ARE_USED to remove the word "be" from this sentence below.

What it does
Checks that every type defined in a schema is be used at least once.