### PR TITLE
fix: fix fully qualified sidebar URLs within pagination

### DIFF
--- a/src/components/Pagination/PaginationButton.js
+++ b/src/components/Pagination/PaginationButton.js
@@ -2,17 +2,20 @@ import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import {Box, Button} from '@chakra-ui/react';
 import {Link as GatsbyLink} from 'gatsby';
-import {PathContext, getFullPath} from '../../utils';
+import {PathContext, isUrl, getFullPath} from '../../utils';
 
 export default function PaginationButton({item, label, ...props}) {
   const {basePath} = useContext(PathContext);
+  const to = isUrl(item.path)
+    ? item.path
+    : getFullPath(item.path, basePath);
   return (
     <Button
       h="auto"
       py="2"
       variant="ghost"
       as={GatsbyLink}
-      to={getFullPath(item.path, basePath)}
+      to={to}
       {...props}
     >
       <div>


### PR DESCRIPTION
Fix for fully-qualifed URL specified for a pagination link. 

Pagination within the docs is based on the sidebar structure, [see links config here](https://github.com/apollographql/apollo-client/blob/80471816396fa023fa2dc3b768ceb3da5b22edf4/docs/source/config.json#L12).

## Reproduction

Reproduce by visiting the below page. At the bottom of the article, try to click the "NEXT Changelog" button. Notice the link resolves to a 404.

The link is being built using `getFullPath`, which is doing: `join('/', basePath, path)`. This is incorrect when `path` is already a fully qualified URL starting with `https://`.

|Page|
|---|
|https://www.apollographql.com/docs/react/get-started|
|<img width="1183" alt="image" src="https://github.com/user-attachments/assets/0db43eca-e71b-445c-a57e-ab617a727008">|

## Screenshots
|Link correctly working in docs sidebar.|
|---|
|<img width="1186" alt="Screenshot 2024-10-07 at 3 45 04 PM" src="https://github.com/user-attachments/assets/a7b80e28-f578-4a27-b9a8-c63e4eab0c76">|

|Link incorrectly working in docs pagination.|
|---|
|<img width="1186" alt="Screenshot 2024-10-07 at 3 43 58 PM" src="https://github.com/user-attachments/assets/28cff274-12bc-4c4d-8c7d-03e007a46963">|
